### PR TITLE
fix(frontend): Add links to useful fields in receipts section

### DIFF
--- a/frontend/src/components/transactions/ReceiptRow.tsx
+++ b/frontend/src/components/transactions/ReceiptRow.tsx
@@ -8,8 +8,9 @@ import * as T from "../../libraries/explorer-wamp/transactions";
 
 import Gas from "../utils/Gas";
 import Balance from "../utils/Balance";
+import AccountLink from "../utils/AccountLink";
 import BlockLink from "../utils/BlockLink";
-import { truncateAccountId } from "../../libraries/formatting";
+import ReceiptLink from "../utils/ReceiptLink";
 import { displayArgs } from "./ActionMessage";
 import ActionRow from "./ActionRow";
 
@@ -17,11 +18,12 @@ import { Translate } from "react-localize-redux";
 
 export interface Props {
   receipt: T.NestedReceiptWithOutcome;
+  transactionHash: string;
 }
 
 class ReceiptRow extends Component<Props> {
   render() {
-    const { receipt } = this.props;
+    const { receipt, transactionHash } = this.props;
 
     let statusInfo;
     if ("SuccessValue" in (receipt.outcome.status as T.ReceiptSuccessValue)) {
@@ -95,15 +97,21 @@ class ReceiptRow extends Component<Props> {
             <Col className="receipt-row-title">
               <Translate id="common.receipts.receipt_id" />:
             </Col>
-            <Col className="receipt-row-receipt-hash">{receipt.receipt_id}</Col>
+            <Col className="receipt-row-receipt-hash trancate-link">
+              <ReceiptLink
+                transactionHash={transactionHash}
+                receiptId={receipt.receipt_id}
+                trancate={false}
+              />
+            </Col>
           </Row>
 
           <Row noGutters className="receipt-row-section">
             <Col className="receipt-row-title">
               <Translate id="common.receipts.executed_in_block" />:
             </Col>
-            <Col className="receipt-row-receipt-hash">
-              <BlockLink blockHash={receipt.block_hash} />
+            <Col className="receipt-row-receipt-hash trancate-link">
+              <BlockLink blockHash={receipt.block_hash} trancate={false} />
             </Col>
           </Row>
 
@@ -115,7 +123,7 @@ class ReceiptRow extends Component<Props> {
               className="receipt-row-receipt-hash"
               title={receipt.predecessor_id}
             >
-              {truncateAccountId(receipt.predecessor_id)}
+              <AccountLink accountId={receipt.predecessor_id} />
             </Col>
           </Row>
 
@@ -127,7 +135,7 @@ class ReceiptRow extends Component<Props> {
               className="receipt-row-receipt-hash"
               title={receipt.receiver_id}
             >
-              {truncateAccountId(receipt.receiver_id)}
+              <AccountLink accountId={receipt.receiver_id} />
             </Col>
           </Row>
 
@@ -196,7 +204,10 @@ class ReceiptRow extends Component<Props> {
                   key={executedReceipt.receipt_id}
                 >
                   <Col>
-                    <ReceiptRow receipt={executedReceipt} />
+                    <ReceiptRow
+                      transactionHash={transactionHash}
+                      receipt={executedReceipt}
+                    />
                   </Col>
                 </Row>
               )
@@ -243,6 +254,10 @@ class ReceiptRow extends Component<Props> {
             overflow: hidden;
             white-space: nowrap;
             text-overflow: ellipsis;
+          }
+
+          .receipt-row-receipt-hash.trancate-link {
+            color: #007bff;
           }
 
           .receipt-row-status {

--- a/frontend/src/components/transactions/__tests__/ReceiptRow.test.tsx
+++ b/frontend/src/components/transactions/__tests__/ReceiptRow.test.tsx
@@ -14,6 +14,7 @@ describe("<ReceiptRow />", () => {
       renderI18nElement(
         <ReceiptRow
           receipt={TRANSACTION_WITH_SUCCESSFUL_RECEIPT.receipt!}
+          transactionHash={TRANSACTION_WITH_SUCCESSFUL_RECEIPT.hash}
           key={TRANSACTION_WITH_SUCCESSFUL_RECEIPT.receipt!.receipt_id}
         />
       )
@@ -25,6 +26,7 @@ describe("<ReceiptRow />", () => {
       renderI18nElement(
         <ReceiptRow
           receipt={TRANSACTION_WITH_MANY_RECEIPTS.receipt!}
+          transactionHash={TRANSACTION_WITH_MANY_RECEIPTS.hash}
           key={TRANSACTION_WITH_MANY_RECEIPTS.receipt!.receipt_id}
         />
       )
@@ -36,6 +38,7 @@ describe("<ReceiptRow />", () => {
       renderI18nElement(
         <ReceiptRow
           receipt={TRANSACTION_WITH_FAILING_RECEIPT.receipt!}
+          transactionHash={TRANSACTION_WITH_FAILING_RECEIPT.hash}
           key={TRANSACTION_WITH_FAILING_RECEIPT.receipt!.receipt_id}
         />
       )

--- a/frontend/src/components/transactions/__tests__/__snapshots__/ReceiptRow.test.tsx.snap
+++ b/frontend/src/components/transactions/__tests__/__snapshots__/ReceiptRow.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
         className="receipt-row-title receipt-hash-title col"
       >
         <b
-          className="jsx-3925159684"
+          className="jsx-3966245134"
         >
           Receipt
           :
@@ -32,9 +32,20 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
         :
       </div>
       <div
-        className="receipt-row-receipt-hash col"
+        className="receipt-row-receipt-hash trancate-link col"
       >
-        R1111111111111111111111111111111111111111111
+        <span
+          onClick={[Function]}
+        >
+          <a
+            className="jsx-4207953579 receipt-hash-link"
+            href="/transactions/T1111111111111111111111111111111111111111111#R1111111111111111111111111111111111111111111"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+          >
+            R1111111111111111111111111111111111111111111
+          </a>
+        </span>
       </div>
     </div>
     <div
@@ -47,7 +58,7 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
         :
       </div>
       <div
-        className="receipt-row-receipt-hash col"
+        className="receipt-row-receipt-hash trancate-link col"
       >
         <span
           onClick={[Function]}
@@ -58,7 +69,7 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
             onClick={[Function]}
             onMouseEnter={[Function]}
           >
-            B111111...
+            B111111111111111111111111111111111111111111
           </a>
         </span>
       </div>
@@ -76,7 +87,18 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
         className="receipt-row-receipt-hash col"
         title="signer.test"
       >
-        signer.test
+        <span
+          onClick={[Function]}
+        >
+          <a
+            className="jsx-3150401870 account-link"
+            href="/accounts/signer.test"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+          >
+            signer.test
+          </a>
+        </span>
       </div>
     </div>
     <div
@@ -92,7 +114,18 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
         className="receipt-row-receipt-hash col"
         title="receiver.test"
       >
-        receiver.test
+        <span
+          onClick={[Function]}
+        >
+          <a
+            className="jsx-3150401870 account-link"
+            href="/accounts/receiver.test"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+          >
+            receiver.test
+          </a>
+        </span>
       </div>
     </div>
     <div
@@ -272,7 +305,7 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
         className="receipt-row-text col"
       >
         <pre
-          className="jsx-3925159684"
+          className="jsx-3966245134"
         >
           000028066 listings not found
         </pre>
@@ -298,7 +331,7 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
                 className="receipt-row-title receipt-hash-title col"
               >
                 <b
-                  className="jsx-3925159684"
+                  className="jsx-3966245134"
                 >
                   Receipt
                   :
@@ -315,9 +348,20 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
                 :
               </div>
               <div
-                className="receipt-row-receipt-hash col"
+                className="receipt-row-receipt-hash trancate-link col"
               >
-                R2222222222222222222222222222222222222222222
+                <span
+                  onClick={[Function]}
+                >
+                  <a
+                    className="jsx-4207953579 receipt-hash-link"
+                    href="/transactions/T1111111111111111111111111111111111111111111#R2222222222222222222222222222222222222222222"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                  >
+                    R2222222222222222222222222222222222222222222
+                  </a>
+                </span>
               </div>
             </div>
             <div
@@ -330,7 +374,7 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
                 :
               </div>
               <div
-                className="receipt-row-receipt-hash col"
+                className="receipt-row-receipt-hash trancate-link col"
               >
                 <span
                   onClick={[Function]}
@@ -341,7 +385,7 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
-                    B222222...
+                    B222222222222222222222222222222222222222222
                   </a>
                 </span>
               </div>
@@ -359,7 +403,18 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
                 className="receipt-row-receipt-hash col"
                 title="system"
               >
-                system
+                <span
+                  onClick={[Function]}
+                >
+                  <a
+                    className="jsx-3150401870 account-link"
+                    href="/accounts/system"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                  >
+                    system
+                  </a>
+                </span>
               </div>
             </div>
             <div
@@ -375,7 +430,18 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
                 className="receipt-row-receipt-hash col"
                 title="receiver.test"
               >
-                receiver.test
+                <span
+                  onClick={[Function]}
+                >
+                  <a
+                    className="jsx-3150401870 account-link"
+                    href="/accounts/receiver.test"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                  >
+                    receiver.test
+                  </a>
+                </span>
               </div>
             </div>
             <div
@@ -531,7 +597,7 @@ exports[`<ReceiptRow /> renders receipt with many outcome receipts 1`] = `
         className="receipt-row-title receipt-hash-title col"
       >
         <b
-          className="jsx-3925159684"
+          className="jsx-3966245134"
         >
           Receipt
           :
@@ -548,9 +614,20 @@ exports[`<ReceiptRow /> renders receipt with many outcome receipts 1`] = `
         :
       </div>
       <div
-        className="receipt-row-receipt-hash col"
+        className="receipt-row-receipt-hash trancate-link col"
       >
-        R1111111111111111111111111111111111111111111
+        <span
+          onClick={[Function]}
+        >
+          <a
+            className="jsx-4207953579 receipt-hash-link"
+            href="/transactions/T1111111111111111111111111111111111111111111#R1111111111111111111111111111111111111111111"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+          >
+            R1111111111111111111111111111111111111111111
+          </a>
+        </span>
       </div>
     </div>
     <div
@@ -563,7 +640,7 @@ exports[`<ReceiptRow /> renders receipt with many outcome receipts 1`] = `
         :
       </div>
       <div
-        className="receipt-row-receipt-hash col"
+        className="receipt-row-receipt-hash trancate-link col"
       >
         <span
           onClick={[Function]}
@@ -574,7 +651,7 @@ exports[`<ReceiptRow /> renders receipt with many outcome receipts 1`] = `
             onClick={[Function]}
             onMouseEnter={[Function]}
           >
-            B222222...
+            B222222222222222222222222222222222222222222
           </a>
         </span>
       </div>
@@ -592,7 +669,18 @@ exports[`<ReceiptRow /> renders receipt with many outcome receipts 1`] = `
         className="receipt-row-receipt-hash col"
         title="signer.test"
       >
-        signer.test
+        <span
+          onClick={[Function]}
+        >
+          <a
+            className="jsx-3150401870 account-link"
+            href="/accounts/signer.test"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+          >
+            signer.test
+          </a>
+        </span>
       </div>
     </div>
     <div
@@ -608,7 +696,18 @@ exports[`<ReceiptRow /> renders receipt with many outcome receipts 1`] = `
         className="receipt-row-receipt-hash col"
         title="receiver.test"
       >
-        receiver.test
+        <span
+          onClick={[Function]}
+        >
+          <a
+            className="jsx-3150401870 account-link"
+            href="/accounts/receiver.test"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+          >
+            receiver.test
+          </a>
+        </span>
       </div>
     </div>
     <div
@@ -777,7 +876,7 @@ exports[`<ReceiptRow /> renders receipt with many outcome receipts 1`] = `
         className="receipt-row-text col"
       >
         <pre
-          className="jsx-3925159684"
+          className="jsx-3966245134"
         >
           Transfer 9807229473212706028 from signer.test to receiver.test
 Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
@@ -804,7 +903,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                 className="receipt-row-title receipt-hash-title col"
               >
                 <b
-                  className="jsx-3925159684"
+                  className="jsx-3966245134"
                 >
                   Receipt
                   :
@@ -821,9 +920,20 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                 :
               </div>
               <div
-                className="receipt-row-receipt-hash col"
+                className="receipt-row-receipt-hash trancate-link col"
               >
-                R222222222222222222222222222222222222222222
+                <span
+                  onClick={[Function]}
+                >
+                  <a
+                    className="jsx-4207953579 receipt-hash-link"
+                    href="/transactions/T1111111111111111111111111111111111111111111#R222222222222222222222222222222222222222222"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                  >
+                    R222222222222222222222222222222222222222222
+                  </a>
+                </span>
               </div>
             </div>
             <div
@@ -836,7 +946,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                 :
               </div>
               <div
-                className="receipt-row-receipt-hash col"
+                className="receipt-row-receipt-hash trancate-link col"
               >
                 <span
                   onClick={[Function]}
@@ -847,7 +957,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
-                    B333333...
+                    B333333333333333333333333333333333333333333
                   </a>
                 </span>
               </div>
@@ -865,7 +975,18 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                 className="receipt-row-receipt-hash col"
                 title="signer1.test"
               >
-                signer1.test
+                <span
+                  onClick={[Function]}
+                >
+                  <a
+                    className="jsx-3150401870 account-link"
+                    href="/accounts/signer1.test"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                  >
+                    signer1.test
+                  </a>
+                </span>
               </div>
             </div>
             <div
@@ -881,7 +1002,18 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                 className="receipt-row-receipt-hash col"
                 title="receiver.test"
               >
-                receiver.test
+                <span
+                  onClick={[Function]}
+                >
+                  <a
+                    className="jsx-3150401870 account-link"
+                    href="/accounts/receiver.test"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                  >
+                    receiver.test
+                  </a>
+                </span>
               </div>
             </div>
             <div
@@ -1098,7 +1230,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                         className="receipt-row-title receipt-hash-title col"
                       >
                         <b
-                          className="jsx-3925159684"
+                          className="jsx-3966245134"
                         >
                           Receipt
                           :
@@ -1115,9 +1247,20 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                         :
                       </div>
                       <div
-                        className="receipt-row-receipt-hash col"
+                        className="receipt-row-receipt-hash trancate-link col"
                       >
-                        R555555555555555555555555555555555555555555
+                        <span
+                          onClick={[Function]}
+                        >
+                          <a
+                            className="jsx-4207953579 receipt-hash-link"
+                            href="/transactions/T1111111111111111111111111111111111111111111#R555555555555555555555555555555555555555555"
+                            onClick={[Function]}
+                            onMouseEnter={[Function]}
+                          >
+                            R555555555555555555555555555555555555555555
+                          </a>
+                        </span>
                       </div>
                     </div>
                     <div
@@ -1130,7 +1273,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                         :
                       </div>
                       <div
-                        className="receipt-row-receipt-hash col"
+                        className="receipt-row-receipt-hash trancate-link col"
                       >
                         <span
                           onClick={[Function]}
@@ -1141,7 +1284,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                             onClick={[Function]}
                             onMouseEnter={[Function]}
                           >
-                            B444444...
+                            B444444444444444444444444444444444444444444
                           </a>
                         </span>
                       </div>
@@ -1159,7 +1302,18 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                         className="receipt-row-receipt-hash col"
                         title="system"
                       >
-                        system
+                        <span
+                          onClick={[Function]}
+                        >
+                          <a
+                            className="jsx-3150401870 account-link"
+                            href="/accounts/system"
+                            onClick={[Function]}
+                            onMouseEnter={[Function]}
+                          >
+                            system
+                          </a>
+                        </span>
                       </div>
                     </div>
                     <div
@@ -1175,7 +1329,18 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                         className="receipt-row-receipt-hash col"
                         title="receiver.test"
                       >
-                        receiver.test
+                        <span
+                          onClick={[Function]}
+                        >
+                          <a
+                            className="jsx-3150401870 account-link"
+                            href="/accounts/receiver.test"
+                            onClick={[Function]}
+                            onMouseEnter={[Function]}
+                          >
+                            receiver.test
+                          </a>
+                        </span>
                       </div>
                     </div>
                     <div
@@ -1336,7 +1501,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                 className="receipt-row-title receipt-hash-title col"
               >
                 <b
-                  className="jsx-3925159684"
+                  className="jsx-3966245134"
                 >
                   Receipt
                   :
@@ -1353,9 +1518,20 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                 :
               </div>
               <div
-                className="receipt-row-receipt-hash col"
+                className="receipt-row-receipt-hash trancate-link col"
               >
-                R3333333333333333333333333333333333333333333
+                <span
+                  onClick={[Function]}
+                >
+                  <a
+                    className="jsx-4207953579 receipt-hash-link"
+                    href="/transactions/T1111111111111111111111111111111111111111111#R3333333333333333333333333333333333333333333"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                  >
+                    R3333333333333333333333333333333333333333333
+                  </a>
+                </span>
               </div>
             </div>
             <div
@@ -1368,7 +1544,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                 :
               </div>
               <div
-                className="receipt-row-receipt-hash col"
+                className="receipt-row-receipt-hash trancate-link col"
               >
                 <span
                   onClick={[Function]}
@@ -1379,7 +1555,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
-                    B444444...
+                    B4444444444444444444444444444444444444444444
                   </a>
                 </span>
               </div>
@@ -1397,7 +1573,18 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                 className="receipt-row-receipt-hash col"
                 title="signer1.test"
               >
-                signer1.test
+                <span
+                  onClick={[Function]}
+                >
+                  <a
+                    className="jsx-3150401870 account-link"
+                    href="/accounts/signer1.test"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                  >
+                    signer1.test
+                  </a>
+                </span>
               </div>
             </div>
             <div
@@ -1413,7 +1600,18 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                 className="receipt-row-receipt-hash col"
                 title="receiver1.test"
               >
-                receiver1.test
+                <span
+                  onClick={[Function]}
+                >
+                  <a
+                    className="jsx-3150401870 account-link"
+                    href="/accounts/receiver1.test"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                  >
+                    receiver1.test
+                  </a>
+                </span>
               </div>
             </div>
             <div
@@ -1630,7 +1828,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                         className="receipt-row-title receipt-hash-title col"
                       >
                         <b
-                          className="jsx-3925159684"
+                          className="jsx-3966245134"
                         >
                           Receipt
                           :
@@ -1647,9 +1845,20 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                         :
                       </div>
                       <div
-                        className="receipt-row-receipt-hash col"
+                        className="receipt-row-receipt-hash trancate-link col"
                       >
-                        R6666666666666666666666666666666666666666666
+                        <span
+                          onClick={[Function]}
+                        >
+                          <a
+                            className="jsx-4207953579 receipt-hash-link"
+                            href="/transactions/T1111111111111111111111111111111111111111111#R6666666666666666666666666666666666666666666"
+                            onClick={[Function]}
+                            onMouseEnter={[Function]}
+                          >
+                            R6666666666666666666666666666666666666666666
+                          </a>
+                        </span>
                       </div>
                     </div>
                     <div
@@ -1662,7 +1871,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                         :
                       </div>
                       <div
-                        className="receipt-row-receipt-hash col"
+                        className="receipt-row-receipt-hash trancate-link col"
                       >
                         <span
                           onClick={[Function]}
@@ -1673,7 +1882,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                             onClick={[Function]}
                             onMouseEnter={[Function]}
                           >
-                            B666666...
+                            B666666666666666666666666666666666666666666
                           </a>
                         </span>
                       </div>
@@ -1691,7 +1900,18 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                         className="receipt-row-receipt-hash col"
                         title="system"
                       >
-                        system
+                        <span
+                          onClick={[Function]}
+                        >
+                          <a
+                            className="jsx-3150401870 account-link"
+                            href="/accounts/system"
+                            onClick={[Function]}
+                            onMouseEnter={[Function]}
+                          >
+                            system
+                          </a>
+                        </span>
                       </div>
                     </div>
                     <div
@@ -1707,7 +1927,18 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                         className="receipt-row-receipt-hash col"
                         title="receiver.test"
                       >
-                        receiver.test
+                        <span
+                          onClick={[Function]}
+                        >
+                          <a
+                            className="jsx-3150401870 account-link"
+                            href="/accounts/receiver.test"
+                            onClick={[Function]}
+                            onMouseEnter={[Function]}
+                          >
+                            receiver.test
+                          </a>
+                        </span>
                       </div>
                     </div>
                     <div
@@ -1868,7 +2099,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                 className="receipt-row-title receipt-hash-title col"
               >
                 <b
-                  className="jsx-3925159684"
+                  className="jsx-3966245134"
                 >
                   Receipt
                   :
@@ -1885,9 +2116,20 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                 :
               </div>
               <div
-                className="receipt-row-receipt-hash col"
+                className="receipt-row-receipt-hash trancate-link col"
               >
-                R4444444444444444444444444444444444444444444
+                <span
+                  onClick={[Function]}
+                >
+                  <a
+                    className="jsx-4207953579 receipt-hash-link"
+                    href="/transactions/T1111111111111111111111111111111111111111111#R4444444444444444444444444444444444444444444"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                  >
+                    R4444444444444444444444444444444444444444444
+                  </a>
+                </span>
               </div>
             </div>
             <div
@@ -1900,7 +2142,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                 :
               </div>
               <div
-                className="receipt-row-receipt-hash col"
+                className="receipt-row-receipt-hash trancate-link col"
               >
                 <span
                   onClick={[Function]}
@@ -1911,7 +2153,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
-                    B555555...
+                    B555555555555555555555555555555555555555555
                   </a>
                 </span>
               </div>
@@ -1929,7 +2171,18 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                 className="receipt-row-receipt-hash col"
                 title="system"
               >
-                system
+                <span
+                  onClick={[Function]}
+                >
+                  <a
+                    className="jsx-3150401870 account-link"
+                    href="/accounts/system"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                  >
+                    system
+                  </a>
+                </span>
               </div>
             </div>
             <div
@@ -1945,7 +2198,18 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                 className="receipt-row-receipt-hash col"
                 title="receiver.test"
               >
-                receiver.test
+                <span
+                  onClick={[Function]}
+                >
+                  <a
+                    className="jsx-3150401870 account-link"
+                    href="/accounts/receiver.test"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                  >
+                    receiver.test
+                  </a>
+                </span>
               </div>
             </div>
             <div
@@ -2101,7 +2365,7 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
         className="receipt-row-title receipt-hash-title col"
       >
         <b
-          className="jsx-3925159684"
+          className="jsx-3966245134"
         >
           Receipt
           :
@@ -2118,9 +2382,20 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
         :
       </div>
       <div
-        className="receipt-row-receipt-hash col"
+        className="receipt-row-receipt-hash trancate-link col"
       >
-        R1111111111111111111111111111111111111111111
+        <span
+          onClick={[Function]}
+        >
+          <a
+            className="jsx-4207953579 receipt-hash-link"
+            href="/transactions/T1111111111111111111111111111111111111111111#R1111111111111111111111111111111111111111111"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+          >
+            R1111111111111111111111111111111111111111111
+          </a>
+        </span>
       </div>
     </div>
     <div
@@ -2133,7 +2408,7 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
         :
       </div>
       <div
-        className="receipt-row-receipt-hash col"
+        className="receipt-row-receipt-hash trancate-link col"
       >
         <span
           onClick={[Function]}
@@ -2144,7 +2419,7 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
             onClick={[Function]}
             onMouseEnter={[Function]}
           >
-            B222222...
+            B222222222222222222222222222222222222222222
           </a>
         </span>
       </div>
@@ -2162,7 +2437,18 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
         className="receipt-row-receipt-hash col"
         title="signer.test"
       >
-        signer.test
+        <span
+          onClick={[Function]}
+        >
+          <a
+            className="jsx-3150401870 account-link"
+            href="/accounts/signer.test"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+          >
+            signer.test
+          </a>
+        </span>
       </div>
     </div>
     <div
@@ -2178,7 +2464,18 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
         className="receipt-row-receipt-hash col"
         title="receiver.test"
       >
-        receiver.test
+        <span
+          onClick={[Function]}
+        >
+          <a
+            className="jsx-3150401870 account-link"
+            href="/accounts/receiver.test"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+          >
+            receiver.test
+          </a>
+        </span>
       </div>
     </div>
     <div
@@ -2400,7 +2697,7 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
                 className="receipt-row-title receipt-hash-title col"
               >
                 <b
-                  className="jsx-3925159684"
+                  className="jsx-3966245134"
                 >
                   Receipt
                   :
@@ -2417,9 +2714,20 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
                 :
               </div>
               <div
-                className="receipt-row-receipt-hash col"
+                className="receipt-row-receipt-hash trancate-link col"
               >
-                R2222222222222222222222222222222222222222222
+                <span
+                  onClick={[Function]}
+                >
+                  <a
+                    className="jsx-4207953579 receipt-hash-link"
+                    href="/transactions/T1111111111111111111111111111111111111111111#R2222222222222222222222222222222222222222222"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                  >
+                    R2222222222222222222222222222222222222222222
+                  </a>
+                </span>
               </div>
             </div>
             <div
@@ -2432,7 +2740,7 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
                 :
               </div>
               <div
-                className="receipt-row-receipt-hash col"
+                className="receipt-row-receipt-hash trancate-link col"
               >
                 <span
                   onClick={[Function]}
@@ -2443,7 +2751,7 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
-                    B333333...
+                    B333333333333333333333333333333333333333333
                   </a>
                 </span>
               </div>
@@ -2461,7 +2769,18 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
                 className="receipt-row-receipt-hash col"
                 title="system"
               >
-                system
+                <span
+                  onClick={[Function]}
+                >
+                  <a
+                    className="jsx-3150401870 account-link"
+                    href="/accounts/system"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                  >
+                    system
+                  </a>
+                </span>
               </div>
             </div>
             <div
@@ -2477,7 +2796,18 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
                 className="receipt-row-receipt-hash col"
                 title="receiver.test"
               >
-                receiver.test
+                <span
+                  onClick={[Function]}
+                >
+                  <a
+                    className="jsx-3150401870 account-link"
+                    href="/accounts/receiver.test"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                  >
+                    receiver.test
+                  </a>
+                </span>
               </div>
             </div>
             <div

--- a/frontend/src/components/utils/BlockLink.tsx
+++ b/frontend/src/components/utils/BlockLink.tsx
@@ -1,13 +1,14 @@
 import Link from "../utils/Link";
 export interface Props {
   blockHash: string;
+  trancate?: boolean;
   children?: React.ReactNode;
 }
 
-const BlockLink = ({ blockHash, children }: Props) => (
+const BlockLink = ({ blockHash, children, trancate = true }: Props) => (
   <Link href="/blocks/[hash]" as={`/blocks/${blockHash}`}>
     <a className="block-link">
-      {children || `${blockHash.substring(0, 7)}...`}
+      {children || (trancate ? `${blockHash.substring(0, 7)}...` : blockHash)}
     </a>
   </Link>
 );

--- a/frontend/src/components/utils/ReceiptLink.tsx
+++ b/frontend/src/components/utils/ReceiptLink.tsx
@@ -3,15 +3,22 @@ import Link from "./Link";
 export interface Props {
   transactionHash?: string | null;
   receiptId: string;
+  trancate?: boolean;
   children?: React.ReactNode;
 }
 
-const ReceiptLink = ({ transactionHash, receiptId, children }: Props) => {
+const ReceiptLink = ({
+  transactionHash,
+  receiptId,
+  trancate = true,
+  children,
+}: Props) => {
   return (
     <>
       {!transactionHash ? (
         <span className="receipt-hash-link disabled" title={receiptId}>
-          {children || `${receiptId.substring(0, 7)}...`}
+          {children ||
+            (trancate ? `${receiptId.substring(0, 7)}...` : receiptId)}
         </span>
       ) : (
         <Link
@@ -19,7 +26,8 @@ const ReceiptLink = ({ transactionHash, receiptId, children }: Props) => {
           as={`/transactions/${transactionHash}#${receiptId}`}
         >
           <a className="receipt-hash-link">
-            {children || `${receiptId.substring(0, 7)}...`}
+            {children ||
+              (trancate ? `${receiptId.substring(0, 7)}...` : receiptId)}
           </a>
         </Link>
       )}

--- a/frontend/src/pages/transactions/[hash].jsx
+++ b/frontend/src/pages/transactions/[hash].jsx
@@ -109,7 +109,10 @@ class TransactionDetailsPage extends Component {
                   transaction={transaction.transactionOutcome}
                 />
 
-                <ReceiptRow receipt={transaction.receipt} />
+                <ReceiptRow
+                  receipt={transaction.receipt}
+                  transactionHash={transaction.hash}
+                />
               </Content>
             )}
           </>


### PR DESCRIPTION
Those fields like `receipt_id`, `predecessor_id` and `receiver_id` are links to Receipt and AccountPage accordingly