### PR TITLE
Rewrite error logic on accounts page

### DIFF
--- a/frontend/src/libraries/explorer-wamp/accounts.ts
+++ b/frontend/src/libraries/explorer-wamp/accounts.ts
@@ -52,10 +52,7 @@ export default class AccountsApi extends ExplorerApi {
       ]);
 
       if (accountsBasicInfo.length === 0) {
-        throw {
-          account_id: accountId,
-          status: 404,
-        };
+        throw "account_not_found";
       }
       const accountBasicInfo = accountsBasicInfo[0];
       return {

--- a/frontend/src/pages/accounts/[id].jsx
+++ b/frontend/src/pages/accounts/[id].jsx
@@ -55,13 +55,11 @@ class AccountDetail extends Component {
           }
           border={false}
         >
-          {accountFetchingError?.status === 404 ? (
+          {accountFetchingError ? (
             <Translate
-              id="page.accounts.error.account_not_found"
-              data={{ account_id: accountFetchingError.account_id }}
+              id={`page.accounts.error.${accountFetchingError}`}
+              data={{ account_id: account.accountId }}
             />
-          ) : accountFetchingError ? (
-            <Translate id="page.accounts.error.account_fetching" />
           ) : (
             <AccountDetails
               account={account}

--- a/frontend/src/translations/en.global.json
+++ b/frontend/src/translations/en.global.json
@@ -88,7 +88,6 @@
     "accounts": {
       "account": "Account",
       "error": {
-        "account_fetching": "Information is not available at the moment. Please, check if the account name is correct or try later.",
         "account_not_found": "Account ${account_id} not found. Please, check if the account name is correct or try later."
       }
     },

--- a/frontend/src/translations/vi.global.json
+++ b/frontend/src/translations/vi.global.json
@@ -88,7 +88,6 @@
     "accounts": {
       "account": "Tài khoản",
       "error": {
-        "account_fetching": "Hiện tại chưa thấy thông tin. Xin vui lòng kiểm tra lại tên tài khoản, hoặc thử lại vào lúc khác.",
         "account_not_found": "Account ${account_id} not found. Please, check if the account name is correct or try later."
       }
     },

--- a/frontend/src/translations/zh-hans.global.json
+++ b/frontend/src/translations/zh-hans.global.json
@@ -88,7 +88,6 @@
     "accounts": {
       "account": "账户",
       "error": {
-        "account_fetching": "当前信息不可用。请检查账户名称是否正确或稍后再次尝试。",
         "account_not_found": "Account ${account_id} not found. Please, check if the account name is correct or try later."
       }
     },


### PR DESCRIPTION
Previously we've talking about error handling and we decide to move error logic from component so component will only receive an error text (in our case the string will be a key from `./translations/*.json`) and immediately display it. I'm not sure about solution as we need to support the error translations so I'll leave this PR as draft.