### PR TITLE
refactor(backend): disambiguated the configuration options

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -52,11 +52,11 @@ If you maintain your own Indexer for Explorer database or NEAR Archival Node, yo
 Your local config file may look like:
 
 ```
-export NEAR_RPC_URL=https://archival-rpc.testnet.near.org
-export NEAR_INDEXER_DATABASE_HOST=35.184.214.98
-export NEAR_INDEXER_DATABASE_NAME=testnet_explorer
-export NEAR_INDEXER_DATABASE_USERNAME=public_readonly
-export NEAR_INDEXER_DATABASE_PASSWORD=nearprotocol
+export NEAR_ARCHIVAL_RPC_URL=https://archival-rpc.testnet.near.org
+export NEAR_READ_ONLY_INDEXER_DATABASE_HOST=testnet.db.explorer.indexer.near.dev
+export NEAR_READ_ONLY_INDEXER_DATABASE_NAME=testnet_explorer
+export NEAR_READ_ONLY_INDEXER_DATABASE_USERNAME=public_readonly
+export NEAR_READ_ONLY_INDEXER_DATABASE_PASSWORD=nearprotocol
 ```
 
 When all preparation is done run backend:

--- a/backend/config/database.js
+++ b/backend/config/database.js
@@ -1,23 +1,67 @@
 module.exports = {
-  telemetryDatabase: {
+  readOnlyIndexerDatabase: {
     dialect: "postgres",
-    host: process.env.NEAR_TELEMETRY_DATABASE_HOST,
-    database: process.env.NEAR_TELEMETRY_DATABASE_NAME,
-    username: process.env.NEAR_TELEMETRY_DATABASE_USERNAME,
-    password: process.env.NEAR_TELEMETRY_DATABASE_PASSWORD,
+    host:
+      process.env.NEAR_READ_ONLY_INDEXER_DATABASE_HOST ||
+      process.env.NEAR_INDEXER_DATABASE_HOST,
+    database:
+      process.env.NEAR_READ_ONLY_INDEXER_DATABASE_NAME ||
+      process.env.NEAR_INDEXER_DATABASE_NAME,
+    username:
+      process.env.NEAR_READ_ONLY_INDEXER_DATABASE_USERNAME ||
+      process.env.NEAR_INDEXER_DATABASE_USERNAME,
+    password:
+      process.env.NEAR_READ_ONLY_INDEXER_DATABASE_PASSWORD ||
+      process.env.NEAR_INDEXER_DATABASE_PASSWORD,
+    logging: false,
   },
-  indexerDatabase: {
+  readOnlyAnalyticsDatabase: {
     dialect: "postgres",
-    host: process.env.NEAR_INDEXER_DATABASE_HOST,
-    database: process.env.NEAR_INDEXER_DATABASE_NAME,
-    username: process.env.NEAR_INDEXER_DATABASE_USERNAME,
-    password: process.env.NEAR_INDEXER_DATABASE_PASSWORD,
+    host:
+      process.env.NEAR_READ_ONLY_ANALYTICS_DATABASE_HOST ||
+      process.env.NEAR_ANALYTICS_DATABASE_HOST,
+    database:
+      process.env.NEAR_READ_ONLY_ANALYTICS_DATABASE_NAME ||
+      process.env.NEAR_ANALYTICS_DATABASE_NAME,
+    username:
+      process.env.NEAR_READ_ONLY_ANALYTICS_DATABASE_USERNAME ||
+      process.env.NEAR_ANALYTICS_DATABASE_USERNAME,
+    password:
+      process.env.NEAR_READ_ONLY_ANALYTICS_DATABASE_PASSWORD ||
+      process.env.NEAR_ANALYTICS_DATABASE_PASSWORD,
+    logging: false,
   },
-  analyticsDatabase: {
+  readOnlyTelemetryDatabase: {
     dialect: "postgres",
-    host: process.env.NEAR_ANALYTICS_DATABASE_HOST,
-    database: process.env.NEAR_ANALYTICS_DATABASE_NAME,
-    username: process.env.NEAR_ANALYTICS_DATABASE_USERNAME,
-    password: process.env.NEAR_ANALYTICS_DATABASE_PASSWORD,
+    host:
+      process.env.NEAR_READ_ONLY_TELEMETRY_DATABASE_HOST ||
+      process.env.NEAR_TELEMETRY_DATABASE_HOST,
+    database:
+      process.env.NEAR_READ_ONLY_TELEMETRY_DATABASE_NAME ||
+      process.env.NEAR_TELEMETRY_DATABASE_NAME,
+    username:
+      process.env.NEAR_READ_ONLY_TELEMETRY_DATABASE_USERNAME ||
+      process.env.NEAR_TELEMETRY_DATABASE_USERNAME,
+    password:
+      process.env.NEAR_READ_ONLY_TELEMETRY_DATABASE_PASSWORD ||
+      process.env.NEAR_TELEMETRY_DATABASE_PASSWORD,
+    logging: false,
+  },
+  writeOnlyTelemetryDatabase: {
+    dialect: "postgres",
+    host:
+      process.env.NEAR_WRITE_ONLY_TELEMETRY_DATABASE_HOST ||
+      process.env.NEAR_TELEMETRY_DATABASE_HOST,
+    database:
+      process.env.NEAR_WRITE_ONLY_TELEMETRY_DATABASE_NAME ||
+      process.env.NEAR_TELEMETRY_DATABASE_NAME,
+    username:
+      process.env.NEAR_WRITE_ONLY_TELEMETRY_DATABASE_USERNAME ||
+      process.env.NEAR_TELEMETRY_DATABASE_USERNAME,
+    password:
+      process.env.NEAR_WRITE_ONLY_TELEMETRY_DATABASE_PASSWORD ||
+      process.env.NEAR_TELEMETRY_DATABASE_PASSWORD,
+    logging: false,
+    pool: { min: 0, max: 15 },
   },
 };

--- a/backend/config/database.js
+++ b/backend/config/database.js
@@ -1,3 +1,5 @@
+// NOTE: The fallback names of the env variables are here for backward compatibility only.
+// Prefer using the explicit READ_ONLY_*/WRITE_ONLY_* configuration options.
 module.exports = {
   readOnlyIndexerDatabase: {
     dialect: "postgres",

--- a/backend/config/env-indexer-mainnet
+++ b/backend/config/env-indexer-mainnet
@@ -3,23 +3,28 @@ export WAMP_NEAR_NETWORK_NAME=mainnet
 # NOTE: These are public services that operate under fair use conditions. Do not abuse them.
 
 # Learn more about running your own archival node here: https://docs.near.org/docs/roles/integrator/exchange-integration#running-an-archival-node
-export NEAR_RPC_URL=https://archival-rpc.mainnet.near.org
+export NEAR_ARCHIVAL_RPC_URL=https://archival-rpc.mainnet.near.org
 
 # Learn more about running your own Indexer for Explorer here: https://github.com/near/near-indexer-for-explorer
-export NEAR_INDEXER_DATABASE_HOST=104.199.89.51
-export NEAR_INDEXER_DATABASE_NAME=mainnet_explorer
-export NEAR_INDEXER_DATABASE_USERNAME=public_readonly
-export NEAR_INDEXER_DATABASE_PASSWORD=nearprotocol
+export NEAR_READ_ONLY_INDEXER_DATABASE_HOST=mainnet.db.explorer.indexer.near.dev
+export NEAR_READ_ONLY_INDEXER_DATABASE_NAME=mainnet_explorer
+export NEAR_READ_ONLY_INDEXER_DATABASE_USERNAME=public_readonly
+export NEAR_READ_ONLY_INDEXER_DATABASE_PASSWORD=nearprotocol
 
-export NEAR_TELEMETRY_DATABASE_HOST=34.78.19.198
-export NEAR_TELEMETRY_DATABASE_NAME=telemetry_mainnet
-export NEAR_TELEMETRY_DATABASE_USERNAME=public_readonly
-export NEAR_TELEMETRY_DATABASE_PASSWORD=nearprotocol
+export NEAR_READ_ONLY_ANALYTICS_DATABASE_HOST=34.78.19.198
+export NEAR_READ_ONLY_ANALYTICS_DATABASE_NAME=indexer_analytics_mainnet
+export NEAR_READ_ONLY_ANALYTICS_DATABASE_USERNAME=public_readonly
+export NEAR_READ_ONLY_ANALYTICS_DATABASE_PASSWORD=nearprotocol
 
-export NEAR_ANALYTICS_DATABASE_HOST=34.78.19.198
-export NEAR_ANALYTICS_DATABASE_NAME=indexer_analytics_mainnet
-export NEAR_ANALYTICS_DATABASE_USERNAME=public_readonly
-export NEAR_ANALYTICS_DATABASE_PASSWORD=nearprotocol
+export NEAR_READ_ONLY_TELEMETRY_DATABASE_HOST=34.78.19.198
+export NEAR_READ_ONLY_TELEMETRY_DATABASE_NAME=telemetry_mainnet
+export NEAR_READ_ONLY_TELEMETRY_DATABASE_USERNAME=public_readonly
+export NEAR_READ_ONLY_TELEMETRY_DATABASE_PASSWORD=nearprotocol
+
+export NEAR_WRITE_ONLY_TELEMETRY_DATABASE_HOST=
+export NEAR_WRITE_ONLY_TELEMETRY_DATABASE_NAME=telemetry_mainnet
+export NEAR_WRITE_ONLY_TELEMETRY_DATABASE_USERNAME=
+export NEAR_WRITE_ONLY_TELEMETRY_DATABASE_PASSWORD=
 
 # To override the above values during local development, create the file with
 # `-local` suffix and export all the necessary environment variables there

--- a/backend/config/env-indexer-testnet
+++ b/backend/config/env-indexer-testnet
@@ -3,23 +3,28 @@ export WAMP_NEAR_NETWORK_NAME=testnet
 # NOTE: These are public services that operate under fair use conditions. Do not abuse them.
 
 # Learn more about running your own archival node here: https://docs.near.org/docs/roles/integrator/exchange-integration#running-an-archival-node
-export NEAR_RPC_URL=https://archival-rpc.testnet.near.org
+export NEAR_ARCHIVAL_RPC_URL=https://archival-rpc.testnet.near.org
 
 # Learn more about running your own Indexer for Explorer here: https://github.com/near/near-indexer-for-explorer
-export NEAR_INDEXER_DATABASE_HOST=35.184.214.98
-export NEAR_INDEXER_DATABASE_NAME=testnet_explorer
-export NEAR_INDEXER_DATABASE_USERNAME=public_readonly
-export NEAR_INDEXER_DATABASE_PASSWORD=nearprotocol
+export NEAR_READ_ONLY_INDEXER_DATABASE_HOST=testnet.db.explorer.indexer.near.dev
+export NEAR_READ_ONLY_INDEXER_DATABASE_NAME=testnet_explorer
+export NEAR_READ_ONLY_INDEXER_DATABASE_USERNAME=public_readonly
+export NEAR_READ_ONLY_INDEXER_DATABASE_PASSWORD=nearprotocol
 
-export NEAR_TELEMETRY_DATABASE_HOST=35.241.197.241
-export NEAR_TELEMETRY_DATABASE_NAME=telemetry_testnet
-export NEAR_TELEMETRY_DATABASE_USERNAME=public_readonly
-export NEAR_TELEMETRY_DATABASE_PASSWORD=nearprotocol
+export NEAR_READ_ONLY_ANALYTICS_DATABASE_HOST=35.241.197.241
+export NEAR_READ_ONLY_ANALYTICS_DATABASE_NAME=indexer_analytics_testnet
+export NEAR_READ_ONLY_ANALYTICS_DATABASE_USERNAME=public_readonly
+export NEAR_READ_ONLY_ANALYTICS_DATABASE_PASSWORD=nearprotocol
 
-export NEAR_ANALYTICS_DATABASE_HOST=35.241.197.241
-export NEAR_ANALYTICS_DATABASE_NAME=indexer_analytics_testnet
-export NEAR_ANALYTICS_DATABASE_USERNAME=public_readonly
-export NEAR_ANALYTICS_DATABASE_PASSWORD=nearprotocol
+export NEAR_READ_ONLY_TELEMETRY_DATABASE_HOST=35.241.197.241
+export NEAR_READ_ONLY_TELEMETRY_DATABASE_NAME=telemetry_testnet
+export NEAR_READ_ONLY_TELEMETRY_DATABASE_USERNAME=public_readonly
+export NEAR_READ_ONLY_TELEMETRY_DATABASE_PASSWORD=nearprotocol
+
+export NEAR_WRITE_ONLY_TELEMETRY_DATABASE_HOST=
+export NEAR_WRITE_ONLY_TELEMETRY_DATABASE_NAME=telemetry_testnet
+export NEAR_WRITE_ONLY_TELEMETRY_DATABASE_USERNAME=
+export NEAR_WRITE_ONLY_TELEMETRY_DATABASE_PASSWORD=
 
 # To override the above values during local development, create the file with
 # `-local` suffix and export all the necessary environment variables there

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -5,81 +5,69 @@ const path = require("path");
 const Sequelize = require("sequelize");
 const basename = path.basename(__filename);
 const dbConfig = require(__dirname + "/../config/database");
-const db = {};
 
-const sequelizeTelemetryBackend = new Sequelize(
-  dbConfig.telemetryDatabase.database,
-  dbConfig.telemetryDatabase.username,
-  dbConfig.telemetryDatabase.password,
-  {
-    ...dbConfig.telemetryDatabase,
-    logging: false,
-  }
-);
+let _exports = {};
+
+const sequelizeTelemetryBackend = dbConfig.writeOnlyTelemetryDatabase.host
+  ? new Sequelize(
+      dbConfig.writeOnlyTelemetryDatabase.database,
+      dbConfig.writeOnlyTelemetryDatabase.username,
+      dbConfig.writeOnlyTelemetryDatabase.password,
+      dbConfig.writeOnlyTelemetryDatabase
+    )
+  : null;
 
 const sequelizeTelemetryBackendReadOnly = new Sequelize(
-  dbConfig.telemetryDatabase.database,
-  dbConfig.telemetryDatabase.username,
-  dbConfig.telemetryDatabase.password,
-  {
-    ...dbConfig.telemetryDatabase,
-    dialectOptions: {
-      ...dbConfig.telemetryDatabase.dialectOptions,
-      // Set SQLITE_OPEN_READONLY mode. Read more:
-      // * http://www.sqlite.org/c3ref/open.html
-      // * http://www.sqlite.org/c3ref/c_open_autoproxy.html
-      mode: 1,
-    },
-    logging: false,
-  }
+  dbConfig.readOnlyTelemetryDatabase.database,
+  dbConfig.readOnlyTelemetryDatabase.username,
+  dbConfig.readOnlyTelemetryDatabase.password,
+  dbConfig.readOnlyTelemetryDatabase
 );
 
 const sequelizeIndexerBackendReadOnly = new Sequelize(
-  dbConfig.indexerDatabase.database,
-  dbConfig.indexerDatabase.username,
-  dbConfig.indexerDatabase.password,
-  {
-    host: dbConfig.indexerDatabase.host,
-    dialect: dbConfig.indexerDatabase.dialect,
-  }
+  dbConfig.readOnlyIndexerDatabase.database,
+  dbConfig.readOnlyIndexerDatabase.username,
+  dbConfig.readOnlyIndexerDatabase.password,
+  dbConfig.readOnlyIndexerDatabase
 );
 
 const sequelizeAnalyticsBackendReadOnly = new Sequelize(
-  dbConfig.analyticsDatabase.database,
-  dbConfig.analyticsDatabase.username,
-  dbConfig.analyticsDatabase.password,
-  {
-    host: dbConfig.analyticsDatabase.host,
-    dialect: dbConfig.analyticsDatabase.dialect,
-  }
+  dbConfig.readOnlyAnalyticsDatabase.database,
+  dbConfig.readOnlyAnalyticsDatabase.username,
+  dbConfig.readOnlyAnalyticsDatabase.password,
+  dbConfig.readOnlyAnalyticsDatabase
 );
 
-fs.readdirSync(__dirname)
-  .filter((file) => {
-    return (
-      file.indexOf(".") !== 0 && file !== basename && file.slice(-3) === ".js"
-    );
-  })
-  .forEach((file) => {
-    // since sequelize ^v6 we should use this structure
-    // https://stackoverflow.com/questions/62917111/sequelize-import-is-not-a-function
-    const model = require(path.join(__dirname, file))(
-      sequelizeTelemetryBackend,
-      Sequelize.DataTypes
-    );
-    db[model.name] = model;
-  });
+if (sequelizeTelemetryBackend) {
+  fs.readdirSync(__dirname)
+    .filter((file) => {
+      return (
+        file.indexOf(".") !== 0 && file !== basename && file.slice(-3) === ".js"
+      );
+    })
+    .forEach((file) => {
+      // since sequelize ^v6 we should use this structure
+      // https://stackoverflow.com/questions/62917111/sequelize-import-is-not-a-function
+      const model = require(path.join(__dirname, file))(
+        sequelizeTelemetryBackend,
+        Sequelize.DataTypes
+      );
+      _exports[model.name] = model;
+    });
+}
 
-Object.keys(db).forEach((modelName) => {
-  if (db[modelName].associate) {
-    db[modelName].associate(db);
+Object.keys(_exports).forEach((modelName) => {
+  if (_exports[modelName].associate) {
+    _exports[modelName].associate(_exports);
   }
 });
 
-db.sequelizeTelemetryBackend = sequelizeTelemetryBackend;
-db.sequelizeTelemetryBackendReadOnly = sequelizeTelemetryBackendReadOnly;
-db.sequelizeIndexerBackendReadOnly = sequelizeIndexerBackendReadOnly;
-db.sequelizeAnalyticsBackendReadOnly = sequelizeAnalyticsBackendReadOnly;
-db.Sequelize = Sequelize;
+if (sequelizeTelemetryBackend) {
+  _exports.sequelizeTelemetryBackend = sequelizeTelemetryBackend;
+}
+_exports.sequelizeTelemetryBackendReadOnly = sequelizeTelemetryBackendReadOnly;
+_exports.sequelizeIndexerBackendReadOnly = sequelizeIndexerBackendReadOnly;
+_exports.sequelizeAnalyticsBackendReadOnly = sequelizeAnalyticsBackendReadOnly;
+_exports.Sequelize = Sequelize;
 
-module.exports = db;
+module.exports = _exports;

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,9 +5,6 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "env NODE_ENV=production node src/index.js",
-    "start:betanet": "env NEAR_RPC_URL=https://rpc.betanet.near.org WAMP_NEAR_NETWORK_NAME=betanet NEAR_GENESIS_RECORDS_URL=https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore-deploy/betanet/genesis.json npm run start",
-    "start:testnet": "env NEAR_RPC_URL=https://rpc.testnet.near.org WAMP_NEAR_NETWORK_NAME=testnet NEAR_GENESIS_RECORDS_URL=https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore-deploy/testnet/genesis.json npm run start",
-    "start:mainnet": "env NEAR_RPC_URL=https://rpc.mainnet.near.org WAMP_NEAR_NETWORK_NAME=mainnet NEAR_GENESIS_RECORDS_URL=https://raw.githubusercontent.com/nearprotocol/nearcore/master/neard/res/mainnet_genesis.json npm run start",
     "start:with-indexer": "env NEAR_IS_INDEXER_BACKEND_ENABLED=true npm run start",
     "start:testnet-with-indexer": "cd ./config && . ./env-indexer-testnet && cd .. && npm run start:with-indexer",
     "start:mainnet-with-indexer": "cd ./config && . ./env-indexer-mainnet && cd .. && npm run start:with-indexer"

--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -1,4 +1,5 @@
-exports.nearRpcUrl = process.env.NEAR_RPC_URL || "http://localhost:3030";
+exports.nearArchivalRpcUrl =
+  process.env.NEAR_ARCHIVAL_RPC_URL || "http://localhost:3030";
 
 exports.debugLogs =
   (process.env.NEAR_DEBUG_LOGS || "TRUE").toUpperCase() !== "FALSE";

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -140,13 +140,8 @@ function startStatsAggregation() {
 async function main() {
   console.log("Starting Explorer backend...");
 
-  try {
+  if (models.sequelizeTelemetryBackend) {
     await models.sequelizeTelemetryBackend.sync();
-  } catch (error) {
-    console.warn(
-      "Initialization of Telemetry database failed, but Explorer backend can operate without it. Explorer backend won't be able to handle telemetry reports. More details about the error:",
-      error
-    );
   }
 
   const wamp = setupWamp();

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -140,6 +140,8 @@ function startStatsAggregation() {
 async function main() {
   console.log("Starting Explorer backend...");
 
+  // Skip initializing Telemetry database if the backend is not configured to
+  // save telemety data (it is absolutely fine for local development)
   if (models.sequelizeTelemetryBackend) {
     await models.sequelizeTelemetryBackend.sync();
   }

--- a/backend/src/near.js
+++ b/backend/src/near.js
@@ -2,11 +2,11 @@ const nearApi = require("near-api-js");
 
 const BN = require("bn.js");
 
-const { nearRpcUrl } = require("./config");
+const { nearArchivalRpcUrl } = require("./config");
 const { queryNodeValidators } = require("./db-utils");
 
 const nearRpc = new nearApi.providers.JsonRpcProvider({
-  url: nearRpcUrl,
+  url: nearArchivalRpcUrl,
 });
 
 let seatPrice = null;


### PR DESCRIPTION
@shelegdmitriy @luixo I don't expect you do extensive review here, but I still want to mention you in the PR, so you are aware of the change

Main objectives:

* I wanted to add a quick fix for telemetry database connection configuration, so it can use up to 15 connections (otherwise we cannot store 50+ telemetry requests per second of constant load)
* Along the way, I wanted to decouple read vs write credentials to telemetry database, so we can actually use the read replica for the read queries
* I decided to make the other configuration options more explicit as to what type of access they are going to be used (received a feedback from people that initially tried to use non-archival RPC server with Explorer and failed to fetch the details about transactions that were included more than 5 epoch [~2.5 days] ago)