### PR TITLE
Stats/partner stats on a new partner page

### DIFF
--- a/backend/src/consts.js
+++ b/backend/src/consts.js
@@ -1,2 +1,23 @@
 exports.DS_LEGACY_SYNC_BACKEND = "LEGACY_SYNC_BACKEND";
 exports.DS_INDEXER_BACKEND = "INDEXER_BACKEND";
+exports.PARTNER_LIST = [
+  "cheese.zest.near",
+  "miguel.zest.near",
+  "zest.near",
+  "paras.near",
+  "diagnostics.tessab.near",
+  "contract.paras.near",
+  "plutus.paras.near",
+  "berryclub.ek.near",
+  "farm.berryclub.ek.near",
+  "berryclub.near",
+  "giveaway.paras.near",
+  "bananaswap.near",
+  "jerry.near.zest",
+  "tessab.near",
+];
+
+// parter list is from the query
+// select distinct receiver_account_id
+// from transactions
+// where receiver_account_id like any (array['%zest%', '%berryclub%', '%paras%', '%bananaswap%', '%tessab%'])

--- a/backend/src/db-utils.js
+++ b/backend/src/db-utils.js
@@ -503,12 +503,11 @@ const queryParterTotalTransactions = async () => {
 };
 
 const queryPartnerFirstThreeMonthTransactions = async () => {
-  return await Promise.all(
-    PARTNER_LIST.forEach(
-      async (partner) =>
-        await querySingleRow(
-          [
-            `SELECT receiver_account_id, COUNT(*) AS transactions_count
+  let partnerList = Array(PARTNER_LIST.length);
+  for (let i = 0; i < PARTNER_LIST.length; i++) {
+    let result = await querySingleRow(
+      [
+        `SELECT receiver_account_id, COUNT(*) AS transactions_count
         FROM transactions 
         WHERE receiver_account_id = :partner
         AND TO_TIMESTAMP(block_timestamp / 1000000000) < (
@@ -519,12 +518,13 @@ const queryPartnerFirstThreeMonthTransactions = async () => {
             LIMIT 1)
         GROUP BY receiver_account_id 
       `,
-            { partner },
-          ],
-          { dataSource: DS_INDEXER_BACKEND }
-        )
-    )
-  );
+        { partner: PARTNER_LIST[i] },
+      ],
+      { dataSource: DS_INDEXER_BACKEND }
+    );
+    partnerList[i] = result;
+  }
+  return partnerList;
 };
 
 exports.queryOnlineNodes = queryOnlineNodes;

--- a/backend/src/db-utils.js
+++ b/backend/src/db-utils.js
@@ -507,16 +507,15 @@ const queryPartnerFirstThreeMonthTransactions = async () => {
   for (let i = 0; i < PARTNER_LIST.length; i++) {
     let result = await querySingleRow(
       [
-        `SELECT receiver_account_id, COUNT(*) AS transactions_count
+        `SELECT :partner AS receiver_account_id, COUNT(*) AS transactions_count
         FROM transactions 
         WHERE receiver_account_id = :partner
         AND TO_TIMESTAMP(block_timestamp / 1000000000) < (
           SELECT (TO_TIMESTAMP(block_timestamp / 1000000000) + INTERVAL '3 month')
             FROM transactions 
             WHERE receiver_account_id = :partner
-            ORDER BY block_timestamp asc 
+            ORDER BY block_timestamp
             LIMIT 1)
-        GROUP BY receiver_account_id 
       `,
         { partner: PARTNER_LIST[i] },
       ],

--- a/backend/src/db-utils.js
+++ b/backend/src/db-utils.js
@@ -486,7 +486,7 @@ const queryActiveAccountsList = async () => {
   );
 };
 
-const queryParterAccountList = async () => {
+const queryParterTotalTransactions = async () => {
   return await queryRows(
     [
       `SELECT receiver_account_id,
@@ -502,13 +502,13 @@ const queryParterAccountList = async () => {
   );
 };
 
-const queryFirstThreeMonthTransactions = async () => {
+const queryPartnerFirstThreeMonthTransactions = async () => {
   return await Promise.all(
     PARTNER_LIST.forEach(
       async (partner) =>
         await querySingleRow(
           [
-            `SELECT receiver_account_id, COUNT(*)
+            `SELECT receiver_account_id, COUNT(*) AS transactions_count
         FROM transactions 
         WHERE receiver_account_id = :partner
         AND TO_TIMESTAMP(block_timestamp / 1000000000) < (
@@ -543,5 +543,5 @@ exports.queryActiveContractsCountAggregatedByDate = queryActiveContractsCountAgg
 exports.queryActiveAccountsCountAggregatedByDate = queryActiveAccountsCountAggregatedByDate;
 exports.queryActiveContractsList = queryActiveContractsList;
 exports.queryActiveAccountsList = queryActiveAccountsList;
-exports.queryParterAccountList = queryParterAccountList;
-exports.queryFirstThreeMonthTransactions = queryFirstThreeMonthTransactions;
+exports.queryParterTotalTransactions = queryParterTotalTransactions;
+exports.queryPartnerFirstThreeMonthTransactions = queryPartnerFirstThreeMonthTransactions;

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -44,6 +44,8 @@ const {
   aggregateActiveAccountsCountByDate,
   aggregateActiveAccountsList,
   aggregateActiveContractsList,
+  aggregatePartnerTotalTransactionsCount,
+  aggregatePartnerFirst3MonthTransactionsCount,
 } = require("./stats");
 
 async function startLegacySync() {
@@ -211,6 +213,8 @@ function startStatsAggregation() {
       await aggregateActiveAccountsCountByDate();
       await aggregateActiveAccountsList();
       await aggregateActiveContractsList();
+      await aggregatePartnerTotalTransactionsCount();
+      await aggregatePartnerFirst3MonthTransactionsCount();
     } catch (error) {
       console.warn("Regular Stats Aggregation is crashed due to:", error);
     }

--- a/backend/src/stats.js
+++ b/backend/src/stats.js
@@ -177,6 +177,7 @@ async function aggregatePartnerFirst3MonthTransactionsCount() {
       })
     );
     console.log("PARTNER_FIRST_3_MONTH_TRANSACTIONS_COUNT updated");
+    return partnerFirst3MonthTransactionsCount;
   } catch (error) {
     console.log(error);
   }

--- a/backend/src/stats.js
+++ b/backend/src/stats.js
@@ -7,6 +7,8 @@ const {
   queryActiveAccountsCountAggregatedByDate,
   queryActiveContractsList,
   queryActiveAccountsList,
+  queryParterTotalTransactions,
+  queryPartnerFirstThreeMonthTransactions,
 } = require("./db-utils");
 const { formatDate } = require("./utils");
 
@@ -18,6 +20,8 @@ let ACTIVE_CONTRACTS_COUNT_AGGREGATED_BY_DATE = null;
 let ACTIVE_ACCOUNTS_COUNT_AGGREGATED_BY_DATE = null;
 let ACTIVE_CONTRACTS_LIST = null;
 let ACTIVE_ACCOUNTS_LIST = null;
+let PARTNER_TOTAL_TRANSACTIONS_COUNT = null;
+let PARTNER_FIRST_3_MONTH_TRANSACTIONS_COUNT = null;
 
 async function aggregateTransactionsCountByDate() {
   try {
@@ -142,6 +146,42 @@ async function aggregateActiveContractsList() {
   }
 }
 
+async function aggregatePartnerTotalTransactionsCount() {
+  try {
+    const partnerTotalTransactionList = await queryParterTotalTransactions();
+    PARTNER_TOTAL_TRANSACTIONS_COUNT = partnerTotalTransactionList.map(
+      ({
+        receiver_account_id: account,
+        transactions_count: transactionsCount,
+      }) => ({
+        account,
+        transactionsCount,
+      })
+    );
+    console.log("PARTNER_TOTAL_TRANSACTIONS_COUNT updated");
+  } catch (error) {
+    console.log(error);
+  }
+}
+
+async function aggregatePartnerFirst3MonthTransactionsCount() {
+  try {
+    const partnerFirst3MonthTransactionsCount = await queryPartnerFirstThreeMonthTransactions();
+    PARTNER_FIRST_3_MONTH_TRANSACTIONS_COUNT = partnerFirst3MonthTransactionsCount.map(
+      ({
+        receiver_account_id: account,
+        transactions_count: transactionsCount,
+      }) => ({
+        account,
+        transactionsCount,
+      })
+    );
+    console.log("PARTNER_FIRST_3_MONTH_TRANSACTIONS_COUNT updated");
+  } catch (error) {
+    console.log(error);
+  }
+}
+
 async function getTransactionsByDate() {
   return TRANSACTIONS_COUNT_AGGREGATED_BY_DATE;
 }
@@ -174,6 +214,14 @@ async function getActiveContractsList() {
   return ACTIVE_CONTRACTS_LIST;
 }
 
+async function getPartnerTotalTransactionsCount() {
+  return PARTNER_TOTAL_TRANSACTIONS_COUNT;
+}
+
+async function getPartnerFirst3MonthTransactionsCount() {
+  return PARTNER_FIRST_3_MONTH_TRANSACTIONS_COUNT;
+}
+
 exports.aggregateTransactionsCountByDate = aggregateTransactionsCountByDate;
 exports.aggregateTeragasUsedByDate = aggregateTeragasUsedByDate;
 exports.aggregateNewAccountsCountByDate = aggregateNewAccountsCountByDate;
@@ -182,6 +230,8 @@ exports.aggregateActiveContractsCountByDate = aggregateActiveContractsCountByDat
 exports.aggregateActiveAccountsCountByDate = aggregateActiveAccountsCountByDate;
 exports.aggregateActiveAccountsList = aggregateActiveAccountsList;
 exports.aggregateActiveContractsList = aggregateActiveContractsList;
+exports.aggregatePartnerTotalTransactionsCount = aggregatePartnerTotalTransactionsCount;
+exports.aggregatePartnerFirst3MonthTransactionsCount = aggregatePartnerFirst3MonthTransactionsCount;
 
 exports.getTransactionsByDate = getTransactionsByDate;
 exports.getTeragasUsedByDate = getTeragasUsedByDate;
@@ -191,3 +241,5 @@ exports.getActiveContractsCountByDate = getActiveContractsCountByDate;
 exports.getActiveAccountsCountByDate = getActiveAccountsCountByDate;
 exports.getActiveAccountsList = getActiveAccountsList;
 exports.getActiveContractsList = getActiveContractsList;
+exports.getPartnerTotalTransactionsCount = getPartnerTotalTransactionsCount;
+exports.getPartnerFirst3MonthTransactionsCount = getPartnerFirst3MonthTransactionsCount;

--- a/backend/src/wamp.js
+++ b/backend/src/wamp.js
@@ -262,6 +262,14 @@ wampHandlers["active-contracts-list"] = async () => {
   return await stats.getActiveContractsList();
 };
 
+wampHandlers["partner-total-transactions-count"] = async () => {
+  return await stats.getPartnerTotalTransactionsCount();
+};
+
+wampHandlers["partner-first-3-month-transactions-count"] = async () => {
+  return await stats.getPartnerFirst3MonthTransactionsCount();
+};
+
 function setupWamp() {
   const wamp = new autobahn.Connection({
     realm: "near-explorer",

--- a/frontend/src/components/stats/PartnerFirst3MonthTransactionsList.tsx
+++ b/frontend/src/components/stats/PartnerFirst3MonthTransactionsList.tsx
@@ -1,0 +1,74 @@
+import React, { useState, useEffect } from "react";
+import ReactEcharts from "echarts-for-react";
+
+import StatsApi, { Account } from "../../libraries/explorer-wamp/stats";
+
+export default () => {
+  const [activeAccounts, setAccounts] = useState(Array());
+  const [count, setCount] = useState(Array());
+
+  useEffect(() => {
+    new StatsApi()
+      .partnerFirst3MonthTransactionsCount()
+      .then((accounts: Account[]) => {
+        if (accounts) {
+          const activeAccounts = accounts.map(
+            (account: Account) => account.account
+          );
+          const count = accounts.map((account: Account) =>
+            Number(account.transactionsCount)
+          );
+          setAccounts(activeAccounts);
+          setCount(count);
+        }
+      });
+  }, []);
+
+  let height = Math.max(20 * activeAccounts.length, 300);
+
+  const getOption = () => {
+    return {
+      title: {
+        text:
+          "Partner Accounts of transactions the first 3 months on the network",
+      },
+      grid: { containLabel: true },
+      tooltip: {
+        trigger: "axis",
+        axisPointer: {
+          type: "shadow",
+        },
+      },
+      xAxis: [
+        {
+          name: "Transactions",
+          type: "value",
+        },
+      ],
+      yAxis: [
+        {
+          type: "category",
+          data: activeAccounts,
+        },
+      ],
+      series: [
+        {
+          type: "bar",
+          data: count,
+        },
+      ],
+    };
+  };
+
+  return (
+    <ReactEcharts
+      option={getOption()}
+      style={{
+        height: height.toString() + "px",
+        width: "100%",
+        marginTop: "26px",
+        marginLeft: "24px",
+      }}
+    />
+  );
+};

--- a/frontend/src/components/stats/PartnerFirst3MonthTransactionsList.tsx
+++ b/frontend/src/components/stats/PartnerFirst3MonthTransactionsList.tsx
@@ -24,7 +24,7 @@ export default () => {
       });
   }, []);
 
-  let height = Math.max(20 * activeAccounts.length, 300);
+  let height = 30 * activeAccounts.length;
 
   const getOption = () => {
     return {

--- a/frontend/src/components/stats/PartnerTotalTransactionList.tsx
+++ b/frontend/src/components/stats/PartnerTotalTransactionList.tsx
@@ -24,8 +24,7 @@ export default () => {
       });
   }, []);
 
-  let height = Math.max(20 * activeAccounts.length, 300);
-
+  let height = 30 * activeAccounts.length;
   const getOption = () => {
     return {
       title: {

--- a/frontend/src/components/stats/PartnerTotalTransactionList.tsx
+++ b/frontend/src/components/stats/PartnerTotalTransactionList.tsx
@@ -1,0 +1,73 @@
+import React, { useState, useEffect } from "react";
+import ReactEcharts from "echarts-for-react";
+
+import StatsApi, { Account } from "../../libraries/explorer-wamp/stats";
+
+export default () => {
+  const [activeAccounts, setAccounts] = useState(Array());
+  const [count, setCount] = useState(Array());
+
+  useEffect(() => {
+    new StatsApi()
+      .partnerTotalTransactionsCount()
+      .then((accounts: Account[]) => {
+        if (accounts) {
+          const activeAccounts = accounts.map(
+            (account: Account) => account.account
+          );
+          const count = accounts.map((account: Account) =>
+            Number(account.transactionsCount)
+          );
+          setAccounts(activeAccounts);
+          setCount(count);
+        }
+      });
+  }, []);
+
+  let height = Math.max(20 * activeAccounts.length, 300);
+
+  const getOption = () => {
+    return {
+      title: {
+        text: "Partner Accounts for Inception to date of transactions",
+      },
+      grid: { containLabel: true },
+      tooltip: {
+        trigger: "axis",
+        axisPointer: {
+          type: "shadow",
+        },
+      },
+      xAxis: [
+        {
+          name: "Transactions",
+          type: "value",
+        },
+      ],
+      yAxis: [
+        {
+          type: "category",
+          data: activeAccounts,
+        },
+      ],
+      series: [
+        {
+          type: "bar",
+          data: count,
+        },
+      ],
+    };
+  };
+
+  return (
+    <ReactEcharts
+      option={getOption()}
+      style={{
+        height: height.toString() + "px",
+        width: "100%",
+        marginTop: "26px",
+        marginLeft: "24px",
+      }}
+    />
+  );
+};

--- a/frontend/src/libraries/explorer-wamp/stats.ts
+++ b/frontend/src/libraries/explorer-wamp/stats.ts
@@ -74,4 +74,14 @@ export default class StatsApi extends ExplorerApi {
   async activeContractsList(): Promise<Contract[]> {
     return await this.call<Contract[]>("active-contracts-list");
   }
+
+  async partnerTotalTransactionsCount(): Promise<Account[]> {
+    return await this.call<Account[]>("partner-total-transactions-count");
+  }
+
+  async partnerFirst3MonthTransactionsCount(): Promise<Account[]> {
+    return await this.call<Account[]>(
+      "partner-first-3-month-transactions-count"
+    );
+  }
 }

--- a/frontend/src/pages/partner/index.jsx
+++ b/frontend/src/pages/partner/index.jsx
@@ -1,0 +1,22 @@
+import Head from "next/head";
+
+import Content from "../../components/utils/Content";
+
+import PartnerTotalTransactionList from "../../components/stats/PartnerTotalTransactionList";
+import PartnerFirst3MonthTransactionslist from "../../components/stats/PartnerFirst3MonthTransactionsList";
+
+export default class extends React.Component {
+  render() {
+    return (
+      <>
+        <Head>
+          <title>NEAR Explorer | Partner Project Stats</title>
+        </Head>
+        <Content title={<h1>Partner Project Stats</h1>}>
+          <PartnerTotalTransactionList />
+          <PartnerFirst3MonthTransactionslist />
+        </Content>
+      </>
+    );
+  }
+}


### PR DESCRIPTION
this PR is build under the requirements under business team, they want our five partner transactions numbers:
1. use query to find the account that with company name -- backend
2. use query to get total transactions count and first 3 month transactions count for list of partners -- backend
3. generate /partner page for stats display -- frontend