### PR TITLE
refactor: Enabled CI jobs to be run on Pull Requests, so external contributions are also checked

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -1,5 +1,9 @@
 name: Run Tests
-on: [push]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   codestyle:


### PR DESCRIPTION
Currently, CI does not work for our external contributors: https://github.com/near/near-explorer/pull/335

Docs on Github Actions: https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#on