### PR TITLE
fix(frontend): Clarified the documentation message for the locked state of a contract

### DIFF
--- a/frontend/src/components/contracts/ContractDetails.tsx
+++ b/frontend/src/components/contracts/ContractDetails.tsx
@@ -124,7 +124,8 @@ export default class extends React.Component<Props, State> {
                 title={
                   <Term title={"Locked?"}>
                     {`Locked contract means that there are no access keys allowing the contract code to be re-deployed 
-                (e.g. even a single FullAccess permission access key casts the locked status to "No"). `}
+                (e.g. even a single FullAccess permission access key casts the locked status to "No"). However, the
+                contract itself may still be implemented the way that it re-deploys itself or re-add FullAccess keys.`}
                   </Term>
                 }
                 text={lockedShow ? lockedShow : ""}

--- a/frontend/src/components/contracts/ContractDetails.tsx
+++ b/frontend/src/components/contracts/ContractDetails.tsx
@@ -123,9 +123,11 @@ export default class extends React.Component<Props, State> {
               <CardCell
                 title={
                   <Term title={"Locked?"}>
-                    {`Locked contract means that there are no access keys allowing the contract code to be re-deployed 
-                (e.g. even a single FullAccess permission access key casts the locked status to "No"). However, the
-                contract itself may still be implemented the way that it re-deploys itself or re-adds FullAccess keys.`}
+                    <p>{`Locked contract means that there are no access keys allowing the
+                      contract code to be re-deployed (e.g. even a single FullAccess
+                      permission access key casts the locked status to "No").`}</p>
+                    <p>{`Note: The contract itself may be implemented to re-deploy itself
+                      or re-add FullAccess keys.`}</p>
                   </Term>
                 }
                 text={lockedShow ? lockedShow : ""}

--- a/frontend/src/components/contracts/ContractDetails.tsx
+++ b/frontend/src/components/contracts/ContractDetails.tsx
@@ -125,7 +125,7 @@ export default class extends React.Component<Props, State> {
                   <Term title={"Locked?"}>
                     {`Locked contract means that there are no access keys allowing the contract code to be re-deployed 
                 (e.g. even a single FullAccess permission access key casts the locked status to "No"). However, the
-                contract itself may still be implemented the way that it re-deploys itself or re-add FullAccess keys.`}
+                contract itself may still be implemented the way that it re-deploys itself or re-adds FullAccess keys.`}
                   </Term>
                 }
                 text={lockedShow ? lockedShow : ""}


### PR DESCRIPTION
This is a quite techy explanation, so feel free to suggest a better one