### PR TITLE
update docs links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to NEAR Explorer
 
 Thank you for your interest in contributing to NEAR! There are many opportunities to contribute:
-https://docs.near.org/docs/contribution/contribution-overview
+https://docs.near.org/docs/community/contribute/contribute-overview
 
 ## Feature Requests
 

--- a/frontend/src/components/accounts/AccountDetails.tsx
+++ b/frontend/src/components/accounts/AccountDetails.tsx
@@ -58,7 +58,11 @@ export default class extends React.Component<Props> {
                     {
                       "Total blockchain storage (in bytes) used by this account. "
                     }
-                    <a href={"https://docs.near.org/docs/concepts/storage-staking"}>
+                    <a
+                      href={
+                        "https://docs.near.org/docs/concepts/storage-staking"
+                      }
+                    >
                       docs
                     </a>
                   </Term>

--- a/frontend/src/components/accounts/AccountDetails.tsx
+++ b/frontend/src/components/accounts/AccountDetails.tsx
@@ -58,7 +58,7 @@ export default class extends React.Component<Props> {
                     {
                       "Total blockchain storage (in bytes) used by this account. "
                     }
-                    <a href={"https://docs.near.org/docs/concepts/storage"}>
+                    <a href={"https://docs.near.org/docs/concepts/storage-staking"}>
                       docs
                     </a>
                   </Term>

--- a/frontend/src/components/blocks/BlockDetails.tsx
+++ b/frontend/src/components/blocks/BlockDetails.tsx
@@ -89,7 +89,7 @@ export default ({ block }: Props) => {
                         }
                         <a
                           href={
-                            "https://docs.near.org/docs/interaction/rpc#block"
+                            "https://docs.near.org/docs/develop/front-end/rpc#block"
                           }
                         >
                           docs

--- a/frontend/src/components/contracts/ContractDetails.tsx
+++ b/frontend/src/components/contracts/ContractDetails.tsx
@@ -81,7 +81,7 @@ export default class extends React.Component<Props, State> {
                     {"Latest time the contract deployed. "}
                     <a
                       href={
-                        "https://docs.near.org/docs/roles/developer/quickstart"
+                        "https://docs.near.org/docs/develop/basics/getting-started"
                       }
                     >
                       docs

--- a/frontend/src/components/dashboard/DashboardBlock.tsx
+++ b/frontend/src/components/dashboard/DashboardBlock.tsx
@@ -35,7 +35,7 @@ export default ({ className }: Props) => (
                   <p>{`For example, a block height of 1000 indicates that up to 1001 blocks may exist in the blockchain (genesis + blocks 0-1000).
                 In NEAR, there is not guaranteed to be a block for each sequential number, e.g. block 982 does not necessarily exist.`}</p>
                   <p>
-                    <a href="https://docs.near.org/docs/concepts/overview">
+                    <a href="https://docs.near.org/docs/concepts/new-to-near">
                       {"Learn more about the key concepts"}
                     </a>
                   </p>


### PR DESCRIPTION
docs.near.org has relocated some information... this PR updated those links 🙂 