### PR TITLE
fix(backend): Show nodes that did not sign the telemetry data (non-validation nodes)

### DIFF
--- a/backend/src/wamp.js
+++ b/backend/src/wamp.js
@@ -28,7 +28,7 @@ wampHandlers["node-telemetry"] = async ([nodeInfo]) => {
     peerCount: nodeInfo.chain.num_peers,
     isValidator: nodeInfo.chain.is_validator,
     lastHash: nodeInfo.chain.latest_block_hash,
-    signature: nodeInfo.signature,
+    signature: nodeInfo.signature || "",
     agentName: nodeInfo.agent.name,
     agentVersion: nodeInfo.agent.version,
     agentBuild: nodeInfo.agent.build,


### PR DESCRIPTION
*Resolves #276*

The root cause of the issue was not the empty account ID, but the missing signature.