### PR TITLE
feat(frontend): Added a block id to the receipt details on Transaction Details page

### DIFF
--- a/frontend/src/components/transactions/ReceiptRow.tsx
+++ b/frontend/src/components/transactions/ReceiptRow.tsx
@@ -8,6 +8,7 @@ import * as T from "../../libraries/explorer-wamp/transactions";
 
 import Gas from "../utils/Gas";
 import Balance from "../utils/Balance";
+import BlockLink from "../utils/BlockLink";
 import { truncateAccountId } from "../../libraries/formatting";
 import { displayArgs } from "./ActionMessage";
 import ActionRow from "./ActionRow";
@@ -73,6 +74,13 @@ class ReceiptRow extends React.Component<Props> {
               title={receipt.receipt_id}
             >
               {truncateAccountId(receipt.receipt_id)}
+            </Col>
+          </Row>
+
+          <Row noGutters className="receipt-row-section">
+            <Col className="receipt-row-title">Executed in Block:</Col>
+            <Col className="receipt-row-receipt-hash">
+              <BlockLink blockHash={receipt.block_hash} />
             </Col>
           </Row>
 

--- a/frontend/src/components/transactions/__tests__/__snapshots__/ReceiptRow.test.tsx.snap
+++ b/frontend/src/components/transactions/__tests__/__snapshots__/ReceiptRow.test.tsx.snap
@@ -32,6 +32,27 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
       <div
         className="receipt-row-title col"
       >
+        Executed in Block:
+      </div>
+      <div
+        className="receipt-row-receipt-hash col"
+      >
+        <a
+          className="block-link"
+          href="/blocks/B111111111111111111111111111111111111111111"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+        >
+          B111111...
+        </a>
+      </div>
+    </div>
+    <div
+      className="receipt-row-section row no-gutters"
+    >
+      <div
+        className="receipt-row-title col"
+      >
         Predecessor ID:
       </div>
       <div
@@ -267,6 +288,27 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
               <div
                 className="receipt-row-title col"
               >
+                Executed in Block:
+              </div>
+              <div
+                className="receipt-row-receipt-hash col"
+              >
+                <a
+                  className="block-link"
+                  href="/blocks/B222222222222222222222222222222222222222222"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  B222222...
+                </a>
+              </div>
+            </div>
+            <div
+              className="receipt-row-section row no-gutters"
+            >
+              <div
+                className="receipt-row-title col"
+              >
                 Predecessor ID:
               </div>
               <div
@@ -445,6 +487,27 @@ exports[`<ReceiptRow /> renders receipt with many outcome receipts 1`] = `
         title="R1111111111111111111111111111111111111111111"
       >
         R1111…1111111111
+      </div>
+    </div>
+    <div
+      className="receipt-row-section row no-gutters"
+    >
+      <div
+        className="receipt-row-title col"
+      >
+        Executed in Block:
+      </div>
+      <div
+        className="receipt-row-receipt-hash col"
+      >
+        <a
+          className="block-link"
+          href="/blocks/B222222222222222222222222222222222222222222"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+        >
+          B222222...
+        </a>
       </div>
     </div>
     <div
@@ -670,6 +733,27 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                 title="R222222222222222222222222222222222222222222"
               >
                 R2222…2222222222
+              </div>
+            </div>
+            <div
+              className="receipt-row-section row no-gutters"
+            >
+              <div
+                className="receipt-row-title col"
+              >
+                Executed in Block:
+              </div>
+              <div
+                className="receipt-row-receipt-hash col"
+              >
+                <a
+                  className="block-link"
+                  href="/blocks/B333333333333333333333333333333333333333333"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  B333333...
+                </a>
               </div>
             </div>
             <div
@@ -924,6 +1008,27 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                       <div
                         className="receipt-row-title col"
                       >
+                        Executed in Block:
+                      </div>
+                      <div
+                        className="receipt-row-receipt-hash col"
+                      >
+                        <a
+                          className="block-link"
+                          href="/blocks/B444444444444444444444444444444444444444444"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                        >
+                          B444444...
+                        </a>
+                      </div>
+                    </div>
+                    <div
+                      className="receipt-row-section row no-gutters"
+                    >
+                      <div
+                        className="receipt-row-title col"
+                      >
                         Predecessor ID:
                       </div>
                       <div
@@ -1107,6 +1212,27 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                 title="R3333333333333333333333333333333333333333333"
               >
                 R3333…3333333333
+              </div>
+            </div>
+            <div
+              className="receipt-row-section row no-gutters"
+            >
+              <div
+                className="receipt-row-title col"
+              >
+                Executed in Block:
+              </div>
+              <div
+                className="receipt-row-receipt-hash col"
+              >
+                <a
+                  className="block-link"
+                  href="/blocks/B4444444444444444444444444444444444444444444"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  B444444...
+                </a>
               </div>
             </div>
             <div
@@ -1361,6 +1487,27 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                       <div
                         className="receipt-row-title col"
                       >
+                        Executed in Block:
+                      </div>
+                      <div
+                        className="receipt-row-receipt-hash col"
+                      >
+                        <a
+                          className="block-link"
+                          href="/blocks/B666666666666666666666666666666666666666666"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                        >
+                          B666666...
+                        </a>
+                      </div>
+                    </div>
+                    <div
+                      className="receipt-row-section row no-gutters"
+                    >
+                      <div
+                        className="receipt-row-title col"
+                      >
                         Predecessor ID:
                       </div>
                       <div
@@ -1552,6 +1699,27 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
               <div
                 className="receipt-row-title col"
               >
+                Executed in Block:
+              </div>
+              <div
+                className="receipt-row-receipt-hash col"
+              >
+                <a
+                  className="block-link"
+                  href="/blocks/B555555555555555555555555555555555555555555"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  B555555...
+                </a>
+              </div>
+            </div>
+            <div
+              className="receipt-row-section row no-gutters"
+            >
+              <div
+                className="receipt-row-title col"
+              >
                 Predecessor ID:
               </div>
               <div
@@ -1730,6 +1898,27 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
         title="R1111111111111111111111111111111111111111111"
       >
         R1111…1111111111
+      </div>
+    </div>
+    <div
+      className="receipt-row-section row no-gutters"
+    >
+      <div
+        className="receipt-row-title col"
+      >
+        Executed in Block:
+      </div>
+      <div
+        className="receipt-row-receipt-hash col"
+      >
+        <a
+          className="block-link"
+          href="/blocks/B222222222222222222222222222222222222222222"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+        >
+          B222222...
+        </a>
       </div>
     </div>
     <div
@@ -1981,6 +2170,27 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
                 title="R2222222222222222222222222222222222222222222"
               >
                 R2222…2222222222
+              </div>
+            </div>
+            <div
+              className="receipt-row-section row no-gutters"
+            >
+              <div
+                className="receipt-row-title col"
+              >
+                Executed in Block:
+              </div>
+              <div
+                className="receipt-row-receipt-hash col"
+              >
+                <a
+                  className="block-link"
+                  href="/blocks/B333333333333333333333333333333333333333333"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  B333333...
+                </a>
               </div>
             </div>
             <div


### PR DESCRIPTION
Ideally, we want to display a block height instead of a block hash since it is more useful for the end-user, but we can improve that in #589.

Example page: https://near-explorer-frontend-with-indexer-pr-5jya.onrender.com/transactions/BnQcHwyvP9EfdaLEErA8CsL2yVVNGs3Lfds8o4MMPPDL

# Test plan

* [x] Existing ReceiptRow unit-test is updated and reviewed
* [x] Manually confirmed that it displays the block hash correctly corresponding to the block the receipt is included in