### PR TITLE
fix overflowing H1s

### DIFF
--- a/frontend/src/pages/_app.jsx
+++ b/frontend/src/pages/_app.jsx
@@ -123,7 +123,22 @@ export default class extends App {
           }
 
           h1 {
-            font-size: 48px;
+            font-size: calc(
+              28px + (48 - 28) * ((100vw - 300px) / (1600 - 300))
+            );
+            word-wrap: break-word;
+          }
+
+          @media (max-width: 300px) {
+            h1 {
+              font-size: 28px;
+            }
+          }
+
+          @media (min-width: 1600px) {
+            h1 {
+              font-size: 48px;
+            }
           }
 
           h2,


### PR DESCRIPTION
I noticed that H1s tend to overflow the page/screen on mobile devices. I’ve added a dynamic font size (for all H1s) based on screen width (min 28px, max 48px), and word-wrap for longer account IDs.
![Screen Shot 2020-05-08 at 4 24 08 PM](https://user-images.githubusercontent.com/24921205/81457541-5a31a880-914b-11ea-9781-1dfc78b296f7.png)
