### PR TITLE
feat(frontend): improved transactions list query performance

### DIFF
--- a/frontend/src/libraries/explorer-wamp/transactions.ts
+++ b/frontend/src/libraries/explorer-wamp/transactions.ts
@@ -307,7 +307,7 @@ export default class TransactionsApi extends ExplorerApi {
         );
       }
       whereClause.push(
-        `transaction_hash IN (SELECT DISTINCT originated_from_transaction_hash FROM receipts WHERE ${accountIdWhereClause.join(
+        `transaction_hash IN (SELECT originated_from_transaction_hash FROM receipts WHERE ${accountIdWhereClause.join(
           " OR "
         )})`
       );


### PR DESCRIPTION
This partially resolves #628.

Before:

```
mainnet_explorer=> EXPLAIN ANALYZE SELECT
            transactions.transaction_hash as hash,
            transactions.signer_account_id as signer_id,
            transactions.receiver_account_id as receiver_id,
            transactions.included_in_block_hash as block_hash,
            DIV(transactions.block_timestamp, 1000*1000) as block_timestamp,
            transactions.index_in_chunk as transaction_index
          FROM transactions WHERE transaction_hash IN (SELECT DISTINCT originated_from_transaction_hash FROM receipts WHERE receipts.predecessor_account_id = 'near' OR receipts.receiver_account_id = 'near') ORDER BY transactions.block_timestamp DESC, transactions.index_in_chunk DESC
          LIMIT 10;
                                                                               QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=1303288.58..1303288.60 rows=10 width=179) (actual time=6359.203..6359.337 rows=10 loops=1)
   ->  Sort  (cost=1303288.58..1304136.57 rows=339198 width=179) (actual time=6359.201..6359.333 rows=10 loops=1)
         Sort Key: transactions.block_timestamp DESC, transactions.index_in_chunk DESC
         Sort Method: top-N heapsort  Memory: 30kB
         ->  Hash Join  (cost=702249.14..1295958.63 rows=339198 width=179) (actual time=2214.761..6321.092 rows=101183 loops=1)
               Hash Cond: (transactions.transaction_hash = receipts.originated_from_transaction_hash)
               ->  Seq Scan on transactions  (cost=0.00..378548.48 rows=4635048 width=147) (actual time=0.010..1513.356 rows=4671275 loops=1)
               ->  Hash  (cost=695027.17..695027.17 rows=339198 width=44) (actual time=2214.587..2214.716 rows=101183 loops=1)
                     Buckets: 65536  Batches: 8  Memory Usage: 1454kB
                     ->  Unique  (cost=688934.10..691635.19 rows=339198 width=44) (actual time=1832.261..2188.627 rows=101183 loops=1)
                           ->  Sort  (cost=688934.10..690284.65 rows=540217 width=44) (actual time=1832.259..2131.910 rows=434834 loops=1)
                                 Sort Key: receipts.originated_from_transaction_hash
                                 Sort Method: external merge  Disk: 23464kB
                                 ->  Gather  (cost=1000.00..620875.36 rows=540217 width=44) (actual time=0.271..985.710 rows=434834 loops=1)
                                       Workers Planned: 2
                                       Workers Launched: 2
                                       ->  Parallel Seq Scan on receipts  (cost=0.00..565853.66 rows=225090 width=44) (actual time=0.042..1029.617 rows=144945 loops=3)
                                             Filter: ((predecessor_account_id = 'near'::text) OR (receiver_account_id = 'near'::text))
                                             Rows Removed by Filter: 3918050
 Planning Time: 0.263 ms
 Execution Time: 6363.450 ms
```

After:

```
mainnet_explorer=> EXPLAIN ANALYZE SELECT
            transactions.transaction_hash as hash,
            transactions.signer_account_id as signer_id,
            transactions.receiver_account_id as receiver_id,
            transactions.included_in_block_hash as block_hash,
            DIV(transactions.block_timestamp, 1000*1000) as block_timestamp,
            transactions.index_in_chunk as transaction_index
          FROM transactions WHERE transaction_hash IN (SELECT originated_from_transaction_hash FROM receipts WHERE receipts.predecessor_account_id = 'near' OR receipts.receiver_account_id = 'near') ORDER BY transactions.block_timestamp DESC, transactions.index_in_chunk DESC
          LIMIT 10;
                                                                         QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=1023191.14..1023192.30 rows=10 width=179) (actual time=2662.072..2828.970 rows=10 loops=1)
   ->  Gather Merge  (cost=1023191.14..1073371.11 rows=430084 width=179) (actual time=2662.070..2828.966 rows=10 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Sort  (cost=1022191.11..1022728.72 rows=215042 width=179) (actual time=2658.365..2658.370 rows=8 loops=3)
               Sort Key: transactions.block_timestamp DESC, transactions.index_in_chunk DESC
               Sort Method: top-N heapsort  Memory: 30kB
               Worker 0:  Sort Method: top-N heapsort  Memory: 30kB
               Worker 1:  Sort Method: top-N heapsort  Memory: 30kB
               ->  Parallel Hash Semi Join  (cost=570648.61..1017544.13 rows=215042 width=179) (actual time=2376.597..2646.175 rows=33728 loops=3)
                     Hash Cond: (transactions.transaction_hash = receipts.originated_from_transaction_hash)
                     ->  Parallel Seq Scan on transactions  (cost=0.00..351511.76 rows=1931276 width=147) (actual time=0.010..617.228 rows=1557099 loops=3)
                     ->  Parallel Hash  (cost=565855.97..565855.97 rows=225091 width=44) (actual time=1067.963..1067.964 rows=144947 loops=3)
                           Buckets: 65536  Batches: 16  Memory Usage: 2720kB
                           ->  Parallel Seq Scan on receipts  (cost=0.00..565855.97 rows=225091 width=44) (actual time=0.325..1024.961 rows=144947 loops=3)
                                 Filter: ((predecessor_account_id = 'near'::text) OR (receiver_account_id = 'near'::text))
                                 Rows Removed by Filter: 3918068
 Planning Time: 0.399 ms
 Execution Time: 2829.016 ms
```