### PR TITLE
Fix/genesis query sequence

### DIFF
--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -47,3 +47,8 @@ exports.wampNearExplorerBackendSecret =
   process.env.WAMP_NEAR_EXPLORER_BACKEND_SECRET || "back";
 
 exports.genesisRecordsUrl = process.env.NEAR_GENESIS_RECORDS_URL;
+
+exports.genesisQuerySequence = process.env.NEAR_GENESIS_QUERY_SEQUENCE || 0;
+
+exports.genesisWaitingTime =
+  process.env.NEAR_GENESIS_WAITING_TIME || 5 * 60 * 1000;

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -8,6 +8,8 @@ const {
   regularQueryStatsInterval,
   regularCheckNodeStatusInterval,
   wampNearNetworkName,
+  genesisQuerySequence,
+  genesisWaitingTime,
 } = require("./config");
 
 const { nearRpc, queryFinalTimestamp, queryNodeStats } = require("./near");
@@ -71,7 +73,7 @@ async function main() {
       console.warn("Genesis state crashed due to:", error);
     }
   };
-  setTimeout(SyncGenesisState, 0);
+  setTimeout(SyncGenesisState, genesisQuerySequence * genesisWaitingTime);
 
   // TODO: we should publish (push) the information about the new blocks/transcations via WAMP.
   const regularSyncNewNearcoreState = async () => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,11 +13,12 @@ services:
     build: ./backend
     environment:
       # - NEAR_RPC_URL=https://rpc.testnet.near.org
-      # - NEAR_RPC_URL=https://rpc.betanet.near.org
-      - NEAR_RPC_URL=https://rpc.mainnet.near.org
+      - NEAR_RPC_URL=https://rpc.betanet.near.org
+      # - NEAR_RPC_URL=https://rpc.mainnet.near.org
       # - NEAR_GENESIS_RECORDS_URL=https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore-deploy/testnet/genesis.json
-      # - NEAR_GENESIS_RECORDS_URL=https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore-deploy/betanet/genesis.json
-      - NEAR_GENESIS_RECORDS_URL=https://raw.githubusercontent.com/nearprotocol/nearcore/master/neard/res/mainnet_genesis.json
+      - NEAR_GENESIS_RECORDS_URL=https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore-deploy/betanet/genesis.json
+      # - NEAR_GENESIS_RECORDS_URL=https://raw.githubusercontent.com/nearprotocol/nearcore/master/neard/res/mainnet_genesis.json
+      - NEAR_GENESIS_QUERY_SEQUENCE=2
       - WAMP_NEAR_EXPLORER_URL=ws://wamp:8080/ws
       - WAMP_NEAR_EXPLORER_BACKEND_SECRET=back
     mem_limit: 1G


### PR DESCRIPTION
I see the new instance for testnet memory usage is under 1G, and always under 1G. Thinking nodejs assign these several nets together maybe too heavy to load. I give sequence for every different net (mainnet is the first and then betanet and then guildnet and last one is testnet) and each one having 5 minutes to load genesis, since despite testnet genesis, every one will be really quick to finish genesis querying.