### PR TITLE
refactor(frontend): Display correct error message on pages without any data

### DIFF
--- a/frontend/src/libraries/explorer-wamp/accounts.ts
+++ b/frontend/src/libraries/explorer-wamp/accounts.ts
@@ -69,9 +69,10 @@ export default class AccountsApi extends ExplorerApi {
       }
 
       if (accountsBasicInfo.length === 0) {
-        return {
-          accountId,
-        } as AccountBasicInfo;
+        throw {
+          account_id: accountId,
+          status: 404,
+        };
       }
       const accountBasicInfo = accountsBasicInfo[0];
       return {

--- a/frontend/src/libraries/explorer-wamp/transactions.ts
+++ b/frontend/src/libraries/explorer-wamp/transactions.ts
@@ -438,21 +438,13 @@ export default class TransactionsApi extends ExplorerApi {
     transactionHash: string
   ): Promise<Transaction | null> {
     try {
-      let transactionInfo = await this.getTransactions({
+      const transactionInfo = await this.getTransactions({
         transactionHash,
         limit: 1,
-      }).then((it) => it[0] || null);
-      if (transactionInfo === null) {
-        transactionInfo = {
-          status: "NotStarted",
-          hash: transactionHash,
-          signerId: "",
-          receiverId: "",
-          blockHash: "",
-          blockTimestamp: 0,
-          transactionIndex: 0,
-          actions: [],
-        };
+      }).then((it) => it[0] || undefined);
+
+      if (transactionInfo === undefined) {
+        throw new Error("transaction not found");
       } else {
         const transactionExtraInfo = await this.call<any>("nearcore-tx", [
           transactionInfo.hash,

--- a/frontend/src/pages/accounts/[id].jsx
+++ b/frontend/src/pages/accounts/[id].jsx
@@ -55,7 +55,12 @@ class AccountDetail extends Component {
           }
           border={false}
         >
-          {accountFetchingError ? (
+          {accountFetchingError?.status === 404 ? (
+            <Translate
+              id="page.accounts.error.account_not_found"
+              data={{ account_id: accountFetchingError.account_id }}
+            />
+          ) : accountFetchingError ? (
             <Translate id="page.accounts.error.account_fetching" />
           ) : (
             <AccountDetails

--- a/frontend/src/pages/blocks/[hash].jsx
+++ b/frontend/src/pages/blocks/[hash].jsx
@@ -74,7 +74,7 @@ class BlockDetail extends Component {
               border={false}
             >
               {this.props.err ? (
-                `Information is not available at the moment. Please, check if the block hash is correct or try later.`
+                <>{translate("page.blocks.error.block_fetching")}</>
               ) : (
                 <BlockDetails block={block} />
               )}

--- a/frontend/src/pages/transactions/[hash].jsx
+++ b/frontend/src/pages/transactions/[hash].jsx
@@ -48,76 +48,68 @@ class TransactionDetailsPage extends Component {
     };
 
     return (
-      <Translate>
-        {({ translate }) => (
-          <>
-            <Head>
-              <title>NEAR Explorer | Transaction</title>
-            </Head>
-            <Content
-              title={
-                <h1>
-                  <Translate id="common.transactions.transaction" />
-                  {`: ${transaction.hash.substring(
-                    0,
-                    7
-                  )}...${transaction.hash.substring(
-                    transaction.hash.length - 4
-                  )}`}
-                </h1>
-              }
-              border={false}
-            >
-              {this.props.err ? (
-                `Information is not available at the moment. Please, check if the transaction hash is correct or try later.`
-              ) : (
-                <TransactionDetails transaction={transaction} />
-              )}
-            </Content>
-            {transaction.actions && (
-              <Content
-                size="medium"
-                icon={<TransactionIcon style={{ width: "22px" }} />}
-                title={
-                  <h2>
-                    <Translate id="common.actions.actions" />
-                  </h2>
-                }
-              >
-                <ActionsList
-                  actions={transaction.actions}
-                  signerId={transaction.signerId}
-                  receiverId={transaction.receiverId}
-                  blockTimestamp={transaction.blockTimestamp}
-                  detalizationMode="minimal"
-                  showDetails
-                />
-              </Content>
-            )}
-
-            {transaction.receipt && (
-              <Content
-                size="medium"
-                icon={<TransactionIcon style={{ width: "22px" }} />}
-                title={
-                  <h2>
-                    <Translate id="page.transactions.transaction_execution_plan" />
-                  </h2>
-                }
-              >
-                <TransactionOutcome
-                  transaction={transaction.transactionOutcome}
-                />
-
-                <ReceiptRow
-                  receipt={transaction.receipt}
-                  transactionHash={transaction.hash}
-                />
-              </Content>
-            )}
-          </>
+      <>
+        <Head>
+          <title>NEAR Explorer | Transaction</title>
+        </Head>
+        <Content
+          title={
+            <h1>
+              <Translate id="common.transactions.transaction" />
+              {`: ${transaction.hash.substring(
+                0,
+                7
+              )}...${transaction.hash.substring(transaction.hash.length - 4)}`}
+            </h1>
+          }
+          border={false}
+        >
+          {this.props.err ? (
+            <Translate id="page.transactions.error.transaction_fetching" />
+          ) : (
+            <TransactionDetails transaction={transaction} />
+          )}
+        </Content>
+        {transaction.actions && (
+          <Content
+            size="medium"
+            icon={<TransactionIcon style={{ width: "22px" }} />}
+            title={
+              <h2>
+                <Translate id="common.actions.actions" />
+              </h2>
+            }
+          >
+            <ActionsList
+              actions={transaction.actions}
+              signerId={transaction.signerId}
+              receiverId={transaction.receiverId}
+              blockTimestamp={transaction.blockTimestamp}
+              detalizationMode="minimal"
+              showDetails
+            />
+          </Content>
         )}
-      </Translate>
+
+        {transaction.receipt && (
+          <Content
+            size="medium"
+            icon={<TransactionIcon style={{ width: "22px" }} />}
+            title={
+              <h2>
+                <Translate id="page.transactions.transaction_execution_plan" />
+              </h2>
+            }
+          >
+            <TransactionOutcome transaction={transaction.transactionOutcome} />
+
+            <ReceiptRow
+              receipt={transaction.receipt}
+              transactionHash={transaction.hash}
+            />
+          </Content>
+        )}
+      </>
     );
   }
 }

--- a/frontend/src/translations/en.global.json
+++ b/frontend/src/translations/en.global.json
@@ -88,14 +88,21 @@
     "accounts": {
       "account": "Account",
       "error": {
-        "account_fetching": "Information is not available at the moment. Please, check if the account name is correct or try later."
+        "account_fetching": "Information is not available at the moment. Please, check if the account name is correct or try later.",
+        "account_not_found": "Account ${account_id} not found. Please, check if the account name is correct or try later."
       }
     },
     "blocks": {
-      "title": "Blocks"
+      "title": "Blocks",
+      "error": {
+        "block_fetching": "Information is not available at the moment. Please, check if the block hash is correct or try later."
+      }
     },
     "transactions": {
-      "transaction_execution_plan": "Transaction Execution Plan"
+      "transaction_execution_plan": "Transaction Execution Plan",
+      "error": {
+        "transaction_fetching": "Information is not available at the moment. Please, check if the transaction hash is correct or try later."
+      }
     }
   },
   "component": {

--- a/frontend/src/translations/vi.global.json
+++ b/frontend/src/translations/vi.global.json
@@ -88,14 +88,21 @@
     "accounts": {
       "account": "Tài khoản",
       "error": {
-        "account_fetching": "Hiện tại chưa thấy thông tin. Xin vui lòng kiểm tra lại tên tài khoản, hoặc thử lại vào lúc khác."
+        "account_fetching": "Hiện tại chưa thấy thông tin. Xin vui lòng kiểm tra lại tên tài khoản, hoặc thử lại vào lúc khác.",
+        "account_not_found": "Account ${account_id} not found. Please, check if the account name is correct or try later."
       }
     },
     "blocks": {
-      "title": "Các Khối"
+      "title": "Các Khối",
+      "error": {
+        "block_fetching": "Information is not available at the moment. Please, check if the block hash is correct or try later."
+      }
     },
     "transactions": {
-      "transaction_execution_plan": "Kế hoạch Thực thi Giao dịch"
+      "transaction_execution_plan": "Kế hoạch Thực thi Giao dịch",
+      "error": {
+        "transaction_fetching": "Information is not available at the moment. Please, check if the transaction hash is correct or try later."
+      }
     }
   },
   "component": {

--- a/frontend/src/translations/zh-hans.global.json
+++ b/frontend/src/translations/zh-hans.global.json
@@ -88,14 +88,21 @@
     "accounts": {
       "account": "账户",
       "error": {
-        "account_fetching": "当前信息不可用。请检查账户名称是否正确或稍后再次尝试。"
+        "account_fetching": "当前信息不可用。请检查账户名称是否正确或稍后再次尝试。",
+        "account_not_found": "Account ${account_id} not found. Please, check if the account name is correct or try later."
       }
     },
     "blocks": {
-      "title": "区块"
+      "title": "区块",
+      "error": {
+        "block_fetching": "Information is not available at the moment. Please, check if the block hash is correct or try later."
+      }
     },
     "transactions": {
-      "transaction_execution_plan": "交易执行计划"
+      "transaction_execution_plan": "交易执行计划",
+      "error": {
+        "transaction_fetching": "Information is not available at the moment. Please, check if the transaction hash is correct or try later."
+      }
     }
   },
   "component": {


### PR DESCRIPTION
### Story
User tries to view transaction (already created and redirected from wallet). But the page shows default values that doesn't make any sense and get user a bit confused. This can happen by a lot of receipts which must proсessed by validators. That's why that kind of transactions will be available in rpc in some time.

Solution: show to the user correct message that transaction which will be available soon.

Also we had such a problem with accounts when we try to query to a non-existent account. For now we will show the message that account does not exist