### PR TITLE
fix: take hostname from req.headers.host

### DIFF
--- a/frontend/src/pages/api/circulating-supply-in-near.js
+++ b/frontend/src/pages/api/circulating-supply-in-near.js
@@ -3,7 +3,7 @@ import { getCirculatingSupplyToday } from "./circulating-supply";
 
 export default async function (req, res) {
   // This API is currenlty providing computed estimation based on the inflation, so we only have it for mainnet
-  const nearNetwork = getNearNetwork(req.socket.hostname);
+  const nearNetwork = getNearNetwork(req.headers.host);
   if (nearNetwork.name !== "mainnet") {
     res.status(404).end();
     return;

--- a/frontend/src/pages/api/circulating-supply.js
+++ b/frontend/src/pages/api/circulating-supply.js
@@ -1919,7 +1919,7 @@ export async function getCirculatingSupplyToday(req) {
 export default async function (req, res) {
   // This API is currently providing computed estimation based on the inflation, so we only have it for mainnet
   // TODO remove whole this logic after transition will be finished
-  const nearNetwork = getNearNetwork(req.socket.hostname);
+  const nearNetwork = getNearNetwork(req.headers.host);
   if (nearNetwork.name !== "mainnet") {
     res.status(404).end();
     return;


### PR DESCRIPTION
still investigate why we don't have host parameter in request here https://explorer.near.org/api/circulating-supply