### PR TITLE
feat(frontend): display up to 120 nodes per page

### DIFF
--- a/frontend/src/components/nodes/Validators.tsx
+++ b/frontend/src/components/nodes/Validators.tsx
@@ -15,7 +15,7 @@ interface Props {
 
 class Validators extends React.PureComponent<Props> {
   static defaultProps = {
-    itemsPerPage: 12,
+    itemsPerPage: 120,
   };
 
   state = {

--- a/frontend/src/components/nodes/Validators.tsx
+++ b/frontend/src/components/nodes/Validators.tsx
@@ -49,13 +49,19 @@ class Validators extends React.PureComponent<Props> {
                 {validatorType ? (
                   <Table
                     className="validators-section"
-                    pagination={{
-                      className: "validators-node-pagination",
-                      pageCount: Math.ceil(validatorType.length / itemsPerPage),
-                      marginPagesDisplayed: 1,
-                      pageRangeDisplayed: 3,
-                      onPageChange: this.onPageChange,
-                    }}
+                    pagination={
+                      validatorType.length > itemsPerPage
+                        ? {
+                            className: "validators-node-pagination",
+                            pageCount: Math.ceil(
+                              validatorType.length / itemsPerPage
+                            ),
+                            marginPagesDisplayed: 1,
+                            pageRangeDisplayed: 3,
+                            onPageChange: this.onPageChange,
+                          }
+                        : undefined
+                    }
                   >
                     <thead>
                       <tr className="validators-header-row">

--- a/frontend/src/context/NodeProvider.tsx
+++ b/frontend/src/context/NodeProvider.tsx
@@ -17,20 +17,10 @@ export interface Props {
 }
 
 const NodeProvider = (props: Props) => {
-  const [currentValidators, dispatchValidators] = useState<
-    ValidationNodeInfo[]
-  >();
-  const [currentProposals, dispatchCurrentProposals] = useState<
-    ValidationNodeInfo[]
-  >();
-  const [onlineNodes, dispatchOnlineNodes] = useState<NodeInfo[]>();
-  const [onlineValidatingNodes, dispatchNodes] = useState<NodeInfo[]>();
+  const [currentContext, setContext] = useState<INodeContext>({});
 
-  const fetchNodeInfo = (_positionalArgs: any, namedArgs: INodeContext) => {
-    dispatchValidators(namedArgs.currentValidators);
-    dispatchCurrentProposals(namedArgs.currentProposals);
-    dispatchOnlineNodes(namedArgs.onlineNodes);
-    dispatchNodes(namedArgs.onlineValidatingNodes);
+  const fetchNodeInfo = (_positionalArgs: any, context: INodeContext) => {
+    setContext(context);
   };
 
   useEffect(() => {
@@ -43,14 +33,7 @@ const NodeProvider = (props: Props) => {
   }, []);
 
   return (
-    <NodeContext.Provider
-      value={{
-        currentValidators,
-        currentProposals,
-        onlineNodes,
-        onlineValidatingNodes,
-      }}
-    >
+    <NodeContext.Provider value={currentContext}>
       {props.children}
     </NodeContext.Provider>
   );


### PR DESCRIPTION
Partially address #646.

# Test Plan

* [x] existing tests pass without changes
* [x] the page displays all the current validators on mainnet (59) on a single page
* [x] the regular updates do not crash CPU (without the change in the Context, it did x4 more re-renders since each individual state dispatch triggered re-render)