### PR TITLE
fix: Fixed pagination of transactions in a single block

### DIFF
--- a/backend/models/Transaction.js
+++ b/backend/models/Transaction.js
@@ -16,6 +16,10 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.BIGINT,
         allowNull: false,
       },
+      transactionIndex: {
+        type: DataTypes.BIGINT,
+        allowNull: false,
+      },
       nonce: {
         type: DataTypes.BIGINT,
         allowNull: false,
@@ -46,6 +50,7 @@ module.exports = (sequelize, DataTypes) => {
         { fields: ["block_timestamp"] },
         { fields: ["signer_id"] },
         { fields: ["receiver_id"] },
+        { fields: ["transaction_index"] },
       ],
     }
   );

--- a/backend/src/sync.js
+++ b/backend/src/sync.js
@@ -57,12 +57,13 @@ async function saveBlocks(blocksInfo) {
               const timestamp = parseInt(blockInfo.header.timestamp / 1000000);
               return Promise.all([
                 models.Transaction.bulkCreate(
-                  blockInfo.transactions.map((tx) => {
+                  blockInfo.transactions.map((tx, index) => {
                     return {
                       hash: tx.hash,
                       nonce: tx.nonce,
                       blockHash: blockInfo.header.hash,
                       blockTimestamp: timestamp,
+                      transactionIndex: index,
                       signerId: tx.signer_id,
                       signerPublicKey: tx.signer_public_key || tx.public_key,
                       signature: tx.signature,

--- a/frontend/src/components/transactions/Transactions.tsx
+++ b/frontend/src/components/transactions/Transactions.tsx
@@ -18,7 +18,10 @@ export default class extends React.Component<OuterProps> {
     count: 15,
   };
 
-  fetchTransactions = async (count: number, paginationIndexer?: number) => {
+  fetchTransactions = async (
+    count: number,
+    paginationIndexer?: T.TxPagination
+  ) => {
     return await new TransactionsApi().getTransactions({
       signerId: this.props.accountId,
       receiverId: this.props.accountId,

--- a/frontend/src/components/transactions/__tests__/common.tsx
+++ b/frontend/src/components/transactions/__tests__/common.tsx
@@ -9,6 +9,7 @@ export const TRANSACTIONS: T.Transaction[] = [
     status: "SuccessValue",
     blockHash: "BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj",
     blockTimestamp: +new Date(2019, 1, 1),
+    transactionIndex: 0,
     actions: [
       {
         kind: "CreateAccount",
@@ -91,6 +92,7 @@ export const TRANSACTIONS: T.Transaction[] = [
     status: "SuccessValue",
     blockHash: "222BBBgnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj",
     blockTimestamp: +new Date(2019, 1, 1),
+    transactionIndex: 0,
     actions: [
       {
         kind: "FunctionCall",
@@ -139,6 +141,7 @@ export const TRANSACTIONS: T.Transaction[] = [
     status: "SuccessValue",
     blockHash: "222BBBgnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj",
     blockTimestamp: +new Date(2019, 1, 1),
+    transactionIndex: 0,
     actions: [
       {
         kind: "Transfer",

--- a/frontend/src/components/utils/autoRefreshHandler.tsx
+++ b/frontend/src/components/utils/autoRefreshHandler.tsx
@@ -141,8 +141,12 @@ export default (
             .nodeId;
           break;
         case "Transaction":
-          paginationIndexer = this.state.items[this.state.items.length - 1]
-            .blockTimestamp;
+          paginationIndexer = {
+            endTimestamp: this.state.items[this.state.items.length - 1]
+              .blockTimestamp,
+            transactionIndex: this.state.items[this.state.items.length - 1]
+              .transactionIndex,
+          };
           break;
         default:
           paginationIndexer = undefined;

--- a/frontend/src/libraries/explorer-wamp/transactions.ts
+++ b/frontend/src/libraries/explorer-wamp/transactions.ts
@@ -178,7 +178,7 @@ export default class TransactionsApi extends ExplorerApi {
           transactionIndex: queries.paginationIndexer?.transactionIndex,
         },
       ]);
-      console.log(transactions);
+
       if (transactions.length > 0) {
         await Promise.all(
           transactions.map(async (transaction) => {

--- a/frontend/src/libraries/explorer-wamp/transactions.ts
+++ b/frontend/src/libraries/explorer-wamp/transactions.ts
@@ -112,13 +112,17 @@ export type Transaction = TransactionInfo &
   ReceiptsOutcomeWrapper &
   TransactionOutcomeWrapper;
 
+export interface TxPagination {
+  endTimestamp: number;
+  transactionIndex: number;
+}
 export interface QueryArgs {
   signerId?: string;
   receiverId?: string;
   transactionHash?: string;
   blockHash?: string;
   limit: number;
-  paginationIndexer?: number;
+  paginationIndexer?: TxPagination;
 }
 
 export default class TransactionsApi extends ExplorerApi {
@@ -132,21 +136,21 @@ export default class TransactionsApi extends ExplorerApi {
     } = queries;
     const whereClause = [];
     if (signerId) {
-      whereClause.push(`transactions.signer_id = :signerId`);
+      whereClause.push(`signer_id = :signerId`);
     }
     if (receiverId) {
-      whereClause.push(`transactions.receiver_id = :receiverId`);
+      whereClause.push(`receiver_id = :receiverId`);
     }
     if (transactionHash) {
-      whereClause.push(`transactions.hash = :transactionHash`);
+      whereClause.push(`hash = :transactionHash`);
     }
     if (blockHash) {
-      whereClause.push(`transactions.block_hash = :blockHash`);
+      whereClause.push(`block_hash = :blockHash`);
     }
     let WHEREClause;
     if (whereClause.length > 0) {
       if (paginationIndexer) {
-        WHEREClause = `WHERE block_timestamp < :paginationIndexer AND (${whereClause.join(
+        WHEREClause = `WHERE block_timestamp < :endTimestamp OR (block_timestamp = :endTimestamp AND transaction_index < :transactionIndex) AND (${whereClause.join(
           " OR "
         )})`;
       } else {
@@ -154,29 +158,33 @@ export default class TransactionsApi extends ExplorerApi {
       }
     } else {
       if (paginationIndexer) {
-        WHEREClause = `WHERE block_timestamp < :paginationIndexer`;
+        WHEREClause = `WHERE block_timestamp < :endTimestamp OR (block_timestamp = :endTimestamp AND transaction_index < :transactionIndex)`;
       } else {
         WHEREClause = "";
       }
     }
     try {
       const transactions = await this.call<TransactionInfo[]>("select", [
-        `SELECT transactions.hash, transactions.signer_id as signerId, transactions.receiver_id as receiverId, 
-              transactions.block_hash as blockHash, transactions.block_timestamp as blockTimestamp
+        `SELECT hash, signer_id as signerId, receiver_id as receiverId, 
+              block_hash as blockHash, block_timestamp as blockTimestamp, transaction_index as transactionIndex
           FROM transactions
           ${WHEREClause}
           ORDER BY block_timestamp DESC
           LIMIT :limit`,
-        queries,
+        {
+          ...queries,
+          endTimestamp: queries.paginationIndexer?.endTimestamp,
+          transactionIndex: queries.paginationIndexer?.transactionIndex,
+        },
       ]);
       if (transactions.length > 0) {
         await Promise.all(
           transactions.map(async (transaction) => {
             const actions = await this.call<any>("select", [
-              `SELECT actions.transaction_hash, actions.action_index, actions.action_type as kind, actions.action_args as args
+              `SELECT transaction_hash, action_index, action_type as kind, action_args as args
             FROM actions
-            WHERE actions.transaction_hash = :hash
-            ORDER BY actions.action_index`,
+            WHERE transaction_hash = :hash
+            ORDER BY action_index`,
               {
                 hash: transaction.hash,
               },

--- a/frontend/src/libraries/explorer-wamp/transactions.ts
+++ b/frontend/src/libraries/explorer-wamp/transactions.ts
@@ -13,6 +13,7 @@ export interface TransactionInfo {
   receiverId: string;
   blockHash: string;
   blockTimestamp: number;
+  transactionIndex: number;
   status?: ExecutionStatus;
 }
 
@@ -244,6 +245,7 @@ export default class TransactionsApi extends ExplorerApi {
           receiverId: "",
           blockHash: "",
           blockTimestamp: 0,
+          transactionIndex: 0,
           actions: [],
         };
       } else {

--- a/frontend/src/libraries/explorer-wamp/transactions.ts
+++ b/frontend/src/libraries/explorer-wamp/transactions.ts
@@ -151,9 +151,9 @@ export default class TransactionsApi extends ExplorerApi {
     let WHEREClause;
     if (whereClause.length > 0) {
       if (paginationIndexer) {
-        WHEREClause = `WHERE block_timestamp < :endTimestamp OR (block_timestamp = :endTimestamp AND transaction_index < :transactionIndex) AND (${whereClause.join(
+        WHEREClause = `WHERE (${whereClause.join(
           " OR "
-        )})`;
+        )}) AND block_timestamp < :endTimestamp OR (block_timestamp = :endTimestamp AND transaction_index < :transactionIndex)`;
       } else {
         WHEREClause = `WHERE ${whereClause.join(" OR ")}`;
       }
@@ -170,7 +170,7 @@ export default class TransactionsApi extends ExplorerApi {
               block_hash as blockHash, block_timestamp as blockTimestamp, transaction_index as transactionIndex
           FROM transactions
           ${WHEREClause}
-          ORDER BY block_timestamp DESC
+          ORDER BY block_timestamp DESC, transaction_index DESC
           LIMIT :limit`,
         {
           ...queries,
@@ -178,6 +178,7 @@ export default class TransactionsApi extends ExplorerApi {
           transactionIndex: queries.paginationIndexer?.transactionIndex,
         },
       ]);
+      console.log(transactions);
       if (transactions.length > 0) {
         await Promise.all(
           transactions.map(async (transaction) => {


### PR DESCRIPTION
the transaction query failure is from all the transactions have same block_timestamp which we use to indicate the pagination In the future, this maybe more easily to happen and I suggest just like what we do to accounts table, add one more index column and query both

