### PR TITLE
Fix i18n of block page

### DIFF
--- a/frontend/src/pages/blocks/[hash].jsx
+++ b/frontend/src/pages/blocks/[hash].jsx
@@ -94,7 +94,7 @@ class BlockDetail extends React.Component {
                 <Content
                   size="medium"
                   icon={<TransactionIcon style={{ width: "22px" }} />}
-                  title={<h2>{translate("common.receipts.title")}</h2>}
+                  title={<h2>{translate("common.receipts.receipts")}</h2>}
                 >
                   <ReceiptsInBlock blockHash={block.hash} />
                 </Content>


### PR DESCRIPTION
With https://github.com/near/near-explorer/pull/679, now we support i18n in explorer. 

Here we missed one translation here for **Receipts** in block page: https://explorer.testnet.near.org/blocks/C4qtSqRyfQpH6amDMWgfqpXExhnk76G5VSVNLRC5G3ku 

![image](https://user-images.githubusercontent.com/46699230/126019701-46e43b9d-1fe4-4bf4-a898-cc9a7e70d8fa.png)
