### PR TITLE
fix(backend): Fix viewing of deleted account

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -143,7 +143,10 @@ async function main() {
   try {
     await models.sequelizeTelemetryBackend.sync();
   } catch (error) {
-    console.warn("Initialization of Telemetry database failed, but Explorer backend can operate without it. Explorer backend won't be able to handle telemetry reports. More details about the error:", error);
+    console.warn(
+      "Initialization of Telemetry database failed, but Explorer backend can operate without it. Explorer backend won't be able to handle telemetry reports. More details about the error:",
+      error
+    );
   }
 
   const wamp = setupWamp();

--- a/frontend/src/libraries/explorer-wamp/accounts.ts
+++ b/frontend/src/libraries/explorer-wamp/accounts.ts
@@ -36,9 +36,6 @@ export default class AccountsApi extends ExplorerApi {
         this.getAccountBaseInfo(accountId),
         this.getAccountDetails(accountId),
       ]);
-      if (!accountBasic || !accountInfo) {
-        throw new Error("account info not found");
-      }
       return {
         ...accountBasic,
         ...accountInfo,
@@ -88,7 +85,21 @@ export default class AccountsApi extends ExplorerApi {
   }
 
   async getAccountBaseInfo(accountId: string): Promise<AccountBasicInfo> {
-    return await this.call<AccountBasicInfo>("account-info", [accountId]);
+    try {
+      const accountInfo = await this.call<AccountBasicInfo>("account-info", [
+        accountId,
+      ]);
+      if (!accountInfo) {
+        throw new Error("account info not found");
+      }
+      return accountInfo;
+    } catch (error) {
+      console.error(
+        "AccountsApi.getAccountBaseInfo failed to fetch data due to:"
+      );
+      console.error(error);
+      throw error;
+    }
   }
 
   async getAccountDetails(accountId: string): Promise<any> {


### PR DESCRIPTION
_Resolves_: #780 

Also, I find a bug with number of transactions on AccountDetails page. If account was just created, there was no any transactions at the top of page, but you could see all of them in the **Transactions** section.