### PR TITLE
fix(backend): handle missing geoIP information gracefully

### DIFF
--- a/backend/src/wamp.js
+++ b/backend/src/wamp.js
@@ -14,9 +14,13 @@ const wampHandlers = {};
 
 wampHandlers["node-telemetry"] = async ([nodeInfo]) => {
   let geo = geoip.lookup(nodeInfo.ip_address);
-  nodeInfo.latitude = geo.ll[0];
-  nodeInfo.longitude = geo.ll[1];
-  nodeInfo.city = geo.city;
+  if (geo) {
+    nodeInfo.latitude = geo.ll[0];
+    nodeInfo.longitude = geo.ll[1];
+    nodeInfo.city = geo.city;
+  } else {
+    console.warn("Node Telemetry failed to lookup geoIP for ", nodeInfo);
+  }
   return saveNodeIntoDatabase(nodeInfo);
 };
 


### PR DESCRIPTION
I noticed in the logs that some IPs could not be resolved via our geoIP database which prevented the Telemetry information being stored into the database (it was just crashing there for one of the validators)