### PR TITLE
feat(backend): sunset `select:INDEXER_BACKEND` endpoint

### DIFF
--- a/backend/src/wamp.js
+++ b/backend/src/wamp.js
@@ -64,14 +64,6 @@ const saveNodeIntoDatabase = async (nodeInfo) => {
   });
 };
 
-// select query directly from indexer
-wampHandlers["select:INDEXER_BACKEND"] = async ([query, replacements]) => {
-  return await models.sequelizeIndexerBackendReadOnly.query(query, {
-    replacements,
-    type: models.Sequelize.QueryTypes.SELECT,
-  });
-};
-
 // rpc endpoint
 wampHandlers["nearcore-view-account"] = async ([accountId]) => {
   return await nearRpc.sendJsonRpc("query", {


### PR DESCRIPTION
We saw people abusing it sending heavy requests and slowing our Explorer experience down, so it is a natural next step after #774

If you want to make queries, use the public shared access or run your own indexer: https://github.com/near/near-indexer-for-explorer/#shared-public-access