### PR TITLE
feat(fossa): run fossa only on master to unbreak external contributors

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -1,8 +1,9 @@
 name: Fossa Compliance Scanning
 
 on:
-  - pull_request
-  - push
+  push:
+    branches:
+      - 'master'
 
 jobs:
   build:


### PR DESCRIPTION
Running FOSSA only on master is sufficient enough. We can easily revert or fix the issues as they occur.