### PR TITLE
feat(frontend): update titles on charts and stats page to reflect the timeframe

### DIFF
--- a/frontend/src/components/stats/ActiveAccountsByDate.tsx
+++ b/frontend/src/components/stats/ActiveAccountsByDate.tsx
@@ -104,7 +104,7 @@ const ActiveAccountsByDate = ({ chartStyle }: Props) => {
   return (
     <ReactEcharts
       option={getOption(
-        "Daily Amount of Active Accounts",
+        "Daily Amount of Active Accounts in last 14 days",
         activeAccountsByDate
       )}
       style={chartStyle}

--- a/frontend/src/components/stats/ActiveAccountsList.tsx
+++ b/frontend/src/components/stats/ActiveAccountsList.tsx
@@ -29,7 +29,7 @@ const ActiveAccountsList = ({ chartStyle }: Props) => {
   const getOption = () => {
     return {
       title: {
-        text: "Top 10 of Active Accounts",
+        text: "Top 10 of Active Accounts in last 14 days",
       },
       grid: { containLabel: true },
       tooltip: {

--- a/frontend/src/components/stats/ActiveContractsByDate.tsx
+++ b/frontend/src/components/stats/ActiveContractsByDate.tsx
@@ -103,7 +103,10 @@ const ActiveContractsByDate = ({ chartStyle }: Props) => {
 
   return (
     <ReactEcharts
-      option={getOption("Daily Amount of Active Contracts", newContractsByDate)}
+      option={getOption(
+        "Daily Amount of Active Contracts in last 14 days",
+        newContractsByDate
+      )}
       style={chartStyle}
     />
   );

--- a/frontend/src/components/stats/ActiveContractsList.tsx
+++ b/frontend/src/components/stats/ActiveContractsList.tsx
@@ -29,7 +29,7 @@ const ActiveContractsList = ({ chartStyle }: Props) => {
   const getOption = () => {
     return {
       title: {
-        text: "Top 10 of Active Contracts",
+        text: "Top 10 of Active Contracts in last 14 days",
       },
       grid: { containLabel: true },
       tooltip: {


### PR DESCRIPTION
users are confused what is active status from our side. I just add `in last 14 days` in title, if you have better ideas, please touch it.