### PR TITLE
fix(frontend): Fix values on circulating supply chart

### DIFF
--- a/backend/src/db-utils.js
+++ b/backend/src/db-utils.js
@@ -496,8 +496,8 @@ const queryCirculatingSupply = async () => {
     [
       `SELECT
         DATE_TRUNC('day', TO_TIMESTAMP(DIV(computed_at_block_timestamp, 1000*1000*1000))) AS date,
-        DIV(circulating_tokens_supply, 1000*1000*1000) AS circulating_tokens_supply,
-        DIV(total_tokens_supply, 1000*1000*1000) as total_tokens_supply
+        circulating_tokens_supply,
+        total_tokens_supply
        FROM aggregated__circulating_supply
        ORDER BY date`,
     ],

--- a/frontend/src/components/stats/CirculatingSupplyStats.tsx
+++ b/frontend/src/components/stats/CirculatingSupplyStats.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import { Translate } from "react-localize-redux";
 import ReactEcharts from "echarts-for-react";
 import echarts from "echarts";
+import { utils } from "near-api-js";
 
 import StatsApi from "../../libraries/explorer-wamp/stats";
 import { Props } from "./TransactionsByDate";
@@ -22,14 +23,10 @@ const CirculatingSupplyStats = ({ chartStyle }: Props) => {
           ({ date, circulatingTokensSupply, totalTokensSupply }) => ({
             date,
             circulatingTokensSupply: new BN(circulatingTokensSupply)
-              .divn(10 ** 6)
-              .divn(10 ** 6)
-              .divn(10 ** 3)
+              .div(utils.format.NEAR_NOMINATION)
               .toNumber(),
             totalTokensSupply: new BN(totalTokensSupply)
-              .divn(10 ** 6)
-              .divn(10 ** 6)
-              .divn(10 ** 3)
+              .div(utils.format.NEAR_NOMINATION)
               .toNumber(),
           })
         );

--- a/frontend/src/components/stats/CirculatingSupplyStats.tsx
+++ b/frontend/src/components/stats/CirculatingSupplyStats.tsx
@@ -24,10 +24,12 @@ const CirculatingSupplyStats = ({ chartStyle }: Props) => {
             circulatingTokensSupply: new BN(circulatingTokensSupply)
               .divn(10 ** 6)
               .divn(10 ** 6)
+              .divn(10 ** 3)
               .toNumber(),
             totalTokensSupply: new BN(totalTokensSupply)
               .divn(10 ** 6)
               .divn(10 ** 6)
+              .divn(10 ** 3)
               .toNumber(),
           })
         );

--- a/frontend/src/components/stats/ProtocolConfigInfo.tsx
+++ b/frontend/src/components/stats/ProtocolConfigInfo.tsx
@@ -1,6 +1,7 @@
 import moment from "moment";
 import BN from "bn.js";
 import React, { useEffect, useState, useContext } from "react";
+import { utils } from "near-api-js";
 
 import StatsApi from "../../libraries/explorer-wamp/stats";
 import { NetworkStatsContext } from "../../context/NetworkStatsProvider";
@@ -24,16 +25,14 @@ const ProtocolConfigInfo = () => {
 
   let epochTotalSupply = epochStartBlock?.totalSupply
     ? new BN(epochStartBlock.totalSupply.toString())
-        .div(new BN((10 ** 20).toString()))
-        .div(new BN((10 ** 4).toString()))
+        .div(utils.format.NEAR_NOMINATION)
         .toNumber() /
       10 ** 6
     : null;
 
   const genesisTotaSupply = totalGenesisSupply
     ? new BN(totalGenesisSupply.toString())
-        .div(new BN((10 ** 20).toString()))
-        .div(new BN((10 ** 4).toString()))
+        .div(utils.format.NEAR_NOMINATION)
         .toNumber() /
       10 ** 6
     : null;

--- a/frontend/src/pages/stats/index.jsx
+++ b/frontend/src/pages/stats/index.jsx
@@ -3,6 +3,7 @@ import { PureComponent } from "react";
 import Mixpanel from "../../libraries/mixpanel";
 import NodeProvider, { NodeConsumer } from "../../context/NodeProvider";
 import NetworkStatsProvider from "../../context/NetworkStatsProvider";
+import { NetworkConsumer } from "../../context/NetworkProvider";
 
 import Content from "../../components/utils/Content";
 import TransactionsByDate from "../../components/stats/TransactionsByDate";
@@ -48,9 +49,15 @@ class Stats extends PureComponent {
               <ProtocolConfigInfo />
             </NetworkStatsProvider>
           </div>
-          <div id="circulatingSupply">
-            <CirculatingSupplyStats chartStyle={chartStyle} />
-          </div>
+          <NetworkConsumer>
+            {({ currentNearNetwork }) =>
+              currentNearNetwork.name === "mainnet" ? (
+                <div id="circulatingSupply">
+                  <CirculatingSupplyStats chartStyle={chartStyle} />
+                </div>
+              ) : null
+            }
+          </NetworkConsumer>
           <div id="transactionsByDate">
             <TransactionsByDate chartStyle={chartStyle} />
           </div>


### PR DESCRIPTION
Resolves #750 

We will show this chart only for `mainnet`:

<img width="1101" alt="Снимок экрана 2021-09-29 в 13 52 46" src="https://user-images.githubusercontent.com/34593263/135255193-d5ab1e8e-6a2a-4b4e-86a3-5addb8912e9b.png">
