### PR TITLE
feat(frontend): fix several Chinese translation issues

### DIFF
--- a/frontend/src/components/accounts/AccountDetails.tsx
+++ b/frontend/src/components/accounts/AccountDetails.tsx
@@ -200,7 +200,9 @@ class AccountDetails extends React.Component<Props> {
                       ) : account.createdAtBlockTimestamp ? (
                         <>
                           {moment(account.createdAtBlockTimestamp).format(
-                            "MMMM DD, YYYY [at] h:mm:ssa"
+                            translate(
+                              "common.date_time.date_time_format"
+                            ).toString()
                           )}
                         </>
                       ) : (
@@ -261,7 +263,9 @@ class AccountDetails extends React.Component<Props> {
                     text={
                       <>
                         {moment(account.deletedAtBlockTimestamp).format(
-                          "MMMM DD, YYYY [at] h:mm:ssa"
+                          translate(
+                            "common.date_time.date_time_format"
+                          ).toString()
                         )}
                       </>
                     }

--- a/frontend/src/components/blocks/BlockDetails.tsx
+++ b/frontend/src/components/blocks/BlockDetails.tsx
@@ -153,7 +153,9 @@ const BlockDetails = ({ block }: Props) => {
                           />
                         }
                         text={moment(block.timestamp).format(
-                          "MMMM DD, YYYY [at] h:mm:ssa"
+                          translate(
+                            "common.date_time.date_time_format"
+                          ).toString()
                         )}
                         className="block-card-created border-0"
                       />

--- a/frontend/src/components/contracts/ContractDetails.tsx
+++ b/frontend/src/components/contracts/ContractDetails.tsx
@@ -101,7 +101,9 @@ class ContractDetails extends React.Component<Props, State> {
                     text={
                       timestamp
                         ? moment(timestamp).format(
-                            "MMMM DD, YYYY [at] h:mm:ssa"
+                            translate(
+                              "common.date_time.date_time_format"
+                            ).toString()
                           )
                         : translate("common.state.not_available").toString()
                     }

--- a/frontend/src/components/nodes/NodesEpoch.tsx
+++ b/frontend/src/components/nodes/NodesEpoch.tsx
@@ -42,7 +42,7 @@ class NodesEpoch extends React.PureComponent<Props> {
                     <Col>
                       {translate(
                         "component.nodes.NodesEpoch.current_epoch_start"
-                      ) + ":"}
+                      ) + ": "}
                       <span className="text-value">
                         {translate("component.nodes.NodesEpoch.block") + " #"}
                         {epochStartHeight}

--- a/frontend/src/components/nodes/__test__/__snapshots__/NodesEpoch.test.tsx.snap
+++ b/frontend/src/components/nodes/__test__/__snapshots__/NodesEpoch.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`<NodesEpoch /> renders 1`] = `
           <div
             className="col"
           >
-            Current Epoch Start:
+            Current Epoch Start: 
             <span
               className="jsx-2616163488 text-value"
             >

--- a/frontend/src/components/stats/ProtocolConfigInfo.tsx
+++ b/frontend/src/components/stats/ProtocolConfigInfo.tsx
@@ -82,10 +82,14 @@ const ProtocolConfigInfo = () => {
               {networkStats?.genesisTime && (
                 <>
                   <span>
-                    {moment(networkStats?.genesisTime).format("MMMM DD, YYYY")}
+                    {moment(networkStats?.genesisTime).format(
+                      translate("common.date_time.date_format").toString()
+                    )}
                   </span>
                   <div style={{ fontSize: "10px", lineHeight: "1" }}>
-                    {moment(networkStats?.genesisTime).format("[at] h:mm:ssa")}
+                    {moment(networkStats?.genesisTime).format(
+                      translate("common.date_time.time_format").toString()
+                    )}
                   </div>
                 </>
               )}

--- a/frontend/src/components/transactions/TransactionDetails.tsx
+++ b/frontend/src/components/transactions/TransactionDetails.tsx
@@ -307,7 +307,9 @@ class TransactionDetails extends React.Component<Props, State> {
                         />
                       }
                       text={moment(transaction.blockTimestamp).format(
-                        "MMMM DD, YYYY [at] h:mm:ssa"
+                        translate(
+                          "common.date_time.date_time_format"
+                        ).toString()
                       )}
                       className="border-0"
                     />

--- a/frontend/src/translations/en.global.json
+++ b/frontend/src/translations/en.global.json
@@ -71,6 +71,11 @@
       "not_available": "N/A",
       "yes": "Yes",
       "no": "No"
+    },
+    "date_time": {
+      "date_time_format": "MMMM DD, YYYY [at] h:mm:ssa",
+      "date_format": "MMMM DD, YYYY",
+      "time_format": "[at] h:mm:ssa"
     }
   },
   "page": {

--- a/frontend/src/translations/zh-hans.global.json
+++ b/frontend/src/translations/zh-hans.global.json
@@ -27,7 +27,7 @@
         "SuccessValue": "成功"
       },
       "execution": {
-        "convert_transaction_to_receipt": "将交易转换为收据",
+        "convert_transaction_to_receipt": "将交易转换为回执",
         "gas_burned": "销毁的Gas",
         "tokens_burned": "销毁的Tokens"
       }
@@ -36,9 +36,9 @@
       "actions": "操作"
     },
     "receipts": {
-      "receipt": "收据",
-      "receipts": "收据",
-      "receipt_id": "收据ID",
+      "receipt": "交易回执",
+      "receipts": "交易回执",
+      "receipt_id": "交易回执ID",
       "executed_in_block": "执行时所在的区块",
       "predecessor_id": "前任账户ID",
       "receiver_id": "接收账户ID",
@@ -243,14 +243,14 @@
         "no_result": "没有结果",
         "empty_result": "结果为空",
         "failure": "失败",
-        "success_receipt_id": "成功收据ID",
+        "success_receipt_id": "成功交易回执ID",
         "no_logs": "没有日志",
         "no_actions": "没有操作"
       }
     },
     "blocks": {
       "ReceiptsInBlock": {
-        "no_receipts": "此区块中没有收据"
+        "no_receipts": "此区块中没有交易回执"
       },
       "BlockDetails": {
         "transactions": {
@@ -258,7 +258,7 @@
           "text": "该区块的交易数。"
         },
         "receipts": {
-          "title": "收据数"
+          "title": "交易回执数"
         },
         "status": {
           "title": "状态",

--- a/frontend/src/translations/zh-hans.global.json
+++ b/frontend/src/translations/zh-hans.global.json
@@ -71,6 +71,11 @@
       "not_available": "无",
       "yes": "是",
       "no": "否"
+    },
+    "date_time": {
+      "date_time_format": "MoDo, YYYY, ah:mm:ss",
+      "date_format": "MoDo, YYYY",
+      "time_format": "a h:mm:ss"
     }
   },
   "page": {


### PR DESCRIPTION
### Description 

Fix the below issues: 

- [x] add one extra space before the **Block**

![image](https://user-images.githubusercontent.com/46699230/127312016-85ae24b9-d5fb-4027-9979-bb1ff220ed15.png)
![image](https://user-images.githubusercontent.com/46699230/127311983-53cfc163-eac2-460b-a921-54507b51ab2a.png)

=>

![image](https://user-images.githubusercontent.com/46699230/127310480-e12047c6-a820-4c9d-a333-2495fa568dab.png)
![image](https://user-images.githubusercontent.com/46699230/127310706-c242ba01-8055-4b3d-9fbc-13040500e6d2.png)

- [x] fix translations of `receipts`

**"收据"** => **"交易回执"**

- [x] fix date and time format of moment

![image](https://user-images.githubusercontent.com/46699230/127311863-367a4f62-6853-4e4b-8cdf-337474e1b317.png)

=> 

![image](https://user-images.githubusercontent.com/46699230/127311790-7b435957-bb0c-4163-96e4-8ec13ed6c966.png)
