### PR TITLE
fix(frontend): the missing i18n support in the ValidatorRow component

### DIFF
--- a/frontend/src/components/nodes/ValidatorRow.tsx
+++ b/frontend/src/components/nodes/ValidatorRow.tsx
@@ -219,10 +219,12 @@ class ValidatorRow extends React.PureComponent<Props, State> {
                             <Row noGutters>
                               <Col className="validator-nodes-details-title">
                                 <Term
-                                  title={"Uptime"}
-                                  text={
-                                    "Uptime is estimated by the ratio of the number of produced blocks to the number of expected blocks"
-                                  }
+                                  title={translate(
+                                    "component.nodes.ValidatorRow.uptime.title"
+                                  )}
+                                  text={translate(
+                                    "component.nodes.ValidatorRow.uptime.text"
+                                  )}
                                   href="https://nomicon.io/Economics/README.html#rewards-calculation"
                                 />
                               </Col>
@@ -253,10 +255,12 @@ class ValidatorRow extends React.PureComponent<Props, State> {
                             <Row noGutters>
                               <Col className="validator-nodes-details-title">
                                 <Term
-                                  title={"Latest block"}
-                                  text={
-                                    "The block height the validation node reported in the most recent telemetry heartbeat."
-                                  }
+                                  title={translate(
+                                    "component.nodes.ValidatorRow.latest_block.title"
+                                  )}
+                                  text={translate(
+                                    "component.nodes.ValidatorRow.latest_block.text"
+                                  )}
                                 />
                               </Col>
                             </Row>
@@ -290,10 +294,12 @@ class ValidatorRow extends React.PureComponent<Props, State> {
                             <Row noGutters>
                               <Col className="validator-nodes-details-title">
                                 <Term
-                                  title={"Latest Telemetry Update"}
-                                  text={
-                                    "Telemetry is a regular notification coming from the nodes which includes generic information like the latest known block height, and the version of NEAR Protocol agent (nearcore)."
-                                  }
+                                  title={translate(
+                                    "component.nodes.ValidatorRow.latest_telemetry_update.title"
+                                  )}
+                                  text={translate(
+                                    "component.nodes.ValidatorRow.latest_telemetry_update.text"
+                                  )}
                                 />
                               </Col>
                             </Row>
@@ -313,18 +319,12 @@ class ValidatorRow extends React.PureComponent<Props, State> {
                             <Row noGutters>
                               <Col className="validator-nodes-details-title">
                                 <Term
-                                  title={"Node Agent Name"}
-                                  text={
-                                    <>
-                                      {
-                                        "NEAR Protocol could have multiple implementations, so agent is the name of that implementation, where 'near-rs' is "
-                                      }
-                                      <a href="https://github.com/near/nearcore">
-                                        {"the official implementation"}
-                                      </a>
-                                      {"."}
-                                    </>
-                                  }
+                                  title={translate(
+                                    "component.nodes.ValidatorRow.node_agent_name.title"
+                                  )}
+                                  text={translate(
+                                    "component.nodes.ValidatorRow.node_agent_name.text"
+                                  )}
                                 />
                               </Col>
                             </Row>
@@ -349,7 +349,9 @@ class ValidatorRow extends React.PureComponent<Props, State> {
                             <Col className="validator-nodes-content-cell">
                               <Row noGutters>
                                 <Col className="validator-nodes-details-title">
-                                  {"Node Agent Version / Build"}
+                                  {translate(
+                                    "component.nodes.ValidatorRow.node_agent_version_or_build.title"
+                                  )}
                                 </Col>
                               </Row>
                               <Row noGutters>

--- a/frontend/src/translations/en.global.json
+++ b/frontend/src/translations/en.global.json
@@ -126,6 +126,25 @@
             "text": "node staked to be new validating one"
           }
         },
+        "uptime": {
+          "title": "Uptime",
+          "text": "Uptime is estimated by the ratio of the number of produced blocks to the number of expected blocks"
+        },
+        "latest_block": {
+          "title": "Latest block",
+          "text": "The block height the validation node reported in the most recent telemetry heartbeat."
+        },
+        "latest_telemetry_update": {
+          "title": "Latest Telemetry Update",
+          "text": "Telemetry is a regular notification coming from the nodes which includes generic information like the latest known block height, and the version of NEAR Protocol agent (nearcore)."
+        },
+        "node_agent_name": {
+          "title": "Node Agent Name",
+          "text": "NEAR Protocol could have multiple implementations, so agent is the name of that implementation, where 'near-rs' is <a href=\"https://github.com/near/nearcore\">the official implementation</a>. "
+        },
+        "node_agent_version_or_build": {
+          "title": "Node Agent Version / Build"
+        },
         "warning_tip": "Validators 1 - ${node_tip_max} hold a cumulative stake above 33%. Delegating to the validators below improves the decentralization of the network."
       },
       "NodesEpoch": {

--- a/frontend/src/translations/vi.global.json
+++ b/frontend/src/translations/vi.global.json
@@ -126,6 +126,25 @@
             "text": "node được ký gửi để thành node xác thực mới"
           }
         },
+        "uptime": {
+          "title": "Uptime",
+          "text": "Uptime is estimated by the ratio of the number of produced blocks to the number of expected blocks"
+        },
+        "latest_block": {
+          "title": "Latest block",
+          "text": "The block height the validation node reported in the most recent telemetry heartbeat."
+        },
+        "latest_telemetry_update": {
+          "title": "Latest Telemetry Update",
+          "text": "Telemetry is a regular notification coming from the nodes which includes generic information like the latest known block height, and the version of NEAR Protocol agent (nearcore)."
+        },
+        "node_agent_name": {
+          "title": "Node Agent Name",
+          "text": "NEAR Protocol could have multiple implementations, so agent is the name of that implementation, where 'near-rs' is <a href=\"https://github.com/near/nearcore\">the official implementation</a>. "
+        },
+        "node_agent_version_or_build": {
+          "title": "Node Agent Version / Build"
+        },
         "warning_tip": "Các node xác thực 1 - ${node_tip_max} đang tích lũy stake trên 33%. Việc ký gửi cho những node xác thực bên dưới sẽ cải thiện tính phân tán cho mạng lưới."
       },
       "NodesEpoch": {

--- a/frontend/src/translations/zh-hans.global.json
+++ b/frontend/src/translations/zh-hans.global.json
@@ -126,6 +126,25 @@
             "text": "节点将要被标记为新的验证节点"
           }
         },
+        "uptime": {
+          "title": "在线率",
+          "text": "在线率是通过已产生出块数与预期出块数的比值估算的"
+        },
+        "latest_block": {
+          "title": "最后区块",
+          "text": "验证节点在最近的检测心跳中上报的块高度。"
+        },
+        "latest_telemetry_update": {
+          "title": "最后检测更新",
+          "text": "检测是来自节点的常规通知，其中包括诸如最新已知块高度和 NEAR 协议代理 (nearcore) 版本等通用信息。"
+        },
+        "node_agent_name": {
+          "title": "节点代理名称",
+          "text": "NEAR协议可以有多种实现，'节点代理名称'是该实现的名称, 其中'near-rs'是<a href=\"https://github.com/near/nearcore\">官方实现</a>。"
+        },
+        "node_agent_version_or_build": {
+          "title": "节点代理版本 / 构建id"
+        },
         "warning_tip": "前${node_tip_max}个验证节点持有了超过33%的累积质押。委托给下面的验证节点可以改善网络的去中心化。"
       },
       "NodesEpoch": {

--- a/frontend/src/translations/zh-hans.global.json
+++ b/frontend/src/translations/zh-hans.global.json
@@ -131,11 +131,11 @@
           "text": "在线率是通过已产生出块数与预期出块数的比值估算的"
         },
         "latest_block": {
-          "title": "最后区块",
+          "title": "最新区块",
           "text": "验证节点在最近的检测心跳中上报的块高度。"
         },
         "latest_telemetry_update": {
-          "title": "最后检测更新",
+          "title": "最新检测更新",
           "text": "检测是来自节点的常规通知，其中包括诸如最新已知块高度和 NEAR 协议代理 (nearcore) 版本等通用信息。"
         },
         "node_agent_name": {
@@ -143,7 +143,7 @@
           "text": "NEAR协议可以有多种实现，'节点代理名称'是该实现的名称, 其中'near-rs'是<a href=\"https://github.com/near/nearcore\">官方实现</a>。"
         },
         "node_agent_version_or_build": {
-          "title": "节点代理版本 / 构建id"
+          "title": "节点代理版本 / 构建ID"
         },
         "warning_tip": "前${node_tip_max}个验证节点持有了超过33%的累积质押。委托给下面的验证节点可以改善网络的去中心化。"
       },


### PR DESCRIPTION
Fix: the missing i18n support in the ValidatorRow component
Related PR: #700 
Because I don’t understand Vietnamese, it kept the default in Vietnamese mode
![](https://user-images.githubusercontent.com/34593263/128868543-5dc42250-2e21-4a8d-a537-5b941c01cb05.png)