### PR TITLE
Expose 'First produced block' instead of 'Genesis Start'

### DIFF
--- a/backend/src/db-utils.js
+++ b/backend/src/db-utils.js
@@ -537,6 +537,19 @@ const queryCirculatingSupply = async () => {
   );
 };
 
+const queryFirstProducedBlockTimestamp = async () => {
+  return await querySingleRow(
+    [
+      `SELECT
+        TO_TIMESTAMP(DIV(block_timestamp, 1000 * 1000 * 1000))::date AS first_produced_block_timestamp
+       FROM blocks
+       ORDER BY blocks.block_timestamp
+       LIMIT 1`,
+    ],
+    { dataSource: DS_INDEXER_BACKEND }
+  );
+};
+
 // node part
 exports.queryOnlineNodes = queryOnlineNodes;
 exports.extendWithTelemetryInfo = extendWithTelemetryInfo;
@@ -563,6 +576,9 @@ exports.queryDeletedAccountsCountAggregatedByDate = queryDeletedAccountsCountAgg
 exports.queryActiveAccountsCountAggregatedByDate = queryActiveAccountsCountAggregatedByDate;
 exports.queryActiveAccountsList = queryActiveAccountsList;
 exports.queryActiveAccountsCountAggregatedByWeek = queryActiveAccountsCountAggregatedByWeek;
+
+// blocks
+exports.queryFirstProducedBlockTimestamp = queryFirstProducedBlockTimestamp;
 
 // contracts
 exports.queryNewContractsCountAggregatedByDate = queryNewContractsCountAggregatedByDate;

--- a/backend/src/stats.js
+++ b/backend/src/stats.js
@@ -18,6 +18,7 @@ const {
   queryLatestCirculatingSupply,
   queryCirculatingSupply,
   calculateFeesByDay,
+  queryFirstProducedBlockTimestamp,
 } = require("./db-utils");
 const {
   formatDate,
@@ -376,6 +377,14 @@ async function getLiveAccountsCountByDate() {
   return LIVE_ACCOUNTS_COUNT_AGGREGATE_BY_DATE;
 }
 
+// blocks
+async function getFirstProducedBlockTimestamp() {
+  const {
+    first_produced_block_timestamp: firstProducedBlockTimestamp,
+  } = await queryFirstProducedBlockTimestamp();
+  return firstProducedBlockTimestamp;
+}
+
 async function getActiveAccountsList() {
   return ACTIVE_ACCOUNTS_LIST;
 }
@@ -441,6 +450,9 @@ exports.aggregateLiveAccountsCountByDate = aggregateLiveAccountsCountByDate;
 exports.aggregateActiveAccountsCountByDate = aggregateActiveAccountsCountByDate;
 exports.aggregateActiveAccountsCountByWeek = aggregateActiveAccountsCountByWeek;
 exports.aggregateActiveAccountsList = aggregateActiveAccountsList;
+
+// blocks
+exports.getFirstProducedBlockTimestamp = getFirstProducedBlockTimestamp;
 
 // contracts
 exports.aggregateNewContractsCountByDate = aggregateNewContractsCountByDate;

--- a/backend/src/wamp.js
+++ b/backend/src/wamp.js
@@ -274,6 +274,11 @@ wampHandlers["active-accounts-list"] = async () => {
   return await stats.getActiveAccountsList();
 };
 
+// blocks
+wampHandlers["first-produced-block-timestamp"] = async () => {
+  return await stats.getFirstProducedBlockTimestamp();
+};
+
 // contracts
 wampHandlers["new-contracts-count-aggregated-by-date"] = async () => {
   return await stats.getNewContractsCountByDate();

--- a/frontend/src/components/stats/ProtocolConfigInfo.tsx
+++ b/frontend/src/components/stats/ProtocolConfigInfo.tsx
@@ -20,6 +20,10 @@ const ProtocolConfigInfo = () => {
   ] = useState<number>();
   const [liveAccountsCount, setLiveAccountsCount] = useState<number>();
   const [genesisAccountsAmount, setGenesisAccountsAmount] = useState<number>();
+  const [
+    firstProducedBlockTimestamp,
+    setFirstProducedBlockTimestamp,
+  ] = useState<string>();
 
   const { networkStats, epochStartBlock } = useContext(NetworkStatsContext);
 
@@ -65,6 +69,12 @@ const ProtocolConfigInfo = () => {
         setGenesisAccountsAmount(count);
       }
     });
+
+    new StatsApi().firstProducedBlockTimestamp().then((blockTimestamp) => {
+      if (blockTimestamp) {
+        setFirstProducedBlockTimestamp(blockTimestamp);
+      }
+    });
   }, []);
 
   return (
@@ -74,23 +84,16 @@ const ProtocolConfigInfo = () => {
           <InfoCard className="protocol-config">
             <Cell
               title={translate(
-                "component.stats.ProtocolConfigInfo.genesis_started"
+                "component.stats.ProtocolConfigInfo.first_produced_block"
               )}
               cellOptions={{ xs: "12", sm: "6", md: "6", xl: "3" }}
             >
-              {networkStats?.genesisTime && (
-                <>
-                  <span>
-                    {moment(networkStats?.genesisTime).format(
-                      translate("common.date_time.date_format").toString()
-                    )}
-                  </span>
-                  <div style={{ fontSize: "10px", lineHeight: "1" }}>
-                    {moment(networkStats?.genesisTime).format(
-                      translate("common.date_time.time_format").toString()
-                    )}
-                  </div>
-                </>
+              {firstProducedBlockTimestamp && (
+                <span>
+                  {moment(firstProducedBlockTimestamp).format(
+                    translate("common.date_time.date_format").toString()
+                  )}
+                </span>
               )}
             </Cell>
 

--- a/frontend/src/libraries/explorer-wamp/stats.ts
+++ b/frontend/src/libraries/explorer-wamp/stats.ts
@@ -97,6 +97,11 @@ export default class StatsApi extends ExplorerApi {
     return await this.call<Account[]>("active-accounts-list");
   }
 
+  // blocks
+  async firstProducedBlockTimestamp(): Promise<string> {
+    return await this.call<string>("first-produced-block-timestamp");
+  }
+
   // contracts
   async newContractsCountAggregatedByDate(): Promise<ContractsByDate[]> {
     return await this.call<ContractsByDate[]>(

--- a/frontend/src/translations/en.global.json
+++ b/frontend/src/translations/en.global.json
@@ -459,6 +459,7 @@
     },
     "stats": {
       "ProtocolConfigInfo": {
+        "first_produced_block": "First produced block",
         "genesis_started": "Genesis Started",
         "genesis_protocol_or_current_protocol": "Genesis Protocol / Current Protocol",
         "genesis_height": "Genesis Height",

--- a/frontend/src/translations/vi.global.json
+++ b/frontend/src/translations/vi.global.json
@@ -459,6 +459,7 @@
     },
     "stats": {
       "ProtocolConfigInfo": {
+        "first_produced_block": "First produced block",
         "genesis_started": "Genesis Đã Bắt Đầu",
         "genesis_protocol_or_current_protocol": "Giao Thức Genesis / Giao Thức Hiện Tại",
         "genesis_height": "Chiều Cao Genesis",

--- a/frontend/src/translations/zh-hans.global.json
+++ b/frontend/src/translations/zh-hans.global.json
@@ -421,6 +421,7 @@
     },
     "stats": {
       "ProtocolConfigInfo": {
+        "first_produced_block": "First produced block",
         "genesis_started": "创世区块时间",
         "genesis_protocol_or_current_protocol": "创世协议版本 / 当前协议版本",
         "genesis_height": "创世区块高度",


### PR DESCRIPTION
_Resolves: #746_ 

'Genesis Start' wasn't correct so it's better to show 'First produced block' instead.