### PR TITLE
backend: delete unused bridge query 

### DIFF
--- a/backend/src/db-utils.js
+++ b/backend/src/db-utils.js
@@ -528,24 +528,6 @@ const queryPartnerUniqueUserAmount = async () => {
   );
 };
 
-// bridge query
-const queryBridgeTokenHolders = async (bridgeTokenContractId) => {
-  return await queryRows(
-    [
-      `SELECT 
-        DISTINCT transactions.signer_account_id AS holder
-      FROM receipts 
-      JOIN action_receipt_actions ON receipts.receipt_id = action_receipt_actions.receipt_id  
-      JOIN transactions ON transactions.transaction_hash = receipts.originated_from_transaction_hash 
-      WHERE receipts.receiver_account_id = :bridge_token_contract_id
-      AND action_receipt_actions.action_kind = 'FUNCTION_CALL' 
-      AND action_receipt_actions.args->> 'method_name' = 'mint'`,
-      { bridge_token_contract_id: bridgeTokenContractId },
-    ],
-    { dataSource: DS_INDEXER_BACKEND }
-  );
-};
-
 // node part
 exports.queryOnlineNodes = queryOnlineNodes;
 exports.addNodeInfo = addNodeInfo;
@@ -582,6 +564,3 @@ exports.queryActiveContractsList = queryActiveContractsList;
 exports.queryPartnerTotalTransactions = queryPartnerTotalTransactions;
 exports.queryPartnerFirstThreeMonthTransactions = queryPartnerFirstThreeMonthTransactions;
 exports.queryPartnerUniqueUserAmount = queryPartnerUniqueUserAmount;
-
-// bridge
-exports.queryBridgeTokenHolders = queryBridgeTokenHolders;

--- a/backend/src/wamp.js
+++ b/backend/src/wamp.js
@@ -2,7 +2,6 @@ const autobahn = require("autobahn");
 const BN = require("bn.js");
 const geoip = require("geoip-lite");
 const { sha256 } = require("js-sha256");
-const { queryBridgeTokenHolders } = require("./db-utils");
 const stats = require("./stats");
 
 const models = require("../models");
@@ -303,11 +302,6 @@ wampHandlers["partner-first-3-month-transactions-count"] = async () => {
 
 wampHandlers["partner-unique-user-amount"] = async () => {
   return await stats.getPartnerUniqueUserAmount();
-};
-
-// bridge query
-wampHandlers["get-bridge-token-holders"] = async ([bridgeTokenContractId]) => {
-  return await queryBridgeTokenHolders(bridgeTokenContractId);
 };
 
 // set up wamp


### PR DESCRIPTION
since this query is already move to other repo and bridge query that not related to explorer will not put in explorer backend, delete bridge query part