### PR TITLE
fix(backend): Limited the number of new blocks synced in a single iteration to prevent lagging behind

### DIFF
--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -1,9 +1,16 @@
 exports.nearRpcUrl = process.env.NEAR_RPC_URL || "http://localhost:3030";
+
+exports.debugLogs =
+  (process.env.NEAR_DEBUG_LOGS || "TRUE").toUpperCase() !== "FALSE";
+
 exports.syncFetchQueueSize =
   parseInt(process.env.NEAR_SYNC_FETCH_QUEUE_SIZE) || 3;
 
 exports.syncSaveQueueSize =
   parseInt(process.env.NEAR_SYNC_SAVE_QUEUE_SIZE) || 10;
+
+exports.syncNewBlocksHorizon =
+  parseInt(process.env.NEAR_SYNC_NEW_BLOCKS_HORIZON) || 100;
 
 exports.bulkDbUpdateSize =
   parseInt(process.env.NEAR_SYNC_BULK_DB_UPDATE_SIZE) || 10;

--- a/backend/src/sync.js
+++ b/backend/src/sync.js
@@ -5,6 +5,7 @@ const {
   syncFetchQueueSize,
   syncSaveQueueSize,
   bulkDbUpdateSize,
+  syncNewBlocksHorizon,
 } = require("./config");
 const { nearRpc } = require("./near");
 const { Result, delayFor } = require("./utils");
@@ -350,16 +351,28 @@ async function syncNewNearcoreState() {
   const latestSyncedBlock = await models.Block.findOne({
     order: [["height", "DESC"]],
   });
-  let latestSyncedBlockHeight;
+  let targetBlockHeight;
   if (latestSyncedBlock !== null) {
-    latestSyncedBlockHeight = latestSyncedBlock.height;
-    console.debug(`The latest synced block is #${latestSyncedBlockHeight}`);
+    console.debug(`The latest synced block is #${latestSyncedBlock.height}`);
+    if (
+      latestBlockHeight - latestSyncedBlock.height <
+      syncNewBlocksHorizon * 5
+    ) {
+      targetBlockHeight = latestSyncedBlock.height;
+    } else {
+      targetBlockHeight = latestBlockHeight - syncNewBlocksHorizon;
+      console.debug(
+        `The latest synced block #${latestSyncedBlock.height} is far behind of the latest block #${latestBlockHeight}. Syncing the latest ${syncNewBlocksHorizon} blocks...`
+      );
+    }
   } else {
-    latestSyncedBlockHeight = latestBlockHeight - 10;
-    console.debug("There are no synced blocks, yet.");
+    targetBlockHeight = latestBlockHeight - syncNewBlocksHorizon;
+    console.debug(
+      `There are no synced blocks, yet. Syncing the latest ${syncNewBlocksHorizon} blocks...`
+    );
   }
 
-  await syncNearcoreBlocks(latestBlockHeight, latestSyncedBlockHeight + 1);
+  await syncNearcoreBlocks(latestBlockHeight, targetBlockHeight + 1);
 }
 
 async function syncOldNearcoreState() {


### PR DESCRIPTION
This was the root cause of recent Explorer lagging behind the tip of the chain.