### PR TITLE
fix(stats): Fixed various issues with the existing charts

### DIFF
--- a/backend/src/db-utils.js
+++ b/backend/src/db-utils.js
@@ -185,9 +185,9 @@ const queryDashboardTransactionsStats = async (options) => {
       query = `SELECT date_trunc('day', to_timestamp(DIV(block_timestamp, 1000*1000*1000))) as date, count(transaction_hash) as total
                 FROM transactions
                 WHERE
-                  block_timestamp > (cast(EXTRACT(EPOCH FROM NOW()) / (60 * 60 * 24) - 15 as bigint) * 60 * 60 * 24 * 1000 * 1000 * 1000)
+                  block_timestamp > ((cast(EXTRACT(EPOCH FROM NOW()) as bigint) / (60 * 60 * 24) - 15) * 60 * 60 * 24 * 1000 * 1000 * 1000)
                   AND
-                  block_timestamp < (cast(EXTRACT(EPOCH FROM NOW()) / (60 * 60 * 24) as bigint) * 60 * 60 * 24 * 1000 * 1000 * 1000)
+                  block_timestamp < ((cast(EXTRACT(EPOCH FROM NOW()) as bigint) / (60 * 60 * 24)) * 60 * 60 * 24 * 1000 * 1000 * 1000)
                 GROUP BY date
                 ORDER BY date`;
     } else {
@@ -196,7 +196,7 @@ const queryDashboardTransactionsStats = async (options) => {
                 WHERE
                   (block_timestamp/1000) > (strftime('%s','now') / (60 * 60 * 24) - 15) * 60 * 60 * 24
                   AND
-                  (block_timestamp/1000) > (strftime('%s','now') / (60 * 60 * 24)) * 60 * 60 * 24
+                  (block_timestamp/1000) < (strftime('%s','now') / (60 * 60 * 24)) * 60 * 60 * 24
                 GROUP BY date
                 ORDER BY date`;
     }
@@ -370,7 +370,7 @@ const queryActiveAccountsList = async () => {
   );
 };
 
-const queryParterTotalTransactions = async () => {
+const queryPartnerTotalTransactions = async () => {
   return await queryRows(
     [
       `SELECT receiver_account_id,
@@ -439,6 +439,6 @@ exports.queryActiveContractsCountAggregatedByDate = queryActiveContractsCountAgg
 exports.queryActiveAccountsCountAggregatedByDate = queryActiveAccountsCountAggregatedByDate;
 exports.queryActiveContractsList = queryActiveContractsList;
 exports.queryActiveAccountsList = queryActiveAccountsList;
-exports.queryParterTotalTransactions = queryParterTotalTransactions;
+exports.queryPartnerTotalTransactions = queryPartnerTotalTransactions;
 exports.queryPartnerFirstThreeMonthTransactions = queryPartnerFirstThreeMonthTransactions;
 exports.queryTotalDepositAmount = queryTotalDepositAmount;

--- a/backend/src/stats.js
+++ b/backend/src/stats.js
@@ -7,7 +7,7 @@ const {
   queryActiveAccountsCountAggregatedByDate,
   queryActiveContractsList,
   queryActiveAccountsList,
-  queryParterTotalTransactions,
+  queryPartnerTotalTransactions,
   queryPartnerFirstThreeMonthTransactions,
   queryTotalDepositAmount,
 } = require("./db-utils");
@@ -150,7 +150,7 @@ async function aggregateActiveContractsList() {
 
 async function aggregatePartnerTotalTransactionsCount() {
   try {
-    const partnerTotalTransactionList = await queryParterTotalTransactions();
+    const partnerTotalTransactionList = await queryPartnerTotalTransactions();
     PARTNER_TOTAL_TRANSACTIONS_COUNT = partnerTotalTransactionList.map(
       ({
         receiver_account_id: account,

--- a/frontend/src/components/stats/ActiveAccountsList.tsx
+++ b/frontend/src/components/stats/ActiveAccountsList.tsx
@@ -6,10 +6,12 @@ import StatsApi, { Account } from "../../libraries/explorer-wamp/stats";
 export default () => {
   const [activeAccounts, setAccounts] = useState(Array());
   const [count, setCount] = useState(Array());
+  console.log("ACTIVE ACC", activeAccounts, count);
 
   useEffect(() => {
     new StatsApi().activeAccountsList().then((accounts: Account[]) => {
       if (accounts) {
+        accounts.reverse();
         const activeAccounts = accounts.map(
           (account: Account) => account.account
         );
@@ -59,7 +61,7 @@ export default () => {
     <ReactEcharts
       option={getOption()}
       style={{
-        height: "300px",
+        height: "320px",
         width: "100%",
         marginTop: "26px",
         marginLeft: "24px",

--- a/frontend/src/components/stats/ActiveContractsList.tsx
+++ b/frontend/src/components/stats/ActiveContractsList.tsx
@@ -10,6 +10,7 @@ export default () => {
   useEffect(() => {
     new StatsApi().activeContractsList().then((contracts: Contract[]) => {
       if (contracts) {
+        contracts.reverse();
         const activeContracts = contracts.map(
           (account: Contract) => account.contract
         );
@@ -59,7 +60,7 @@ export default () => {
     <ReactEcharts
       option={getOption()}
       style={{
-        height: "300px",
+        height: "320px",
         width: "100%",
         marginTop: "26px",
         marginLeft: "24px",

--- a/frontend/src/pages/stats/index.jsx
+++ b/frontend/src/pages/stats/index.jsx
@@ -1,6 +1,6 @@
 import Head from "next/head";
 
-import NodeProvider from "../../context/NodeProvider";
+import NodeProvider, { NodeConsumer } from "../../context/NodeProvider";
 
 import Content from "../../components/utils/Content";
 


### PR DESCRIPTION
Resolves #528 and additionally address the transactions count history chart (removed the current date from the list which was a rounding bug)

# Test plan

* [x] Confirmed locally that the /stats page loads fine
* [x] Confirmed manually that the new transactions count history does not include the current date on the list