### PR TITLE
Fix i18n error in SSR

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2397,6 +2397,11 @@
       "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.11.tgz",
       "integrity": "sha512-2koNhpWm3DgWRp5tpkiJ8JGc1xTn2q0l+jUNUE7oMKXUf5NpI9AIdC4kbjGNFBdHtcxBD18LAksoudAVhFKCjw=="
     },
+    "@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+    },
     "@types/d3": {
       "version": "5.16.4",
       "resolved": "https://registry.npmjs.org/@types/d3/-/d3-5.16.4.tgz",
@@ -4305,6 +4310,11 @@
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
+    },
+    "cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -13977,6 +13987,15 @@
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
+      }
+    },
+    "universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "requires": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
       }
     },
     "universalify": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -84,7 +84,8 @@
     "react-motion": "^0.5.2",
     "react-paginate": "^7.1.2",
     "react-text-collapse": "^0.5.2",
-    "styled-components": "^4.4.0"
+    "styled-components": "^4.4.0",
+    "universal-cookie": "^4.0.4"
   },
   "devDependencies": {
     "@types/autobahn": "^18.10.0",

--- a/frontend/src/components/utils/LangSwitcher.tsx
+++ b/frontend/src/components/utils/LangSwitcher.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { withLocalize } from "react-localize-redux";
 import { setMomentLocale } from "../../libraries/language";
+import Cookies from "universal-cookie";
 
 interface Lang {
   code: string;
@@ -14,7 +15,7 @@ const LanguageToggle = ({
 }: any) => {
   const selectLanguage = (code: string) => {
     setActiveLanguage(code);
-    localStorage.setItem("languageCode", code);
+    new Cookies().set("NEXT_LOCALE", code);
     setMomentLocale(code);
   };
 

--- a/frontend/src/libraries/language.js
+++ b/frontend/src/libraries/language.js
@@ -169,7 +169,7 @@ export function setMomentLocale(code) {
   moment.locale(locale);
 }
 
-function getLangauge(languages, { cookies, acceptedLanguages }) {
+function getLanguage(languages, { cookies, acceptedLanguages }) {
   if (typeof window === "undefined") {
     return (
       new Cookies(cookies || undefined).get("NEXT_LOCALE") ||
@@ -207,7 +207,7 @@ export function getI18nConfigForProvider({ cookies, acceptedLanguages }) {
   if (typeof window === "undefined") {
     const config = getI18nConfig();
     const { languages } = config;
-    const activeLang = getLangauge(languages, { cookies, acceptedLanguages });
+    const activeLang = getLanguage(languages, { cookies, acceptedLanguages });
     if (activeLang === "zh-hans") {
       config.translation = translations_zh_hans;
     } else {
@@ -221,7 +221,7 @@ export function setI18N(props) {
   const config = getI18nConfig();
   const { languages } = config;
   const { cookies } = props;
-  const activeLang = getLangauge(languages, { cookies });
+  const activeLang = getLanguage(languages, { cookies });
 
   props.initialize(config);
   props.addTranslationForLanguage(translations_en, "en");

--- a/frontend/src/libraries/language.js
+++ b/frontend/src/libraries/language.js
@@ -144,12 +144,11 @@ export function setI18N(props) {
     { name: "简体中文", code: "zh-hans" },
   ];
 
-  const browserLanguage = getBrowserLocale(languages.map((l) => l.code));
   const activeLang =
     typeof window === "undefined"
       ? languages[0].code
       : localStorage.getItem("languageCode") ||
-        browserLanguage ||
+        getBrowserLocale(languages.map((l) => l.code)) ||
         languages[0].code;
 
   props.initialize({

--- a/frontend/src/libraries/language.js
+++ b/frontend/src/libraries/language.js
@@ -138,11 +138,32 @@ export function setMomentLocale(code) {
   moment.locale(locale);
 }
 
+function getI18nConfig() {
+  return {
+    languages: [
+      { name: "English", code: "en" },
+      { name: "简体中文", code: "zh-hans" },
+    ],
+    options: {
+      defaultLanguage: "en",
+      onMissingTranslation: ({ defaultTranslation }) => defaultTranslation,
+      renderToStaticMarkup: false,
+      renderInnerHtml: true,
+    },
+  };
+}
+
+export function getI18nConfigForProvider() {
+  if (typeof window === "undefined") {
+    const config = getI18nConfig();
+    config.translation = translations_en;
+    return config;
+  }
+}
+
 export function setI18N(props) {
-  const languages = [
-    { name: "English", code: "en" },
-    { name: "简体中文", code: "zh-hans" },
-  ];
+  const config = getI18nConfig();
+  const { languages } = config;
 
   const activeLang =
     typeof window === "undefined"
@@ -151,16 +172,7 @@ export function setI18N(props) {
         getBrowserLocale(languages.map((l) => l.code)) ||
         languages[0].code;
 
-  props.initialize({
-    languages,
-    options: {
-      defaultLanguage: "en",
-      onMissingTranslation: ({ defaultTranslation }) => defaultTranslation,
-      renderToStaticMarkup: false,
-      renderInnerHtml: true,
-    },
-  });
-
+  props.initialize(config);
   props.addTranslationForLanguage(translations_en, "en");
   props.addTranslationForLanguage(translations_zh_hans, "zh-hans");
   props.setActiveLanguage(activeLang);

--- a/frontend/src/libraries/language.js
+++ b/frontend/src/libraries/language.js
@@ -57,6 +57,20 @@ const DEBUG_LOG = false;
 
 const debugLog = (...args) => DEBUG_LOG && console.log(...args);
 
+/**
+ * Parses locales provided from browser through `accept-language` header.
+ * @param {string} input
+ * @return {string[]} An array of locale codes. Priority determined by order in array.
+ **/
+export const parseAcceptLanguage = (input) => {
+  // Example input: en-US,en;q=0.9,nb;q=0.8,no;q=0.7
+  // Contains tags separated by comma.
+  // Each tag consists of locale code (2-3 letter language code) and optionally country code
+  // after dash. Tag can also contain score after semicolon, that is assumed to match order
+  // so it's not explicitly used.
+  return input.split(",").map((tag) => tag.split(";")[0]);
+};
+
 export function getBrowserLocale(appLanguages) {
   const browserLanguages = getUserLocales();
 
@@ -69,6 +83,22 @@ export function getBrowserLocale(appLanguages) {
     browserLanguages.length > 0
   ) {
     return findBestSupportedLocale(appLanguages, browserLanguages);
+  }
+}
+
+export function getAcceptedLocale(appLanguages, acceptedLanguages) {
+  acceptedLanguages =
+    acceptedLanguages && parseAcceptLanguage(acceptedLanguages);
+
+  debugLog("Languages from Accepted Languages header:", acceptedLanguages);
+
+  if (
+    appLanguages &&
+    appLanguages.length > 0 &&
+    acceptedLanguages &&
+    acceptedLanguages.length > 0
+  ) {
+    return findBestSupportedLocale(appLanguages, acceptedLanguages);
   }
 }
 
@@ -139,13 +169,23 @@ export function setMomentLocale(code) {
   moment.locale(locale);
 }
 
-function getLangauge(languages, cookies) {
-  return (
-    new Cookies(cookies || undefined).get("NEXT_LOCALE") ||
-    (typeof window !== "undefined" &&
-      getBrowserLocale(languages.map((l) => l.code))) ||
-    languages[0].code
-  );
+function getLangauge(languages, { cookies, acceptedLanguages }) {
+  if (typeof window === "undefined") {
+    return (
+      new Cookies(cookies || undefined).get("NEXT_LOCALE") ||
+      getAcceptedLocale(
+        languages.map((l) => l.code),
+        acceptedLanguages
+      ) ||
+      languages[0].code
+    );
+  } else {
+    return (
+      new Cookies().get("NEXT_LOCALE") ||
+      getBrowserLocale(languages.map((l) => l.code)) ||
+      languages[0].code
+    );
+  }
 }
 
 function getI18nConfig() {
@@ -163,11 +203,11 @@ function getI18nConfig() {
   };
 }
 
-export function getI18nConfigForProvider(cookies) {
+export function getI18nConfigForProvider({ cookies, acceptedLanguages }) {
   if (typeof window === "undefined") {
     const config = getI18nConfig();
     const { languages } = config;
-    const activeLang = getLangauge(languages, cookies);
+    const activeLang = getLangauge(languages, { cookies, acceptedLanguages });
     if (activeLang === "zh-hans") {
       config.translation = translations_zh_hans;
     } else {
@@ -181,7 +221,7 @@ export function setI18N(props) {
   const config = getI18nConfig();
   const { languages } = config;
   const { cookies } = props;
-  const activeLang = getLangauge(languages, cookies);
+  const activeLang = getLangauge(languages, { cookies });
 
   props.initialize(config);
   props.addTranslationForLanguage(translations_en, "en");

--- a/frontend/src/pages/_app.jsx
+++ b/frontend/src/pages/_app.jsx
@@ -11,8 +11,10 @@ import NetworkProvider from "../context/NetworkProvider";
 import DatabaseProvider from "../context/DatabaseProvider";
 
 import "bootstrap/dist/css/bootstrap.min.css";
+
 import { LocalizeProvider } from "react-localize-redux";
 import LocalizeWrapper from "../components/utils/LocalizeWrapper";
+import { getI18nConfigForProvider } from "../libraries/language";
 
 const {
   publicRuntimeConfig: { nearNetworks, googleAnalytics },
@@ -53,7 +55,7 @@ class _App extends App {
     const { Component, pageProps } = this.props;
 
     return (
-      <LocalizeProvider>
+      <LocalizeProvider initialize={getI18nConfigForProvider()}>
         <Head>
           <link
             rel="shortcut icon"

--- a/frontend/src/pages/_app.jsx
+++ b/frontend/src/pages/_app.jsx
@@ -33,15 +33,17 @@ class _App extends App {
     //
     // https://github.com/zeit/next.js#runtime-configuration
 
-    let currentNearNetwork;
+    let currentNearNetwork, cookies;
     if (typeof window === "undefined") {
       currentNearNetwork = getNearNetwork(appContext.ctx.req.headers.host);
+      cookies = appContext.ctx.req.headers.cookie;
     } else {
       currentNearNetwork = getNearNetwork(window.location.host);
     }
     return {
       currentNearNetwork,
       ...(await App.getInitialProps({ ...appContext, currentNearNetwork })),
+      cookies,
     };
   }
 
@@ -55,7 +57,9 @@ class _App extends App {
     const { Component, pageProps } = this.props;
 
     return (
-      <LocalizeProvider initialize={getI18nConfigForProvider()}>
+      <LocalizeProvider
+        initialize={getI18nConfigForProvider(this.props.cookies)}
+      >
         <Head>
           <link
             rel="shortcut icon"

--- a/frontend/src/pages/_app.jsx
+++ b/frontend/src/pages/_app.jsx
@@ -33,10 +33,11 @@ class _App extends App {
     //
     // https://github.com/zeit/next.js#runtime-configuration
 
-    let currentNearNetwork, cookies;
+    let currentNearNetwork, cookies, acceptedLanguages;
     if (typeof window === "undefined") {
       currentNearNetwork = getNearNetwork(appContext.ctx.req.headers.host);
       cookies = appContext.ctx.req.headers.cookie;
+      acceptedLanguages = appContext.ctx.req.headers["accept-language"];
     } else {
       currentNearNetwork = getNearNetwork(window.location.host);
     }
@@ -44,6 +45,7 @@ class _App extends App {
       currentNearNetwork,
       ...(await App.getInitialProps({ ...appContext, currentNearNetwork })),
       cookies,
+      acceptedLanguages,
     };
   }
 
@@ -54,11 +56,11 @@ class _App extends App {
   }
 
   render() {
-    const { Component, pageProps } = this.props;
+    const { Component, pageProps, cookies, acceptedLanguages } = this.props;
 
     return (
       <LocalizeProvider
-        initialize={getI18nConfigForProvider(this.props.cookies)}
+        initialize={getI18nConfigForProvider({ cookies, acceptedLanguages })}
       >
         <Head>
           <link


### PR DESCRIPTION
With https://github.com/near/near-explorer/pull/679, now we support i18n in explorer. 

However, server side rendering is in a mess.

![image](https://user-images.githubusercontent.com/46699230/126021524-8e306ab9-54c9-4abc-8956-bca3459b980c.png)

This fix will render i18n in SSR with either default language or user selected langauge. 