### PR TITLE
fix(backend): Fixed a crash on getting balance of a lockup account

### DIFF
--- a/backend/src/wamp.js
+++ b/backend/src/wamp.js
@@ -117,7 +117,8 @@ wampHandlers["get-account-details"] = async ([accountId]) => {
     if (
       typeof error.message === "string" &&
       (error.message.includes("doesn't exist") ||
-        error.message.includes("does not exist"))
+        error.message.includes("does not exist") ||
+        error.message.includes("MethodNotFound"))
     ) {
       return null;
     }
@@ -125,7 +126,7 @@ wampHandlers["get-account-details"] = async ([accountId]) => {
   }
 
   let lockupAccountId;
-  if (accountId.endsWith(nearLockupAccountIdSuffix)) {
+  if (accountId.endsWith(`.${nearLockupAccountIdSuffix}`)) {
     lockupAccountId = accountId;
   } else {
     lockupAccountId = generateLockupAccountIdFromAccountId(accountId);


### PR DESCRIPTION
Trying to open `lockup.near` account on mainnet it was reported as missing due to an internal error (it tried and failed to do some lockup contract method calls)

# Testing Plan

* [x] Manually confirm that the `lockup.near` account is now reachable through search and direct URL `/accounts/lockup.near` on local setup
* [x] Manually confirm that regular accounts are still working as expected
* [x] Manually confirm that lockup accounts are still working as expected