### PR TITLE
fix(backend): Fix 'Top 10 active accounts for 2 weeks' chart

### DIFF
--- a/backend/src/db-utils.js
+++ b/backend/src/db-utils.js
@@ -519,11 +519,11 @@ const queryActiveAccountsList = async () => {
   return await queryRows(
     [
       `SELECT account_id,
-              SUM(outgoing_transactions_count) AS outgoing_transactions_count
+              SUM(outgoing_transactions_count) AS transactions_count
        FROM daily_outgoing_transactions_per_account_count
        WHERE collected_for_day >= DATE_TRUNC('day', NOW() - INTERVAL '2 week')
        GROUP BY account_id
-       ORDER BY outgoing_transactions_count DESC
+       ORDER BY transactions_count DESC
        LIMIT 10`,
     ],
     { dataSource: DS_ANALYTICS_BACKEND }


### PR DESCRIPTION
After refactoring queries I miss this chart:

<img width="1087" alt="Снимок экрана 2021-11-20 в 08 58 39" src="https://user-images.githubusercontent.com/34593263/142717753-458042ae-6977-43d8-b49a-5d969d588f92.png">
