### PR TITLE
fix(frontend): Fixed the average block time

### DIFF
--- a/frontend/src/components/dashboard/DashboardBlock.tsx
+++ b/frontend/src/components/dashboard/DashboardBlock.tsx
@@ -57,7 +57,7 @@ export default ({ className }: Props) => (
               }
               text={
                 typeof context.recentBlockProductionSpeed !== "undefined"
-                  ? `${context.recentBlockProductionSpeed.toFixed(4)} s`
+                  ? `${(1.0 / context.recentBlockProductionSpeed).toFixed(4)} s`
                   : undefined
               }
             />


### PR DESCRIPTION
The average block time is an inversion of the block production speed. I failed here during the refactoring.