### PR TITLE
fix(backend): Switch `EXPERIMENTAL_genesis_config` query with valid one

### DIFF
--- a/backend/src/wamp.js
+++ b/backend/src/wamp.js
@@ -143,7 +143,7 @@ wampHandlers["get-account-details"] = async ([accountId]) => {
     lockupAccountInfo,
     lockupLockedBalance,
     lockupStakingPoolAccountId,
-    genesisConfig,
+    protocolConfig,
   ] = await Promise.all([
     nearRpc
       .sendJsonRpc("query", {
@@ -168,7 +168,7 @@ wampHandlers["get-account-details"] = async ([accountId]) => {
     nearRpc
       .callViewMethod(lockupAccountId, "get_staking_pool_account_id", {})
       .catch(ignore_if_does_not_exist),
-    nearRpc.sendJsonRpc("EXPERIMENTAL_genesis_config", {}),
+    nearRpc.sendJsonRpc("EXPERIMENTAL_protocol_config", { finality: "final" }),
   ]);
 
   if (accountInfo === null) {
@@ -177,7 +177,7 @@ wampHandlers["get-account-details"] = async ([accountId]) => {
 
   const storageUsage = new BN(accountInfo.storage_usage);
   const storageAmountPerByte = new BN(
-    genesisConfig.runtime_config.storage_amount_per_byte
+    protocolConfig.runtime_config.storage_amount_per_byte
   );
   const stakedBalance = new BN(accountInfo.locked);
   const nonStakedBalance = new BN(accountInfo.amount);


### PR DESCRIPTION
Since new deploy of testnet we haven't `storage_amount_per_byte` property in `EXPERIMENTAL_genesis_config` query, so we change the query with `EXPERIMENTAL_protocol_config`