### PR TITLE
fix(frontend): Fixed the next.js config mock for unit tests

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,4 +1,7 @@
 // next.config.js
+//
+// NOTE: Make sure you update `src/__mocks__/next/config.js` when change this file!
+//
 const defaultWampNearExplorerUrl = "ws://localhost:8080/ws";
 
 let nearNetworks;

--- a/frontend/src/__mocks__/next/config.js
+++ b/frontend/src/__mocks__/next/config.js
@@ -1,17 +1,25 @@
 const defaultWampNearExplorerUrl = "ws://localhost:8080/ws";
 
-module.exports = () => ({
-  publicRuntimeConfig: {
-    nearNetworks: {
+module.exports = () => {
+  const nearNetworks = [
+    {
       name: "localhostnet",
       explorerLink: "http://localhost:3000",
       aliases: ["localhost:3000", "localhost", "127.0.0.1", "127.0.0.1:3000"],
     },
-    nearNetworkAliases: {
-      aliases: ["localhost:3000", "localhost", "127.0.0.1", "127.0.0.1:3000"],
+  ];
+  return {
+    publicRuntimeConfig: {
+      nearNetworks,
+      nearNetworkAliases: {
+        "localhost:3000": nearNetworks[0],
+        localhost: nearNetworks[0],
+        "127.0.0.1": nearNetworks[0],
+        "127.0.0.1:3000": nearNetworks[0],
+      },
+      wampNearExplorerUrl:
+        process.env.WAMP_NEAR_EXPLORER_URL || defaultWampNearExplorerUrl,
+      googleAnalytics: process.env.NEAR_EXPLORER_GOOGLE_ANALYTICS,
     },
-    wampNearExplorerUrl:
-      process.env.WAMP_NEAR_EXPLORER_URL || defaultWampNearExplorerUrl,
-    googleAnalytics: process.env.NEAR_EXPLORER_GOOGLE_ANALYTICS,
-  },
-});
+  };
+};


### PR DESCRIPTION
It is unknown to me how our tests pass without this fix :fearful: 

Unit tests suddenly started crashing on my end with quite a cryptic message:

```
[UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "TypeError: Cannot read property 'name' of undefined".] {
  code: 'ERR_UNHANDLED_REJECTION'
}
```