### PR TITLE
Make search field less annoying on mobile

### DIFF
--- a/frontend/src/components/dashboard/DashboardHeader.tsx
+++ b/frontend/src/components/dashboard/DashboardHeader.tsx
@@ -204,7 +204,8 @@ export default class extends React.Component<State> {
                   placeholder="Search by Account ID, Transaction hash, Block hash or Block Height"
                   aria-label="Search"
                   aria-describedby="search"
-                  autoCorrect="off" autoCapitalize="none"
+                  autoCorrect="off"
+                  autoCapitalize="none"
                   onChange={this.handleSearchValueChange}
                   className="border-left-0 search-field pl-0"
                 />

--- a/frontend/src/components/dashboard/DashboardHeader.tsx
+++ b/frontend/src/components/dashboard/DashboardHeader.tsx
@@ -204,6 +204,7 @@ export default class extends React.Component<State> {
                   placeholder="Search by Account ID, Transaction hash, Block hash or Block Height"
                   aria-label="Search"
                   aria-describedby="search"
+                  autoCorrect="off" autoCapitalize="none"
                   onChange={this.handleSearchValueChange}
                   className="border-left-0 search-field pl-0"
                 />


### PR DESCRIPTION
Auto-capitalization messes with ability to type account name like `bananaswap.near` easily