### PR TITLE
fix(frontend): fixed a missing gas fee chart

### DIFF
--- a/frontend/src/components/stats/GasUsedByDate.tsx
+++ b/frontend/src/components/stats/GasUsedByDate.tsx
@@ -49,7 +49,7 @@ const GasUsedByDate = ({ chartStyle }: Props) => {
         }
       }
     });
-  }, []);
+  }, [latestGasPrice]);
 
   const getOption = (title: string, data: Array<number>, name: string) => {
     return {

--- a/frontend/src/context/DatabaseProvider.tsx
+++ b/frontend/src/context/DatabaseProvider.tsx
@@ -52,8 +52,25 @@ const DatabaseProvider = (props: Props) => {
       recentBlockProductionSpeed: number;
     }
   ) {
-    dispatchLatestBlockHeight(new BN(namedArgs.latestBlockHeight));
-    dispatchLatestGasPrice(new BN(namedArgs.latestGasPrice));
+    const latestBlockHeight = new BN(namedArgs.latestBlockHeight);
+    dispatchLatestBlockHeight((prevLatestBlockHeight) => {
+      if (
+        prevLatestBlockHeight &&
+        latestBlockHeight.eq(prevLatestBlockHeight)
+      ) {
+        return prevLatestBlockHeight;
+      }
+      return latestBlockHeight;
+    });
+
+    const latestGasPrice = new BN(namedArgs.latestGasPrice);
+    dispatchLatestGasPrice((prevLatestGasPrice) => {
+      if (prevLatestGasPrice && latestGasPrice.eq(prevLatestGasPrice)) {
+        return prevLatestGasPrice;
+      }
+      return latestGasPrice;
+    });
+
     dispatchRecentBlockProductionSpeed(namedArgs.recentBlockProductionSpeed);
   };
 


### PR DESCRIPTION
# Test Plan

* [x] Confirmed manually that the chart renders fine
* [x] Confirmed manually with logs that the chart does not get re-rendered more than necessary (`latestGasPrice` is undefined on the initial component render, and only gets populated later)
* [x] Avoid unnecessary re-renders by checking the previous value (`BN` is an object, so shallow compare did not work very well)