### PR TITLE
CSS in Jest tests

### DIFF
--- a/frontend/.babelrc
+++ b/frontend/.babelrc
@@ -1,4 +1,18 @@
 {
-  "plugins": ["inline-react-svg"],
-  "presets": ["next/babel"]
+    "plugins": ["inline-react-svg"],
+    "presets": ["next/babel"],
+    "env": {
+        "test": {
+            "presets": [
+                [
+                    "next/babel",
+                    {
+                        "styled-jsx": {
+                            "babel-test": true
+                        }
+                    }
+                ]
+            ]
+        }
+    }
 }

--- a/frontend/src/components/accounts/__tests__/__snapshots__/AccountDetails.test.js.snap
+++ b/frontend/src/components/accounts/__tests__/__snapshots__/AccountDetails.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<AccountDetails /> renders with account created at genesis (legacy) 1`] = `
 <div
-  className="jsx-3866967115 account-info-container"
+  className="account-info-container"
 >
   <div
     className="row no-gutters"
@@ -23,36 +23,48 @@ exports[`<AccountDetails /> renders with account created at genesis (legacy) 1`]
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-m-transaction.svg"
               />
               Transactions
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
               className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
             >
-              <span
-                className="jsx-3866967115"
-              >
+              <span>
                 ↑
                 <div
                   className="spinner-border text-secondary"
                 />
               </span>
                 
-              <span
-                className="jsx-3866967115"
-              >
+              <span>
                 ↓
                 <div
                   className="spinner-border text-secondary"
@@ -61,6 +73,53 @@ exports[`<AccountDetails /> renders with account created at genesis (legacy) 1`]
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -79,19 +138,35 @@ exports[`<AccountDetails /> renders with account created at genesis (legacy) 1`]
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-storage.svg"
               />
               Storage Used
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -108,6 +183,53 @@ exports[`<AccountDetails /> renders with account created at genesis (legacy) 1`]
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -126,19 +248,35 @@ exports[`<AccountDetails /> renders with account created at genesis (legacy) 1`]
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-m-transaction.svg"
               />
               Lockup Account
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -148,7 +286,7 @@ exports[`<AccountDetails /> renders with account created at genesis (legacy) 1`]
                 onClick={[Function]}
               >
                 <a
-                  className="jsx-3150401870 account-link"
+                  className="account-link"
                   href="/accounts/gjturigjgkjnfidsjffjsa.lockup.near"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
@@ -156,9 +294,63 @@ exports[`<AccountDetails /> renders with account created at genesis (legacy) 1`]
                   gjtur…ockup.near
                 </a>
               </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
   </div>
@@ -182,14 +374,30 @@ exports[`<AccountDetails /> renders with account created at genesis (legacy) 1`]
             >
               Ⓝ Native Account Balance
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -208,6 +416,53 @@ exports[`<AccountDetails /> renders with account created at genesis (legacy) 1`]
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -227,14 +482,30 @@ exports[`<AccountDetails /> renders with account created at genesis (legacy) 1`]
             >
               Ⓝ Validator Stake
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -253,6 +524,53 @@ exports[`<AccountDetails /> renders with account created at genesis (legacy) 1`]
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -272,35 +590,104 @@ exports[`<AccountDetails /> renders with account created at genesis (legacy) 1`]
             >
               Ⓝ Balance Profile
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
               className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
             >
               <span
-                className="jsx-3150401870"
                 onClick={[Function]}
               >
                 <a
-                  className="jsx-3150401870 account-link"
+                  className="account-link"
                   href="http://wallet/profile/megan.near"
                   rel="noopener"
                   target="_blank"
                 >
                   megan.near on Wallet
                 </a>
+                <style>
+                  
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                </style>
               </span>
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
   </div>
@@ -324,14 +711,30 @@ exports[`<AccountDetails /> renders with account created at genesis (legacy) 1`]
             >
               Created At
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -341,15 +744,87 @@ exports[`<AccountDetails /> renders with account created at genesis (legacy) 1`]
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
   </div>
+  <style>
+    
+              .account-info-container {
+                border: solid 4px #e6e6e6;
+                border-radius: 4px;
+              }
+
+              .account-info-container &gt; .row:first-of-type .card-cell-text {
+                font-size: 24px;
+              }
+
+              .account-info-container &gt; .row {
+                border-bottom: 2px solid #e6e6e6;
+              }
+
+              .account-card-back {
+                background-color: #f8f8f8;
+              }
+
+              .transaction-link-icon {
+                width: 15px;
+                margin: 0 0 12px 12px;
+              }
+            
+  </style>
 </div>
 `;
 
 exports[`<AccountDetails /> renders with account created at genesis 1`] = `
 <div
-  className="jsx-3866967115 account-info-container"
+  className="account-info-container"
 >
   <div
     className="row no-gutters"
@@ -370,36 +845,48 @@ exports[`<AccountDetails /> renders with account created at genesis 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-m-transaction.svg"
               />
               Transactions
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
               className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
             >
-              <span
-                className="jsx-3866967115"
-              >
+              <span>
                 ↑
                 <div
                   className="spinner-border text-secondary"
                 />
               </span>
                 
-              <span
-                className="jsx-3866967115"
-              >
+              <span>
                 ↓
                 <div
                   className="spinner-border text-secondary"
@@ -408,6 +895,53 @@ exports[`<AccountDetails /> renders with account created at genesis 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -426,19 +960,35 @@ exports[`<AccountDetails /> renders with account created at genesis 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-storage.svg"
               />
               Storage Used
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -455,6 +1005,53 @@ exports[`<AccountDetails /> renders with account created at genesis 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -473,19 +1070,35 @@ exports[`<AccountDetails /> renders with account created at genesis 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-m-transaction.svg"
               />
               Lockup Account
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -495,7 +1108,7 @@ exports[`<AccountDetails /> renders with account created at genesis 1`] = `
                 onClick={[Function]}
               >
                 <a
-                  className="jsx-3150401870 account-link"
+                  className="account-link"
                   href="/accounts/gjturigjgkjnfidsjffjsa.lockup.near"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
@@ -503,9 +1116,63 @@ exports[`<AccountDetails /> renders with account created at genesis 1`] = `
                   gjtur…ockup.near
                 </a>
               </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
   </div>
@@ -529,14 +1196,30 @@ exports[`<AccountDetails /> renders with account created at genesis 1`] = `
             >
               Ⓝ Native Account Balance
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -555,6 +1238,53 @@ exports[`<AccountDetails /> renders with account created at genesis 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -574,14 +1304,30 @@ exports[`<AccountDetails /> renders with account created at genesis 1`] = `
             >
               Ⓝ Validator Stake
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -600,6 +1346,53 @@ exports[`<AccountDetails /> renders with account created at genesis 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -619,35 +1412,104 @@ exports[`<AccountDetails /> renders with account created at genesis 1`] = `
             >
               Ⓝ Balance Profile
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
               className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
             >
               <span
-                className="jsx-3150401870"
                 onClick={[Function]}
               >
                 <a
-                  className="jsx-3150401870 account-link"
+                  className="account-link"
                   href="http://wallet/profile/megan.near"
                   rel="noopener"
                   target="_blank"
                 >
                   megan.near on Wallet
                 </a>
+                <style>
+                  
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                </style>
               </span>
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
   </div>
@@ -671,14 +1533,30 @@ exports[`<AccountDetails /> renders with account created at genesis 1`] = `
             >
               Created At
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -688,15 +1566,87 @@ exports[`<AccountDetails /> renders with account created at genesis 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
   </div>
+  <style>
+    
+              .account-info-container {
+                border: solid 4px #e6e6e6;
+                border-radius: 4px;
+              }
+
+              .account-info-container &gt; .row:first-of-type .card-cell-text {
+                font-size: 24px;
+              }
+
+              .account-info-container &gt; .row {
+                border-bottom: 2px solid #e6e6e6;
+              }
+
+              .account-card-back {
+                background-color: #f8f8f8;
+              }
+
+              .transaction-link-icon {
+                width: 15px;
+                margin: 0 0 12px 12px;
+              }
+            
+  </style>
 </div>
 `;
 
 exports[`<AccountDetails /> renders with account deletion at 1`] = `
 <div
-  className="jsx-3866967115 account-info-container"
+  className="account-info-container"
 >
   <div
     className="row no-gutters"
@@ -717,36 +1667,48 @@ exports[`<AccountDetails /> renders with account deletion at 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-m-transaction.svg"
               />
               Transactions
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
               className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
             >
-              <span
-                className="jsx-3866967115"
-              >
+              <span>
                 ↑
                 <div
                   className="spinner-border text-secondary"
                 />
               </span>
                 
-              <span
-                className="jsx-3866967115"
-              >
+              <span>
                 ↓
                 <div
                   className="spinner-border text-secondary"
@@ -755,6 +1717,53 @@ exports[`<AccountDetails /> renders with account deletion at 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -773,19 +1782,35 @@ exports[`<AccountDetails /> renders with account deletion at 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-storage.svg"
               />
               Storage Used
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -802,6 +1827,53 @@ exports[`<AccountDetails /> renders with account deletion at 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -820,19 +1892,35 @@ exports[`<AccountDetails /> renders with account deletion at 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-m-transaction.svg"
               />
               Lockup Account
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -842,7 +1930,7 @@ exports[`<AccountDetails /> renders with account deletion at 1`] = `
                 onClick={[Function]}
               >
                 <a
-                  className="jsx-3150401870 account-link"
+                  className="account-link"
                   href="/accounts/gjturigjgkjnfidsjffjsa.lockup.near"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
@@ -850,9 +1938,63 @@ exports[`<AccountDetails /> renders with account deletion at 1`] = `
                   gjtur…ockup.near
                 </a>
               </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
   </div>
@@ -876,14 +2018,30 @@ exports[`<AccountDetails /> renders with account deletion at 1`] = `
             >
               Ⓝ Native Account Balance
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -902,6 +2060,53 @@ exports[`<AccountDetails /> renders with account deletion at 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -921,14 +2126,30 @@ exports[`<AccountDetails /> renders with account deletion at 1`] = `
             >
               Ⓝ Validator Stake
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -947,6 +2168,53 @@ exports[`<AccountDetails /> renders with account deletion at 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -966,35 +2234,104 @@ exports[`<AccountDetails /> renders with account deletion at 1`] = `
             >
               Ⓝ Balance Profile
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
               className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
             >
               <span
-                className="jsx-3150401870"
                 onClick={[Function]}
               >
                 <a
-                  className="jsx-3150401870 account-link"
+                  className="account-link"
                   href="http://wallet/profile/megan.near"
                   rel="noopener"
                   target="_blank"
                 >
                   megan.near on Wallet
                 </a>
+                <style>
+                  
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                </style>
               </span>
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
   </div>
@@ -1018,14 +2355,30 @@ exports[`<AccountDetails /> renders with account deletion at 1`] = `
             >
               Deleted At
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -1035,6 +2388,53 @@ exports[`<AccountDetails /> renders with account deletion at 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -1054,14 +2454,30 @@ exports[`<AccountDetails /> renders with account deletion at 1`] = `
             >
               Deleted By Transaction
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -1078,7 +2494,7 @@ exports[`<AccountDetails /> renders with account deletion at 1`] = `
                   onMouseEnter={[Function]}
                 >
                   <img
-                    className="jsx-3866967115 transaction-link-icon"
+                    className="transaction-link-icon"
                     src="/static/images/icon-m-copy.svg"
                   />
                 </a>
@@ -1086,15 +2502,87 @@ exports[`<AccountDetails /> renders with account deletion at 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
   </div>
+  <style>
+    
+              .account-info-container {
+                border: solid 4px #e6e6e6;
+                border-radius: 4px;
+              }
+
+              .account-info-container &gt; .row:first-of-type .card-cell-text {
+                font-size: 24px;
+              }
+
+              .account-info-container &gt; .row {
+                border-bottom: 2px solid #e6e6e6;
+              }
+
+              .account-card-back {
+                background-color: #f8f8f8;
+              }
+
+              .transaction-link-icon {
+                width: 15px;
+                margin: 0 0 12px 12px;
+              }
+            
+  </style>
 </div>
 `;
 
 exports[`<AccountDetails /> renders with lockup account 1`] = `
 <div
-  className="jsx-3866967115 account-info-container"
+  className="account-info-container"
 >
   <div
     className="row no-gutters"
@@ -1115,36 +2603,48 @@ exports[`<AccountDetails /> renders with lockup account 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-m-transaction.svg"
               />
               Transactions
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
               className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
             >
-              <span
-                className="jsx-3866967115"
-              >
+              <span>
                 ↑
                 <div
                   className="spinner-border text-secondary"
                 />
               </span>
                 
-              <span
-                className="jsx-3866967115"
-              >
+              <span>
                 ↓
                 <div
                   className="spinner-border text-secondary"
@@ -1153,6 +2653,53 @@ exports[`<AccountDetails /> renders with lockup account 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -1171,19 +2718,35 @@ exports[`<AccountDetails /> renders with lockup account 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-storage.svg"
               />
               Storage Used
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -1200,6 +2763,53 @@ exports[`<AccountDetails /> renders with lockup account 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -1218,19 +2828,35 @@ exports[`<AccountDetails /> renders with lockup account 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-m-transaction.svg"
               />
               Lockup Account
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -1240,7 +2866,7 @@ exports[`<AccountDetails /> renders with lockup account 1`] = `
                 onClick={[Function]}
               >
                 <a
-                  className="jsx-3150401870 account-link"
+                  className="account-link"
                   href="/accounts/gjturigjgkjnfidsjffjsa.lockup.near"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
@@ -1248,9 +2874,63 @@ exports[`<AccountDetails /> renders with lockup account 1`] = `
                   gjtur…ockup.near
                 </a>
               </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
   </div>
@@ -1274,14 +2954,30 @@ exports[`<AccountDetails /> renders with lockup account 1`] = `
             >
               Ⓝ Native Account Balance
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -1300,6 +2996,53 @@ exports[`<AccountDetails /> renders with lockup account 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -1319,14 +3062,30 @@ exports[`<AccountDetails /> renders with lockup account 1`] = `
             >
               Ⓝ Validator Stake
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -1345,6 +3104,53 @@ exports[`<AccountDetails /> renders with lockup account 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -1364,35 +3170,104 @@ exports[`<AccountDetails /> renders with lockup account 1`] = `
             >
               Ⓝ Balance Profile
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
               className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
             >
               <span
-                className="jsx-3150401870"
                 onClick={[Function]}
               >
                 <a
-                  className="jsx-3150401870 account-link"
+                  className="account-link"
                   href="http://wallet/profile/megan.near"
                   rel="noopener"
                   target="_blank"
                 >
                   megan.near on Wallet
                 </a>
+                <style>
+                  
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                </style>
               </span>
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
   </div>
@@ -1416,14 +3291,30 @@ exports[`<AccountDetails /> renders with lockup account 1`] = `
             >
               Created At
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -1433,6 +3324,53 @@ exports[`<AccountDetails /> renders with lockup account 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -1452,14 +3390,30 @@ exports[`<AccountDetails /> renders with lockup account 1`] = `
             >
               Created By Transaction
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -1476,7 +3430,7 @@ exports[`<AccountDetails /> renders with lockup account 1`] = `
                   onMouseEnter={[Function]}
                 >
                   <img
-                    className="jsx-3866967115 transaction-link-icon"
+                    className="transaction-link-icon"
                     src="/static/images/icon-m-copy.svg"
                   />
                 </a>
@@ -1484,15 +3438,87 @@ exports[`<AccountDetails /> renders with lockup account 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
   </div>
+  <style>
+    
+              .account-info-container {
+                border: solid 4px #e6e6e6;
+                border-radius: 4px;
+              }
+
+              .account-info-container &gt; .row:first-of-type .card-cell-text {
+                font-size: 24px;
+              }
+
+              .account-info-container &gt; .row {
+                border-bottom: 2px solid #e6e6e6;
+              }
+
+              .account-card-back {
+                background-color: #f8f8f8;
+              }
+
+              .transaction-link-icon {
+                width: 15px;
+                margin: 0 0 12px 12px;
+              }
+            
+  </style>
 </div>
 `;
 
 exports[`<AccountDetails /> renders without lockup account 1`] = `
 <div
-  className="jsx-3866967115 account-info-container"
+  className="account-info-container"
 >
   <div
     className="row no-gutters"
@@ -1513,36 +3539,48 @@ exports[`<AccountDetails /> renders without lockup account 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-m-transaction.svg"
               />
               Transactions
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
               className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
             >
-              <span
-                className="jsx-3866967115"
-              >
+              <span>
                 ↑
                 <div
                   className="spinner-border text-secondary"
                 />
               </span>
                 
-              <span
-                className="jsx-3866967115"
-              >
+              <span>
                 ↓
                 <div
                   className="spinner-border text-secondary"
@@ -1551,6 +3589,53 @@ exports[`<AccountDetails /> renders without lockup account 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -1569,19 +3654,35 @@ exports[`<AccountDetails /> renders without lockup account 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-storage.svg"
               />
               Storage Used
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -1598,6 +3699,53 @@ exports[`<AccountDetails /> renders without lockup account 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
   </div>
@@ -1621,14 +3769,30 @@ exports[`<AccountDetails /> renders without lockup account 1`] = `
             >
               Ⓝ Native Account Balance
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -1647,6 +3811,53 @@ exports[`<AccountDetails /> renders without lockup account 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -1666,14 +3877,30 @@ exports[`<AccountDetails /> renders without lockup account 1`] = `
             >
               Ⓝ Validator Stake
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -1692,6 +3919,53 @@ exports[`<AccountDetails /> renders without lockup account 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -1711,35 +3985,104 @@ exports[`<AccountDetails /> renders without lockup account 1`] = `
             >
               Ⓝ Balance Profile
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
               className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
             >
               <span
-                className="jsx-3150401870"
                 onClick={[Function]}
               >
                 <a
-                  className="jsx-3150401870 account-link"
+                  className="account-link"
                   href="http://wallet/profile/near.near"
                   rel="noopener"
                   target="_blank"
                 >
                   near.near on Wallet
                 </a>
+                <style>
+                  
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                </style>
               </span>
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
   </div>
@@ -1763,14 +4106,30 @@ exports[`<AccountDetails /> renders without lockup account 1`] = `
             >
               Created At
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -1780,6 +4139,53 @@ exports[`<AccountDetails /> renders without lockup account 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -1799,14 +4205,30 @@ exports[`<AccountDetails /> renders without lockup account 1`] = `
             >
               Created By Transaction
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -1823,7 +4245,7 @@ exports[`<AccountDetails /> renders without lockup account 1`] = `
                   onMouseEnter={[Function]}
                 >
                   <img
-                    className="jsx-3866967115 transaction-link-icon"
+                    className="transaction-link-icon"
                     src="/static/images/icon-m-copy.svg"
                   />
                 </a>
@@ -1831,8 +4253,80 @@ exports[`<AccountDetails /> renders without lockup account 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
   </div>
+  <style>
+    
+              .account-info-container {
+                border: solid 4px #e6e6e6;
+                border-radius: 4px;
+              }
+
+              .account-info-container &gt; .row:first-of-type .card-cell-text {
+                font-size: 24px;
+              }
+
+              .account-info-container &gt; .row {
+                border-bottom: 2px solid #e6e6e6;
+              }
+
+              .account-card-back {
+                background-color: #f8f8f8;
+              }
+
+              .transaction-link-icon {
+                width: 15px;
+                margin: 0 0 12px 12px;
+              }
+            
+  </style>
 </div>
 `;

--- a/frontend/src/components/accounts/__tests__/__snapshots__/AccountRow.test.js.snap
+++ b/frontend/src/components/accounts/__tests__/__snapshots__/AccountRow.test.js.snap
@@ -21,7 +21,6 @@ exports[`<AccountRow /> renders with long name 1`] = `
         className="pr-0 col-md-auto col-1"
       >
         <img
-          className="jsx-2652304458"
           src="/static/images/icon-t-acct.svg"
           style={
             Object {
@@ -38,6 +37,51 @@ exports[`<AccountRow /> renders with long name 1`] = `
       <div
         className="ml-auto pt-1 text-right transaction-row-txid col-md-3 col-5"
       />
+      <style>
+        
+                  .transaction-row {
+                    padding-top: 10px;
+                    padding-bottom: 10px;
+                    border-top: solid 2px #f8f8f8;
+                  }
+
+                  .transaction-row:hover {
+                    background: rgba(0, 0, 0, 0.1);
+                  }
+
+                  .transaction-row-title {
+                    font-size: 14px;
+                    font-weight: 500;
+                    line-height: 1.29;
+                    color: #24272a;
+                    word-break: break-word;
+                  }
+
+                  .transaction-row-text {
+                    font-size: 12px;
+                    font-weight: 500;
+                    line-height: 1.5;
+                    color: #999999;
+                  }
+
+                  .transaction-row-txid {
+                    font-size: 14px;
+                    font-weight: 500;
+                    line-height: 1.29;
+                    color: #0072ce;
+                  }
+
+                  .transaction-row-timer {
+                    font-size: 12px;
+                    color: #666666;
+                    font-weight: 300;
+                  }
+
+                  .transaction-row-timer-status {
+                    font-weight: 500;
+                  }
+                
+      </style>
     </div>
   </a>
 </span>
@@ -64,7 +108,6 @@ exports[`<AccountRow /> renders with short name 1`] = `
         className="pr-0 col-md-auto col-1"
       >
         <img
-          className="jsx-2652304458"
           src="/static/images/icon-t-acct.svg"
           style={
             Object {
@@ -81,6 +124,51 @@ exports[`<AccountRow /> renders with short name 1`] = `
       <div
         className="ml-auto pt-1 text-right transaction-row-txid col-md-3 col-5"
       />
+      <style>
+        
+                  .transaction-row {
+                    padding-top: 10px;
+                    padding-bottom: 10px;
+                    border-top: solid 2px #f8f8f8;
+                  }
+
+                  .transaction-row:hover {
+                    background: rgba(0, 0, 0, 0.1);
+                  }
+
+                  .transaction-row-title {
+                    font-size: 14px;
+                    font-weight: 500;
+                    line-height: 1.29;
+                    color: #24272a;
+                    word-break: break-word;
+                  }
+
+                  .transaction-row-text {
+                    font-size: 12px;
+                    font-weight: 500;
+                    line-height: 1.5;
+                    color: #999999;
+                  }
+
+                  .transaction-row-txid {
+                    font-size: 14px;
+                    font-weight: 500;
+                    line-height: 1.29;
+                    color: #0072ce;
+                  }
+
+                  .transaction-row-timer {
+                    font-size: 12px;
+                    color: #666666;
+                    font-weight: 300;
+                  }
+
+                  .transaction-row-timer-status {
+                    font-weight: 500;
+                  }
+                
+      </style>
     </div>
   </a>
 </span>

--- a/frontend/src/components/blocks/__tests__/__snapshots__/BlockDetails.test.tsx.snap
+++ b/frontend/src/components/blocks/__tests__/__snapshots__/BlockDetails.test.tsx.snap
@@ -1,378 +1,958 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<BlockDetails /> renders 1`] = `
-<div
-  className="row no-gutters"
->
+Array [
   <div
-    className="block-info-container col"
+    className="row no-gutters"
   >
     <div
-      className="block-info-header row no-gutters"
+      className="block-info-container col"
     >
       <div
-        className="col-md-4"
+        className="block-info-header row no-gutters"
       >
         <div
-          className="card-cell border-0 card"
+          className="col-md-4"
         >
           <div
-            className="card-body"
+            className="card-cell border-0 card"
           >
             <div
-              className="row no-gutters"
+              className="card-body"
             >
               <div
-                className="card-cell-title align-self-center col-md-12 col-auto"
+                className="row no-gutters"
               >
-                <img
-                  className="jsx-1735495307 card-cell-title-img"
-                  src="/static/images/icon-m-transaction.svg"
-                />
-                Transactions
                 <div
-                  className="jsx-782042476 term-helper"
-                  onClick={[Function]}
+                  className="card-cell-title align-self-center col-md-12 col-auto"
                 >
                   <img
-                    className="jsx-782042476 info"
-                    onClick={[Function]}
-                    src="/static/images/icon-info.svg"
+                    className="card-cell-title-img"
+                    src="/static/images/icon-m-transaction.svg"
                   />
-                </div>
-              </div>
-              <div
-                className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
-              >
-                3
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        className="col-md-4"
-      >
-        <div
-          className="card-cell  card"
-        >
-          <div
-            className="card-body"
-          >
-            <div
-              className="row no-gutters"
-            >
-              <div
-                className="card-cell-title align-self-center col-md-12 col-auto"
-              >
-                Receipts
-              </div>
-              <div
-                className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
-              >
-                5
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        className="col-md-4"
-      >
-        <div
-          className="card-cell  card"
-        >
-          <div
-            className="card-body"
-          >
-            <div
-              className="row no-gutters"
-            >
-              <div
-                className="card-cell-title align-self-center col-md-12 col-auto"
-              >
-                <img
-                  className="jsx-1735495307 card-cell-title-img"
-                  src="/static/images/icon-t-status.svg"
-                />
-                Status
-                <div
-                  className="jsx-782042476 term-helper"
-                  onClick={[Function]}
-                >
-                  <img
-                    className="jsx-782042476 info"
+                  Transactions
+                  <div
+                    className="term-helper"
                     onClick={[Function]}
-                    src="/static/images/icon-info.svg"
-                  />
-                </div>
-              </div>
-              <div
-                className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
-              >
-                Checking Finality...
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="row no-gutters"
-    >
-      <div
-        className="col-md-4"
-      >
-        <div
-          className="card-cell border-0 card"
-        >
-          <div
-            className="card-body"
-          >
-            <div
-              className="row no-gutters"
-            >
-              <div
-                className="card-cell-title align-self-center col-md-12 col-auto"
-              >
-                Author
-              </div>
-              <div
-                className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
-              >
-                <span
-                  onClick={[Function]}
-                >
-                  <a
-                    className="jsx-3150401870 account-link"
-                    href="/accounts/near.near"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
                   >
-                    near.near
-                  </a>
-                </span>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        className="col-md-4"
-      >
-        <div
-          className="card-cell  card"
-        >
-          <div
-            className="card-body"
-          >
-            <div
-              className="row no-gutters"
-            >
-              <div
-                className="card-cell-title align-self-center col-md-12 col-auto"
-              >
-                <img
-                  className="jsx-1735495307 card-cell-title-img"
-                  src="/static/images/icon-m-size.svg"
-                />
-                Gas Used
+                    <img
+                      className="info"
+                      onClick={[Function]}
+                      src="/static/images/icon-info.svg"
+                    />
+                    <style>
+                      
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                    </style>
+                  </div>
+                </div>
                 <div
-                  className="jsx-782042476 term-helper"
-                  onClick={[Function]}
+                  className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
                 >
-                  <img
-                    className="jsx-782042476 info"
-                    onClick={[Function]}
-                    src="/static/images/icon-info.svg"
-                  />
+                  3
                 </div>
               </div>
-              <div
-                className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
-              >
-                1000 gas
-              </div>
             </div>
+            <style>
+              
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+            </style>
           </div>
         </div>
-      </div>
-      <div
-        className="col-md-4"
-      >
         <div
-          className="card-cell  card"
+          className="col-md-4"
         >
           <div
-            className="card-body"
+            className="card-cell  card"
           >
             <div
-              className="row no-gutters"
+              className="card-body"
             >
               <div
-                className="card-cell-title align-self-center col-md-12 col-auto"
+                className="row no-gutters"
               >
-                <img
-                  className="jsx-1735495307 card-cell-title-img"
-                  src="/static/images/icon-m-filter.svg"
-                />
-                Gas Price
                 <div
-                  className="jsx-782042476 term-helper"
-                  onClick={[Function]}
+                  className="card-cell-title align-self-center col-md-12 col-auto"
                 >
-                  <img
-                    className="jsx-782042476 info"
-                    onClick={[Function]}
-                    src="/static/images/icon-info.svg"
-                  />
+                  Receipts
                 </div>
-              </div>
-              <div
-                className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
-              >
-                <span
-                  onBlur={[Function]}
-                  onFocus={[Function]}
-                  onMouseOut={[Function]}
-                  onMouseOver={[Function]}
+                <div
+                  className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
                 >
-                  &lt;0.00001
-                   Ⓝ/Tgas
-                </span>
+                  5
+                </div>
               </div>
             </div>
+            <style>
+              
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+            </style>
           </div>
         </div>
-      </div>
-    </div>
-    <div
-      className="row no-gutters"
-    >
-      <div
-        className="col-md-4"
-      >
         <div
-          className="card-cell block-card-created border-0 card"
+          className="col-md-4"
         >
           <div
-            className="card-body"
+            className="card-cell  card"
           >
             <div
-              className="row no-gutters"
+              className="card-body"
             >
               <div
-                className="card-cell-title align-self-center col-md-12 col-auto"
+                className="row no-gutters"
               >
-                Created
                 <div
-                  className="jsx-782042476 term-helper"
-                  onClick={[Function]}
+                  className="card-cell-title align-self-center col-md-12 col-auto"
                 >
                   <img
-                    className="jsx-782042476 info"
-                    onClick={[Function]}
-                    src="/static/images/icon-info.svg"
+                    className="card-cell-title-img"
+                    src="/static/images/icon-t-status.svg"
                   />
-                </div>
-              </div>
-              <div
-                className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
-              >
-                February 01, 2019 at 12:00:00am
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        className="col-md-8"
-      >
-        <div
-          className="card-cell  card"
-        >
-          <div
-            className="card-body"
-          >
-            <div
-              className="row no-gutters"
-            >
-              <div
-                className="card-cell-title align-self-center col-md-12 col-auto"
-              >
-                Hash
-                <div
-                  className="jsx-782042476 term-helper"
-                  onClick={[Function]}
-                >
-                  <img
-                    className="jsx-782042476 info"
+                  Status
+                  <div
+                    className="term-helper"
                     onClick={[Function]}
-                    src="/static/images/icon-info.svg"
-                  />
-                </div>
-              </div>
-              <div
-                className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
-              >
-                EVvWW1S9BFaEjY1JBNSdstb7ZTtTFjQ6cygkbw1KY4tL
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="row no-gutters"
-    >
-      <div
-        className="col-md-12"
-      >
-        <div
-          className="card-cell block-card-parent-hash border-0 card"
-        >
-          <div
-            className="card-body"
-          >
-            <div
-              className="row no-gutters"
-            >
-              <div
-                className="card-cell-title align-self-center col-md-12 col-auto"
-              >
-                Parent Hash
-                <div
-                  className="jsx-782042476 term-helper"
-                  onClick={[Function]}
-                >
-                  <img
-                    className="jsx-782042476 info"
-                    onClick={[Function]}
-                    src="/static/images/icon-info.svg"
-                  />
-                </div>
-              </div>
-              <div
-                className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
-              >
-                <span
-                  onClick={[Function]}
-                >
-                  <a
-                    className="block-link"
-                    href="/blocks/EVvWW1S9BFaEjY1JBNSdstb7Zjghjlyguiygfhgu"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
                   >
-                    EVvWW1S9BFaEjY1JBNSdstb7Zjghjlyguiygfhgu
-                  </a>
-                </span>
+                    <img
+                      className="info"
+                      onClick={[Function]}
+                      src="/static/images/icon-info.svg"
+                    />
+                    <style>
+                      
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                    </style>
+                  </div>
+                </div>
+                <div
+                  className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
+                >
+                  Checking Finality...
+                </div>
               </div>
             </div>
+            <style>
+              
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+            </style>
+          </div>
+        </div>
+      </div>
+      <div
+        className="row no-gutters"
+      >
+        <div
+          className="col-md-4"
+        >
+          <div
+            className="card-cell border-0 card"
+          >
+            <div
+              className="card-body"
+            >
+              <div
+                className="row no-gutters"
+              >
+                <div
+                  className="card-cell-title align-self-center col-md-12 col-auto"
+                >
+                  Author
+                </div>
+                <div
+                  className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
+                >
+                  <span
+                    onClick={[Function]}
+                  >
+                    <a
+                      className="account-link"
+                      href="/accounts/near.near"
+                      onClick={[Function]}
+                      onMouseEnter={[Function]}
+                    >
+                      near.near
+                    </a>
+                  </span>
+                  <style>
+                    
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                  </style>
+                </div>
+              </div>
+            </div>
+            <style>
+              
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+            </style>
+          </div>
+        </div>
+        <div
+          className="col-md-4"
+        >
+          <div
+            className="card-cell  card"
+          >
+            <div
+              className="card-body"
+            >
+              <div
+                className="row no-gutters"
+              >
+                <div
+                  className="card-cell-title align-self-center col-md-12 col-auto"
+                >
+                  <img
+                    className="card-cell-title-img"
+                    src="/static/images/icon-m-size.svg"
+                  />
+                  Gas Used
+                  <div
+                    className="term-helper"
+                    onClick={[Function]}
+                  >
+                    <img
+                      className="info"
+                      onClick={[Function]}
+                      src="/static/images/icon-info.svg"
+                    />
+                    <style>
+                      
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                    </style>
+                  </div>
+                </div>
+                <div
+                  className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
+                >
+                  1000 gas
+                </div>
+              </div>
+            </div>
+            <style>
+              
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+            </style>
+          </div>
+        </div>
+        <div
+          className="col-md-4"
+        >
+          <div
+            className="card-cell  card"
+          >
+            <div
+              className="card-body"
+            >
+              <div
+                className="row no-gutters"
+              >
+                <div
+                  className="card-cell-title align-self-center col-md-12 col-auto"
+                >
+                  <img
+                    className="card-cell-title-img"
+                    src="/static/images/icon-m-filter.svg"
+                  />
+                  Gas Price
+                  <div
+                    className="term-helper"
+                    onClick={[Function]}
+                  >
+                    <img
+                      className="info"
+                      onClick={[Function]}
+                      src="/static/images/icon-info.svg"
+                    />
+                    <style>
+                      
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                    </style>
+                  </div>
+                </div>
+                <div
+                  className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
+                >
+                  <span
+                    onBlur={[Function]}
+                    onFocus={[Function]}
+                    onMouseOut={[Function]}
+                    onMouseOver={[Function]}
+                  >
+                    &lt;0.00001
+                     Ⓝ/Tgas
+                  </span>
+                </div>
+              </div>
+            </div>
+            <style>
+              
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+            </style>
+          </div>
+        </div>
+      </div>
+      <div
+        className="row no-gutters"
+      >
+        <div
+          className="col-md-4"
+        >
+          <div
+            className="card-cell block-card-created border-0 card"
+          >
+            <div
+              className="card-body"
+            >
+              <div
+                className="row no-gutters"
+              >
+                <div
+                  className="card-cell-title align-self-center col-md-12 col-auto"
+                >
+                  Created
+                  <div
+                    className="term-helper"
+                    onClick={[Function]}
+                  >
+                    <img
+                      className="info"
+                      onClick={[Function]}
+                      src="/static/images/icon-info.svg"
+                    />
+                    <style>
+                      
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                    </style>
+                  </div>
+                </div>
+                <div
+                  className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
+                >
+                  February 01, 2019 at 12:00:00am
+                </div>
+              </div>
+            </div>
+            <style>
+              
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+            </style>
+          </div>
+        </div>
+        <div
+          className="col-md-8"
+        >
+          <div
+            className="card-cell  card"
+          >
+            <div
+              className="card-body"
+            >
+              <div
+                className="row no-gutters"
+              >
+                <div
+                  className="card-cell-title align-self-center col-md-12 col-auto"
+                >
+                  Hash
+                  <div
+                    className="term-helper"
+                    onClick={[Function]}
+                  >
+                    <img
+                      className="info"
+                      onClick={[Function]}
+                      src="/static/images/icon-info.svg"
+                    />
+                    <style>
+                      
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                    </style>
+                  </div>
+                </div>
+                <div
+                  className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
+                >
+                  EVvWW1S9BFaEjY1JBNSdstb7ZTtTFjQ6cygkbw1KY4tL
+                </div>
+              </div>
+            </div>
+            <style>
+              
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+            </style>
+          </div>
+        </div>
+      </div>
+      <div
+        className="row no-gutters"
+      >
+        <div
+          className="col-md-12"
+        >
+          <div
+            className="card-cell block-card-parent-hash border-0 card"
+          >
+            <div
+              className="card-body"
+            >
+              <div
+                className="row no-gutters"
+              >
+                <div
+                  className="card-cell-title align-self-center col-md-12 col-auto"
+                >
+                  Parent Hash
+                  <div
+                    className="term-helper"
+                    onClick={[Function]}
+                  >
+                    <img
+                      className="info"
+                      onClick={[Function]}
+                      src="/static/images/icon-info.svg"
+                    />
+                    <style>
+                      
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                    </style>
+                  </div>
+                </div>
+                <div
+                  className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
+                >
+                  <span
+                    onClick={[Function]}
+                  >
+                    <a
+                      className="block-link"
+                      href="/blocks/EVvWW1S9BFaEjY1JBNSdstb7Zjghjlyguiygfhgu"
+                      onClick={[Function]}
+                      onMouseEnter={[Function]}
+                    >
+                      EVvWW1S9BFaEjY1JBNSdstb7Zjghjlyguiygfhgu
+                    </a>
+                  </span>
+                </div>
+              </div>
+            </div>
+            <style>
+              
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+            </style>
           </div>
         </div>
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+  <style>
+    
+                .block-info-container {
+                  border: solid 4px #e6e6e6;
+                  border-radius: 4px;
+                }
+
+                .block-info-container &gt; .row {
+                  border-bottom: 2px solid #e6e6e6;
+                }
+
+                .block-info-container &gt; .row:last-of-type {
+                  border-bottom: 0;
+                }
+
+                .block-info-header .card-cell-text {
+                  font-size: 24px;
+                }
+
+                .block-card-created-text {
+                  font-size: 18px;
+                  font-weight: 500;
+                  color: #4a4f54;
+                }
+
+                .block-card-parent-hash {
+                  background-color: #f8f8f8;
+                }
+
+                @media (max-width: 768px) {
+                  .block-info-container .card-cell {
+                    border-left: 0;
+                  }
+                }
+              
+  </style>,
+]
 `;

--- a/frontend/src/components/blocks/__tests__/__snapshots__/BlocksRow.test.tsx.snap
+++ b/frontend/src/components/blocks/__tests__/__snapshots__/BlocksRow.test.tsx.snap
@@ -21,7 +21,6 @@ exports[`<BlocksRow /> renders 1`] = `
         className="pr-0 col-md-auto col-1"
       >
         <img
-          className="jsx-3833595686"
           src="/static/images/icon-m-block.svg"
         />
       </div>
@@ -29,7 +28,6 @@ exports[`<BlocksRow /> renders 1`] = `
         className="pr-0 col-md-auto col-1"
       >
         <img
-          className="jsx-3833595686"
           src="/static/images/icon-m-block.svg"
           style={
             Object {
@@ -64,7 +62,6 @@ exports[`<BlocksRow /> renders 1`] = `
                 className="col-md-auto"
               >
                 <img
-                  className="jsx-3833595686"
                   src="/static/images/icon-m-transaction.svg"
                   style={
                     Object {
@@ -97,7 +94,7 @@ exports[`<BlocksRow /> renders 1`] = `
             className="transaction-row-timer col"
           >
             <span
-              className="jsx-3833595686 transaction-row-timer-status"
+              className="transaction-row-timer-status"
             >
               Checking Finality...
             </span>
@@ -108,6 +105,50 @@ exports[`<BlocksRow /> renders 1`] = `
           </div>
         </div>
       </div>
+      <style>
+        
+                      .transaction-row {
+                        padding-top: 10px;
+                        padding-bottom: 10px;
+                        border-top: solid 2px #f8f8f8;
+                      }
+
+                      .transaction-row:hover {
+                        background: rgba(0, 0, 0, 0.1);
+                      }
+
+                      .transaction-row-title {
+                        font-size: 14px;
+                        font-weight: 500;
+                        line-height: 1.29;
+                        color: #24272a;
+                      }
+
+                      .transaction-row-text {
+                        font-size: 12px;
+                        font-weight: 500;
+                        line-height: 1.5;
+                        color: #999999;
+                      }
+
+                      .transaction-row-txid {
+                        font-size: 14px;
+                        font-weight: 500;
+                        line-height: 1.29;
+                        color: #0072ce;
+                      }
+
+                      .transaction-row-timer {
+                        font-size: 12px;
+                        color: #999999;
+                        font-weight: 100;
+                      }
+
+                      .transaction-row-timer-status {
+                        font-weight: 500;
+                      }
+                    
+      </style>
     </div>
   </a>
 </span>

--- a/frontend/src/components/nodes/__test__/__snapshots__/NodeRow.test.tsx.snap
+++ b/frontend/src/components/nodes/__test__/__snapshots__/NodeRow.test.tsx.snap
@@ -1,103 +1,240 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<NodeRow /> renders 1`] = `
-<tr
-  className="jsx-4079813474 table-row online-nodes-row "
->
-  <td
-    className="jsx-164761836"
-    onClick={[Function]}
-    style={
-      Object {
-        "width": "48px",
-      }
-    }
+Array [
+  <tr
+    className="table-row online-nodes-row "
   >
-    <img
-      className="jsx-164761836"
-      src="/static/images/icon-maximize.svg"
+    <td
+      onClick={[Function]}
       style={
         Object {
-          "width": "16px",
+          "width": "48px",
         }
       }
-    />
-  </td>
-  <td
-    className="jsx-164761836 order"
-    style={
-      Object {
-        "width": "48px",
-      }
-    }
-  >
-    1
-  </td>
-  <td
-    className="jsx-164761836"
-  >
-    <div
-      className="align-items-center row no-gutters"
     >
+      <img
+        src="/static/images/icon-maximize.svg"
+        style={
+          Object {
+            "width": "16px",
+          }
+        }
+      />
+    </td>
+    <td
+      className="order"
+      style={
+        Object {
+          "width": "48px",
+        }
+      }
+    >
+      1
+    </td>
+    <td>
       <div
-        className="online-node-label col-2"
-      >
-        <span
-          className="validating-label active badge"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-        >
-          Online
-        </span>
-      </div>
-      <div
-        className="col-10"
+        className="align-items-center row no-gutters"
       >
         <div
-          className="row no-gutters"
+          className="online-node-label col-2"
         >
-          <div
-            className="online-nodes-text col"
-            title="@alice"
+          <span
+            className="validating-label active badge"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
           >
-            alice
-            ...
-          </div>
+            Online
+            <style>
+              
+            .validating-label {
+              padding: 2px 8px;
+              border-radius: 50px;
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 150%;
+            }
+
+            .validating-label.active {
+              background-color: #c8f6e0;
+              color: #008d6a;
+            }
+
+            .validating-label.proposal {
+              background-color: #6ad1e3;
+              color: #11869a;
+            }
+
+            .validating-label.joining {
+              background-color: #ffc107;
+              color: #ffffff;
+            }
+
+            .validating-label.leaving {
+              background-color: #dc3545;
+              color: #ffffff;
+            }
+            .validating-label.idle {
+              background-color: #e5e5e6;
+              color: #72727a;
+            }
+            .validating-label.on-hold {
+              background-color: #2d9cdb;
+              color: #ffffff;
+            }
+            .validating-label.newcomer {
+              background-color: #f2994a;
+              color: #ffffff;
+            }
+          
+            </style>
+          </span>
         </div>
         <div
-          className="row"
+          className="col-10"
         >
           <div
-            className="node-status col"
+            className="row no-gutters"
           >
-            
-          </div>
-        </div>
-        <div
-          className="row no-gutters"
-        >
-          <div
-            className="online-nodes-text col"
-            title="ed25519:fhgjrkfhurjtieokwpitjesdlkfjngdmloytiutkjhgkf"
-          >
-            <span
-              onClick={[Function]}
+            <div
+              className="online-nodes-text col"
+              title="@alice"
             >
-              <a
-                className="transaction-link"
-                href="/transactions/ed25519:fhgjrkfhurjtieokwpitjesdlkfjngdmloytiutkjhgkf"
+              alice
+              ...
+            </div>
+          </div>
+          <div
+            className="row"
+          >
+            <div
+              className="node-status col"
+            >
+              
+            </div>
+          </div>
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="online-nodes-text col"
+              title="ed25519:fhgjrkfhurjtieokwpitjesdlkfjngdmloytiutkjhgkf"
+            >
+              <span
                 onClick={[Function]}
-                onMouseEnter={[Function]}
               >
-                ed25519...
-              </a>
-            </span>
+                <a
+                  className="transaction-link"
+                  href="/transactions/ed25519:fhgjrkfhurjtieokwpitjesdlkfjngdmloytiutkjhgkf"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  ed25519...
+                </a>
+              </span>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  </td>
-</tr>
+    </td>
+  </tr>,
+  <style>
+    
+          .table-row {
+            background-color: #ffffff;
+            flex-wrap: nowrap;
+            white-space: nowrap;
+            box-shadow: inset 0px -1px 0px #f0f0f0;
+          }
+          .table-row td {
+            border-top: none;
+            vertical-align: middle;
+          }
+
+          .table-row td.order {
+            color: #a2a2a8;
+            font-size: 14px;
+            font-weight: 600;
+          }
+
+          .table-row .row {
+            flex-wrap: nowrap;
+          }
+
+          .table-row.expanded {
+            box-shadow: inset 4px 0px 0px #0598eb, inset 0px -1px 0px #f0f0f0,
+              inset 0px 1px 0px #2b9af4, inset -1px 0px 0px #2b9af4;
+            transition: height 0.5s 0.5s, opacity 0.5s;
+            margin-top: 16px;
+            margin-bottom: 16px;
+          }
+
+          .table-row.expanded + .table-expand-row {
+            box-shadow: inset 4px 0px 0px #0598eb, inset 0px -1px 0px #2b9af4,
+              inset -1px 0px 0px #2b9af4;
+            transition: height 0.5s 0.5s, opacity 0.5s;
+            height: auto;
+            opacity: 1;
+          }
+
+          .table-row.expanded:first-child {
+            margin-top: 0;
+          }
+        
+  </style>,
+  <style>
+    
+                  @import url("https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@500&display=swap");
+
+                  .online-nodes-text {
+                    font-weight: 500;
+                    font-size: 14px;
+                    color: #3f4045;
+                  }
+
+                  .online-node-label {
+                    margin-right: 24px;
+                    flex: 0 0 auto;
+                    width: 55px;
+                  }
+
+                  .online-nodes-content-row {
+                    padding-top: 16px;
+                    padding-bottom: 16px;
+                  }
+                  .online-nodes-content-row &gt; .online-nodes-content-cell {
+                    padding: 0 22px;
+                    border-right: 1px solid #e5e5e6;
+                  }
+
+                  .online-nodes-content-row
+                    &gt; .online-nodes-content-cell:last-child {
+                    border-right: none;
+                  }
+
+                  .online-nodes-details-title {
+                    display: flex;
+                    flex-wrap: nowrap;
+                    font-size: 12px;
+                    color: #a2a2a8;
+                  }
+
+                  .agent-name-badge {
+                    background-color: #f0f0f1;
+                    color: #72727a;
+                    font-weight: 500;
+                    font-size: 12px;
+                    font-family: "Roboto Mono", monospace;
+                  }
+
+                  .node-status {
+                    font-size: 12px;
+                    line-height: 18px;
+                    color: #4a4f54;
+                  }
+                
+  </style>,
+]
 `;

--- a/frontend/src/components/nodes/__test__/__snapshots__/NodesEpoch.test.tsx.snap
+++ b/frontend/src/components/nodes/__test__/__snapshots__/NodesEpoch.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`<NodesEpoch /> renders 1`] = `
           >
             Current Epoch Start: 
             <span
-              className="jsx-2616163488 text-value"
+              className="text-value"
             >
               Block #
               36647454
@@ -40,7 +40,7 @@ exports[`<NodesEpoch /> renders 1`] = `
             className="col-12"
           >
             <span
-              className="jsx-2616163488 text-value"
+              className="text-value"
             >
               Block #
               36647454
@@ -52,7 +52,7 @@ exports[`<NodesEpoch /> renders 1`] = `
         className="text-right d-none d-md-block  col-sm-5"
       >
         <span
-          className="jsx-2616163488 text-value persnt-remains"
+          className="text-value persnt-remains"
         >
           50
           % complete
@@ -63,13 +63,13 @@ exports[`<NodesEpoch /> renders 1`] = `
         className="text-right d-xs-block d-md-none col-5"
       >
         <div
-          className="jsx-2667301188 progress-bar circle node-epoch-circle-progress"
+          className="progress-bar circle node-epoch-circle-progress"
         >
           <svg
             className="rc-progress-circle progress-bar-content"
             label={
               <span
-                className="jsx-2616163488 circle-progress-label"
+                className="circle-progress-label"
               >
                 50
                 %
@@ -118,16 +118,41 @@ exports[`<NodesEpoch /> renders 1`] = `
             />
           </svg>
           <div
-            className="jsx-2667301188 progress-bar-label"
+            className="progress-bar-label"
           >
             <span
-              className="jsx-2616163488 circle-progress-label"
+              className="circle-progress-label"
             >
               50
               %
             </span>
           </div>
         </div>
+        <style>
+          
+          .progress-bar {
+            background: transparent;
+            position: relative;
+          }
+
+          .progress-bar .progress-bar-content {
+            background: transparent;
+          }
+
+          .progress-bar .rc-progress-line-path,
+          .progress-bar .rc-progress-circle-path {
+            stroke-linecap: square;
+          }
+
+          .progress-bar .progress-bar-label {
+            position: absolute;
+            width: 100%;
+            margin: auto;
+            font-size: 12px;
+            font-weight: 500;
+          }
+        
+        </style>
       </div>
     </div>
   </div>
@@ -135,7 +160,7 @@ exports[`<NodesEpoch /> renders 1`] = `
     className="d-none d-md-block px-0 col-12"
   >
     <div
-      className="jsx-2667301188 progress-bar line node-epoch-line-progress"
+      className="progress-bar line node-epoch-line-progress"
     >
       <svg
         className="rc-progress-line progress-bar-content"
@@ -170,6 +195,68 @@ exports[`<NodesEpoch /> renders 1`] = `
         />
       </svg>
     </div>
+    <style>
+      
+          .progress-bar {
+            background: transparent;
+            position: relative;
+          }
+
+          .progress-bar .progress-bar-content {
+            background: transparent;
+          }
+
+          .progress-bar .rc-progress-line-path,
+          .progress-bar .rc-progress-circle-path {
+            stroke-linecap: square;
+          }
+
+          .progress-bar .progress-bar-label {
+            position: absolute;
+            width: 100%;
+            margin: auto;
+            font-size: 12px;
+            font-weight: 500;
+          }
+        
+    </style>
   </div>
+  <style>
+    
+              .nodes-epoch {
+                background-color: #292526;
+                color: #d5d4d8;
+                font-size: 16px;
+                font-weight: 500;
+              }
+
+              .nodes-epoch .nodes-epoch-content {
+                margin: 15px 0;
+              }
+
+              .nodes-epoch .nodes-epoch-content .text-value {
+                color: #37dbf4;
+              }
+
+              .nodes-epoch .nodes-epoch-content .text-value.persnt-remains {
+                font-weight: 700;
+              }
+
+              .node-epoch-line-progress {
+                padding-left: 0;
+                padding-right: 0;
+                height: 4px;
+              }
+
+              .node-epoch-circle-progress {
+                margin-left: auto;
+                width: 40px;
+              }
+
+              .node-epoch-circle-progress .circle-progress-label {
+                color: #d5d4d8;
+              }
+            
+  </style>
 </div>
 `;

--- a/frontend/src/components/nodes/__test__/__snapshots__/ValidatorRow.test.tsx.snap
+++ b/frontend/src/components/nodes/__test__/__snapshots__/ValidatorRow.test.tsx.snap
@@ -1,431 +1,1094 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ValidatorRow /> renders 'active' Validators row with full data 1`] = `
-<tr
-  className="jsx-4079813474 table-row validator-nodes-row mx-0 "
->
-  <td
-    className="collapse-row-arrow"
-    onClick={[Function]}
+Array [
+  <tr
+    className="table-row validator-nodes-row mx-0 "
   >
-    <img
-      src="/static/images/icon-maximize.svg"
-      style={
-        Object {
-          "width": "16px",
-        }
-      }
-    />
-  </td>
-  <td
-    className="order"
-  >
-    3
-  </td>
-  <td
-    className="country-flag"
-  >
-    <img
-      id="country_flag_astro-stakers.poolv1.near"
-      onBlur={[Function]}
-      onFocus={[Function]}
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
-      src="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/4.1.4/flags/4x3/aq.svg"
-      style={
-        Object {
-          "display": "inline-block",
-          "height": "1em",
-          "lineHeight": "14px",
-          "verticalAlign": "middle",
-          "width": "22px",
-        }
-      }
-    />
-  </td>
-  <td>
-    <div
-      className="align-items-center row no-gutters"
+    <td
+      className="collapse-row-arrow"
+      onClick={[Function]}
     >
+      <img
+        src="/static/images/icon-maximize.svg"
+        style={
+          Object {
+            "width": "16px",
+          }
+        }
+      />
+    </td>
+    <td
+      className="order"
+    >
+      3
+    </td>
+    <td
+      className="country-flag"
+    >
+      <img
+        id="country_flag_astro-stakers.poolv1.near"
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
+        src="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/4.1.4/flags/4x3/aq.svg"
+        style={
+          Object {
+            "display": "inline-block",
+            "height": "1em",
+            "lineHeight": "14px",
+            "verticalAlign": "middle",
+            "width": "22px",
+          }
+        }
+      />
+    </td>
+    <td>
       <div
-        className="validators-node-label col"
-      >
-        <span
-          className="validating-label active badge"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-        >
-          Active
-        </span>
-      </div>
-      <div
-        className="validator-name col"
+        className="align-items-center row no-gutters"
       >
         <div
-          className="row no-gutters"
+          className="validators-node-label col"
         >
-          <div
-            className="validator-nodes-text col"
-            title="@astro-stakers.poolv1.near"
+          <span
+            className="validating-label active badge"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
           >
-            astro-stakers.poolv1.near
-          </div>
+            Active
+            <style>
+              
+            .validating-label {
+              padding: 2px 8px;
+              border-radius: 50px;
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 150%;
+            }
+
+            .validating-label.active {
+              background-color: #c8f6e0;
+              color: #008d6a;
+            }
+
+            .validating-label.proposal {
+              background-color: #6ad1e3;
+              color: #11869a;
+            }
+
+            .validating-label.joining {
+              background-color: #ffc107;
+              color: #ffffff;
+            }
+
+            .validating-label.leaving {
+              background-color: #dc3545;
+              color: #ffffff;
+            }
+            .validating-label.idle {
+              background-color: #e5e5e6;
+              color: #72727a;
+            }
+            .validating-label.on-hold {
+              background-color: #2d9cdb;
+              color: #ffffff;
+            }
+            .validating-label.newcomer {
+              background-color: #f2994a;
+              color: #ffffff;
+            }
+          
+            </style>
+          </span>
         </div>
         <div
-          className="row no-gutters"
+          className="validator-name col"
         >
           <div
-            className="validator-nodes-text validator-node-pub-key col"
-            title="ed25519:2nPSBCzjqikgwrqUMcuEVReJhmkC91eqJGPGqH9sZc28"
+            className="row no-gutters"
           >
-            ed25519:2nPSBCzjqikgwrqUMcuEVReJhmkC91eqJGPGqH9sZc28
+            <div
+              className="validator-nodes-text col"
+              title="@astro-stakers.poolv1.near"
+            >
+              astro-stakers.poolv1.near
+            </div>
+          </div>
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="validator-nodes-text validator-node-pub-key col"
+              title="ed25519:2nPSBCzjqikgwrqUMcuEVReJhmkC91eqJGPGqH9sZc28"
+            >
+              ed25519:2nPSBCzjqikgwrqUMcuEVReJhmkC91eqJGPGqH9sZc28
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  </td>
-  <td>
-    1%
-  </td>
-  <td>
-    1774
-  </td>
-  <td
-    className="text-right validator-nodes-text stake-text"
-  >
-    <span
-      onBlur={[Function]}
-      onFocus={[Function]}
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
+    </td>
+    <td>
+      1%
+    </td>
+    <td>
+      1774
+    </td>
+    <td
+      className="text-right validator-nodes-text stake-text"
     >
-      17,776,328
-       
-      NEAR
-    </span>
-    <br />
-    <small>
-      +
       <span
         onBlur={[Function]}
         onFocus={[Function]}
         onMouseOut={[Function]}
         onMouseOver={[Function]}
       >
-        712
+        17,776,328
          
         NEAR
       </span>
-    </small>
-  </td>
-  <td>
-    <div
-      className="jsx-2437284421 cumulative-stake-chart"
-    >
+      <br />
+      <small>
+        +
+        <span
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onMouseOut={[Function]}
+          onMouseOver={[Function]}
+        >
+          712
+           
+          NEAR
+        </span>
+      </small>
+    </td>
+    <td>
       <div
-        className="jsx-2437284421 total-value"
-        style={
-          Object {
-            "width": "96.7%",
-          }
-        }
-      />
-      <div
-        className="jsx-2437284421 current-value"
-        style={
-          Object {
-            "width": "20.980000000000004%",
-          }
-        }
-      />
-      <div
-        className="jsx-2437284421 cumulative-stake-label"
+        className="cumulative-stake-chart"
       >
-        117.68%
+        <div
+          className="total-value"
+          style={
+            Object {
+              "width": "96.7%",
+            }
+          }
+        />
+        <div
+          className="current-value"
+          style={
+            Object {
+              "width": "20.980000000000004%",
+            }
+          }
+        />
+        <div
+          className="cumulative-stake-label"
+        >
+          117.68%
+        </div>
+        <style>
+          
+          .cumulative-stake-chart {
+            width: 100%;
+            height: 100%;
+            background-color: #f0f9ff;
+            position: relative;
+            display: flex;
+          }
+          .total-value,
+          .current-value {
+            display: block;
+            height: 75px;
+          }
+          .total-value {
+            background-color: #d6edff;
+          }
+          .current-value {
+            background-color: #8fcdff;
+          }
+          .cumulative-stake-label {
+            position: absolute;
+            top: 0;
+            right: 24px;
+            bottom: 0;
+            display: flex;
+            align-items: center;
+            color: #0072ce;
+            font-size: 14px;
+            font-weight: 500;
+            max-width: 75px;
+          }
+        
+        </style>
       </div>
-    </div>
-  </td>
-</tr>
+    </td>
+  </tr>,
+  <style>
+    
+          .table-row {
+            background-color: #ffffff;
+            flex-wrap: nowrap;
+            white-space: nowrap;
+            box-shadow: inset 0px -1px 0px #f0f0f0;
+          }
+          .table-row td {
+            border-top: none;
+            vertical-align: middle;
+          }
+
+          .table-row td.order {
+            color: #a2a2a8;
+            font-size: 14px;
+            font-weight: 600;
+          }
+
+          .table-row .row {
+            flex-wrap: nowrap;
+          }
+
+          .table-row.expanded {
+            box-shadow: inset 4px 0px 0px #0598eb, inset 0px -1px 0px #f0f0f0,
+              inset 0px 1px 0px #2b9af4, inset -1px 0px 0px #2b9af4;
+            transition: height 0.5s 0.5s, opacity 0.5s;
+            margin-top: 16px;
+            margin-bottom: 16px;
+          }
+
+          .table-row.expanded + .table-expand-row {
+            box-shadow: inset 4px 0px 0px #0598eb, inset 0px -1px 0px #2b9af4,
+              inset -1px 0px 0px #2b9af4;
+            transition: height 0.5s 0.5s, opacity 0.5s;
+            height: auto;
+            opacity: 1;
+          }
+
+          .table-row.expanded:first-child {
+            margin-top: 0;
+          }
+        
+  </style>,
+  <style>
+    
+              @import url("https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@500&display=swap");
+
+              .collapse-row-arrow {
+                cursor: pointer;
+              }
+
+              .collapse-row-arrow.disable {
+                cursor: default;
+                opacity: 0.3;
+                pointer-events: none;
+                touch-action: none;
+              }
+
+              .validator-nodes-text {
+                font-weight: 500;
+                font-size: 14px;
+                color: #3f4045;
+              }
+
+              .validator-node-pub-key {
+                color: #2b9af4;
+              }
+
+              .validator-name {
+                max-width: 250px;
+              }
+
+              .validator-name .validator-nodes-text {
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+              }
+
+              .validator-nodes-details-title {
+                display: flex;
+                flex-wrap: nowrap;
+                font-size: 12px;
+                color: #a2a2a8;
+              }
+
+              .validator-nodes-text.uptime {
+                color: #72727a;
+              }
+
+              .validator-nodes-text.stake-text {
+                font-weight: 700;
+              }
+
+              .validator-nodes-content-row {
+                padding-top: 16px;
+                padding-bottom: 16px;
+              }
+
+              .validator-nodes-content-row &gt; .validator-nodes-content-cell {
+                padding: 0 22px;
+                border-right: 1px solid #e5e5e6;
+              }
+
+              .validator-nodes-content-row
+                &gt; .validator-nodes-content-cell:last-child {
+                border-right: none;
+              }
+
+              .agent-name-badge {
+                background-color: #f0f0f1;
+                color: #72727a;
+                font-weight: 500;
+                font-size: 12px;
+                font-family: "Roboto Mono", monospace;
+              }
+
+              .validators-node-label {
+                margin-right: 24px;
+                max-width: 138px;
+              }
+
+              .cumulative-stake-chart {
+                min-width: 100px;
+              }
+
+              .cumulative-stake-holders-row {
+                background-color: #fff6ed;
+              }
+              .cumulative-stake-holders-row .warning-text {
+                color: #995200;
+                padding: 16px 50px;
+                font-size: 12px;
+              }
+
+              @media (min-width: 1200px) {
+                .validator-name {
+                  max-width: 370px;
+                }
+              }
+            
+  </style>,
+]
 `;
 
 exports[`<ValidatorRow /> renders 'active' Validators row without 'poolDetails' 1`] = `
-<tr
-  className="jsx-4079813474 table-row validator-nodes-row mx-0 "
->
-  <td
-    className="collapse-row-arrow"
-    onClick={[Function]}
+Array [
+  <tr
+    className="table-row validator-nodes-row mx-0 "
   >
-    <img
-      src="/static/images/icon-maximize.svg"
-      style={
-        Object {
-          "width": "16px",
-        }
-      }
-    />
-  </td>
-  <td
-    className="order"
-  >
-    2
-  </td>
-  <td
-    className="country-flag"
-  >
-    <div
-      style={
-        Object {
-          "backgroundColor": "#f0f0f1",
-          "color": "#72727a",
-          "display": "inline-block",
-          "fontSize": "8px",
-          "lineHeight": "16px",
-          "textAlign": "center",
-          "width": "22px",
-        }
-      }
+    <td
+      className="collapse-row-arrow"
+      onClick={[Function]}
     >
-      ?
-    </div>
-  </td>
-  <td>
-    <div
-      className="align-items-center row no-gutters"
+      <img
+        src="/static/images/icon-maximize.svg"
+        style={
+          Object {
+            "width": "16px",
+          }
+        }
+      />
+    </td>
+    <td
+      className="order"
+    >
+      2
+    </td>
+    <td
+      className="country-flag"
     >
       <div
-        className="validators-node-label col"
+        style={
+          Object {
+            "backgroundColor": "#f0f0f1",
+            "color": "#72727a",
+            "display": "inline-block",
+            "fontSize": "8px",
+            "lineHeight": "16px",
+            "textAlign": "center",
+            "width": "22px",
+          }
+        }
       >
-        <span
-          className="validating-label active badge"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-        >
-          Active
-        </span>
+        ?
       </div>
+    </td>
+    <td>
       <div
-        className="validator-name col"
+        className="align-items-center row no-gutters"
       >
         <div
-          className="row no-gutters"
+          className="validators-node-label col"
         >
-          <div
-            className="validator-nodes-text col"
-            title="@bisontrails.poolv1.near"
+          <span
+            className="validating-label active badge"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
           >
-            bisontrails.poolv1.near
-          </div>
+            Active
+            <style>
+              
+            .validating-label {
+              padding: 2px 8px;
+              border-radius: 50px;
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 150%;
+            }
+
+            .validating-label.active {
+              background-color: #c8f6e0;
+              color: #008d6a;
+            }
+
+            .validating-label.proposal {
+              background-color: #6ad1e3;
+              color: #11869a;
+            }
+
+            .validating-label.joining {
+              background-color: #ffc107;
+              color: #ffffff;
+            }
+
+            .validating-label.leaving {
+              background-color: #dc3545;
+              color: #ffffff;
+            }
+            .validating-label.idle {
+              background-color: #e5e5e6;
+              color: #72727a;
+            }
+            .validating-label.on-hold {
+              background-color: #2d9cdb;
+              color: #ffffff;
+            }
+            .validating-label.newcomer {
+              background-color: #f2994a;
+              color: #ffffff;
+            }
+          
+            </style>
+          </span>
         </div>
         <div
-          className="row no-gutters"
+          className="validator-name col"
         >
           <div
-            className="validator-nodes-text validator-node-pub-key col"
-            title="ed25519:Emk6wQJtpQZRJCvvPmmwP9GD2Pk37xxRpmb5uRvJpX62"
+            className="row no-gutters"
           >
-            ed25519:Emk6wQJtpQZRJCvvPmmwP9GD2Pk37xxRpmb5uRvJpX62
+            <div
+              className="validator-nodes-text col"
+              title="@bisontrails.poolv1.near"
+            >
+              bisontrails.poolv1.near
+            </div>
+          </div>
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="validator-nodes-text validator-node-pub-key col"
+              title="ed25519:Emk6wQJtpQZRJCvvPmmwP9GD2Pk37xxRpmb5uRvJpX62"
+            >
+              ed25519:Emk6wQJtpQZRJCvvPmmwP9GD2Pk37xxRpmb5uRvJpX62
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  </td>
-  <td>
-    10%
-  </td>
-  <td>
-    436
-  </td>
-  <td
-    className="text-right validator-nodes-text stake-text"
-  >
-    <span
-      onBlur={[Function]}
-      onFocus={[Function]}
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
+    </td>
+    <td>
+      10%
+    </td>
+    <td>
+      436
+    </td>
+    <td
+      className="text-right validator-nodes-text stake-text"
     >
-      20,814,924
-       
-      NEAR
-    </span>
-    <br />
-    <small>
-      +
       <span
         onBlur={[Function]}
         onFocus={[Function]}
         onMouseOut={[Function]}
         onMouseOver={[Function]}
       >
-        1,545
+        20,814,924
          
         NEAR
       </span>
-    </small>
-  </td>
-  <td>
-    <div
-      className="jsx-2437284421 cumulative-stake-chart"
-    >
-      <div
-        className="jsx-2437284421 total-value"
-        style={
-          Object {
-            "width": "50.15%",
-          }
-        }
-      />
-      <div
-        className="jsx-2437284421 current-value"
-        style={
-          Object {
-            "width": "24.57%",
-          }
-        }
-      />
-      <div
-        className="jsx-2437284421 cumulative-stake-label"
-      >
-        74.72%
-      </div>
-    </div>
-  </td>
-</tr>
-`;
-
-exports[`<ValidatorRow /> renders 'idle' Validators row with minimum data 1`] = `
-<tr
-  className="jsx-4079813474 table-row validator-nodes-row mx-0 "
->
-  <td
-    className="collapse-row-arrow"
-    onClick={[Function]}
-  >
-    <img
-      src="/static/images/icon-maximize.svg"
-      style={
-        Object {
-          "width": "16px",
-        }
-      }
-    />
-  </td>
-  <td
-    className="order"
-  >
-    4
-  </td>
-  <td
-    className="country-flag"
-  >
-    <div
-      style={
-        Object {
-          "backgroundColor": "#f0f0f1",
-          "color": "#72727a",
-          "display": "inline-block",
-          "fontSize": "8px",
-          "lineHeight": "16px",
-          "textAlign": "center",
-          "width": "22px",
-        }
-      }
-    >
-      ?
-    </div>
-  </td>
-  <td>
-    <div
-      className="align-items-center row no-gutters"
-    >
-      <div
-        className="validators-node-label col"
-      >
+      <br />
+      <small>
+        +
         <span
-          className="validating-label idle badge"
           onBlur={[Function]}
           onFocus={[Function]}
           onMouseOut={[Function]}
           onMouseOver={[Function]}
         >
-          Idle
+          1,545
+           
+          NEAR
         </span>
-      </div>
+      </small>
+    </td>
+    <td>
       <div
-        className="validator-name col"
+        className="cumulative-stake-chart"
       >
         <div
-          className="row no-gutters"
+          className="total-value"
+          style={
+            Object {
+              "width": "50.15%",
+            }
+          }
+        />
+        <div
+          className="current-value"
+          style={
+            Object {
+              "width": "24.57%",
+            }
+          }
+        />
+        <div
+          className="cumulative-stake-label"
+        >
+          74.72%
+        </div>
+        <style>
+          
+          .cumulative-stake-chart {
+            width: 100%;
+            height: 100%;
+            background-color: #f0f9ff;
+            position: relative;
+            display: flex;
+          }
+          .total-value,
+          .current-value {
+            display: block;
+            height: 75px;
+          }
+          .total-value {
+            background-color: #d6edff;
+          }
+          .current-value {
+            background-color: #8fcdff;
+          }
+          .cumulative-stake-label {
+            position: absolute;
+            top: 0;
+            right: 24px;
+            bottom: 0;
+            display: flex;
+            align-items: center;
+            color: #0072ce;
+            font-size: 14px;
+            font-weight: 500;
+            max-width: 75px;
+          }
+        
+        </style>
+      </div>
+    </td>
+  </tr>,
+  <style>
+    
+          .table-row {
+            background-color: #ffffff;
+            flex-wrap: nowrap;
+            white-space: nowrap;
+            box-shadow: inset 0px -1px 0px #f0f0f0;
+          }
+          .table-row td {
+            border-top: none;
+            vertical-align: middle;
+          }
+
+          .table-row td.order {
+            color: #a2a2a8;
+            font-size: 14px;
+            font-weight: 600;
+          }
+
+          .table-row .row {
+            flex-wrap: nowrap;
+          }
+
+          .table-row.expanded {
+            box-shadow: inset 4px 0px 0px #0598eb, inset 0px -1px 0px #f0f0f0,
+              inset 0px 1px 0px #2b9af4, inset -1px 0px 0px #2b9af4;
+            transition: height 0.5s 0.5s, opacity 0.5s;
+            margin-top: 16px;
+            margin-bottom: 16px;
+          }
+
+          .table-row.expanded + .table-expand-row {
+            box-shadow: inset 4px 0px 0px #0598eb, inset 0px -1px 0px #2b9af4,
+              inset -1px 0px 0px #2b9af4;
+            transition: height 0.5s 0.5s, opacity 0.5s;
+            height: auto;
+            opacity: 1;
+          }
+
+          .table-row.expanded:first-child {
+            margin-top: 0;
+          }
+        
+  </style>,
+  <style>
+    
+              @import url("https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@500&display=swap");
+
+              .collapse-row-arrow {
+                cursor: pointer;
+              }
+
+              .collapse-row-arrow.disable {
+                cursor: default;
+                opacity: 0.3;
+                pointer-events: none;
+                touch-action: none;
+              }
+
+              .validator-nodes-text {
+                font-weight: 500;
+                font-size: 14px;
+                color: #3f4045;
+              }
+
+              .validator-node-pub-key {
+                color: #2b9af4;
+              }
+
+              .validator-name {
+                max-width: 250px;
+              }
+
+              .validator-name .validator-nodes-text {
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+              }
+
+              .validator-nodes-details-title {
+                display: flex;
+                flex-wrap: nowrap;
+                font-size: 12px;
+                color: #a2a2a8;
+              }
+
+              .validator-nodes-text.uptime {
+                color: #72727a;
+              }
+
+              .validator-nodes-text.stake-text {
+                font-weight: 700;
+              }
+
+              .validator-nodes-content-row {
+                padding-top: 16px;
+                padding-bottom: 16px;
+              }
+
+              .validator-nodes-content-row &gt; .validator-nodes-content-cell {
+                padding: 0 22px;
+                border-right: 1px solid #e5e5e6;
+              }
+
+              .validator-nodes-content-row
+                &gt; .validator-nodes-content-cell:last-child {
+                border-right: none;
+              }
+
+              .agent-name-badge {
+                background-color: #f0f0f1;
+                color: #72727a;
+                font-weight: 500;
+                font-size: 12px;
+                font-family: "Roboto Mono", monospace;
+              }
+
+              .validators-node-label {
+                margin-right: 24px;
+                max-width: 138px;
+              }
+
+              .cumulative-stake-chart {
+                min-width: 100px;
+              }
+
+              .cumulative-stake-holders-row {
+                background-color: #fff6ed;
+              }
+              .cumulative-stake-holders-row .warning-text {
+                color: #995200;
+                padding: 16px 50px;
+                font-size: 12px;
+              }
+
+              @media (min-width: 1200px) {
+                .validator-name {
+                  max-width: 370px;
+                }
+              }
+            
+  </style>,
+]
+`;
+
+exports[`<ValidatorRow /> renders 'idle' Validators row with minimum data 1`] = `
+Array [
+  <tr
+    className="table-row validator-nodes-row mx-0 "
+  >
+    <td
+      className="collapse-row-arrow"
+      onClick={[Function]}
+    >
+      <img
+        src="/static/images/icon-maximize.svg"
+        style={
+          Object {
+            "width": "16px",
+          }
+        }
+      />
+    </td>
+    <td
+      className="order"
+    >
+      4
+    </td>
+    <td
+      className="country-flag"
+    >
+      <div
+        style={
+          Object {
+            "backgroundColor": "#f0f0f1",
+            "color": "#72727a",
+            "display": "inline-block",
+            "fontSize": "8px",
+            "lineHeight": "16px",
+            "textAlign": "center",
+            "width": "22px",
+          }
+        }
+      >
+        ?
+      </div>
+    </td>
+    <td>
+      <div
+        className="align-items-center row no-gutters"
+      >
+        <div
+          className="validators-node-label col"
+        >
+          <span
+            className="validating-label idle badge"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+          >
+            Idle
+            <style>
+              
+            .validating-label {
+              padding: 2px 8px;
+              border-radius: 50px;
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 150%;
+            }
+
+            .validating-label.active {
+              background-color: #c8f6e0;
+              color: #008d6a;
+            }
+
+            .validating-label.proposal {
+              background-color: #6ad1e3;
+              color: #11869a;
+            }
+
+            .validating-label.joining {
+              background-color: #ffc107;
+              color: #ffffff;
+            }
+
+            .validating-label.leaving {
+              background-color: #dc3545;
+              color: #ffffff;
+            }
+            .validating-label.idle {
+              background-color: #e5e5e6;
+              color: #72727a;
+            }
+            .validating-label.on-hold {
+              background-color: #2d9cdb;
+              color: #ffffff;
+            }
+            .validating-label.newcomer {
+              background-color: #f2994a;
+              color: #ffffff;
+            }
+          
+            </style>
+          </span>
+        </div>
+        <div
+          className="validator-name col"
         >
           <div
-            className="validator-nodes-text col"
-            title="@sphere.poolv1.near"
+            className="row no-gutters"
           >
-            sphere.poolv1.near
+            <div
+              className="validator-nodes-text col"
+              title="@sphere.poolv1.near"
+            >
+              sphere.poolv1.near
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  </td>
-  <td>
-    8%
-  </td>
-  <td>
-    1
-  </td>
-  <td
-    className="text-right validator-nodes-text stake-text"
-  >
-    <span
-      onBlur={[Function]}
-      onFocus={[Function]}
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
+    </td>
+    <td>
+      8%
+    </td>
+    <td>
+      1
+    </td>
+    <td
+      className="text-right validator-nodes-text stake-text"
     >
-      50
-       
-      NEAR
-    </span>
-  </td>
-  <td>
-    <div
-      className="jsx-2437284421 cumulative-stake-chart"
-    >
-      <div
-        className="jsx-2437284421 total-value"
-        style={
-          Object {
-            "width": "0%",
-          }
-        }
-      />
-      <div
-        className="jsx-2437284421 current-value"
-        style={
-          Object {
-            "width": "0%",
-          }
-        }
-      />
-      <div
-        className="jsx-2437284421 cumulative-stake-label"
+      <span
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
       >
-        N/A
+        50
+         
+        NEAR
+      </span>
+    </td>
+    <td>
+      <div
+        className="cumulative-stake-chart"
+      >
+        <div
+          className="total-value"
+          style={
+            Object {
+              "width": "0%",
+            }
+          }
+        />
+        <div
+          className="current-value"
+          style={
+            Object {
+              "width": "0%",
+            }
+          }
+        />
+        <div
+          className="cumulative-stake-label"
+        >
+          N/A
+        </div>
+        <style>
+          
+          .cumulative-stake-chart {
+            width: 100%;
+            height: 100%;
+            background-color: #f0f9ff;
+            position: relative;
+            display: flex;
+          }
+          .total-value,
+          .current-value {
+            display: block;
+            height: 75px;
+          }
+          .total-value {
+            background-color: #d6edff;
+          }
+          .current-value {
+            background-color: #8fcdff;
+          }
+          .cumulative-stake-label {
+            position: absolute;
+            top: 0;
+            right: 24px;
+            bottom: 0;
+            display: flex;
+            align-items: center;
+            color: #0072ce;
+            font-size: 14px;
+            font-weight: 500;
+            max-width: 75px;
+          }
+        
+        </style>
       </div>
-    </div>
-  </td>
-</tr>
+    </td>
+  </tr>,
+  <style>
+    
+          .table-row {
+            background-color: #ffffff;
+            flex-wrap: nowrap;
+            white-space: nowrap;
+            box-shadow: inset 0px -1px 0px #f0f0f0;
+          }
+          .table-row td {
+            border-top: none;
+            vertical-align: middle;
+          }
+
+          .table-row td.order {
+            color: #a2a2a8;
+            font-size: 14px;
+            font-weight: 600;
+          }
+
+          .table-row .row {
+            flex-wrap: nowrap;
+          }
+
+          .table-row.expanded {
+            box-shadow: inset 4px 0px 0px #0598eb, inset 0px -1px 0px #f0f0f0,
+              inset 0px 1px 0px #2b9af4, inset -1px 0px 0px #2b9af4;
+            transition: height 0.5s 0.5s, opacity 0.5s;
+            margin-top: 16px;
+            margin-bottom: 16px;
+          }
+
+          .table-row.expanded + .table-expand-row {
+            box-shadow: inset 4px 0px 0px #0598eb, inset 0px -1px 0px #2b9af4,
+              inset -1px 0px 0px #2b9af4;
+            transition: height 0.5s 0.5s, opacity 0.5s;
+            height: auto;
+            opacity: 1;
+          }
+
+          .table-row.expanded:first-child {
+            margin-top: 0;
+          }
+        
+  </style>,
+  <style>
+    
+              @import url("https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@500&display=swap");
+
+              .collapse-row-arrow {
+                cursor: pointer;
+              }
+
+              .collapse-row-arrow.disable {
+                cursor: default;
+                opacity: 0.3;
+                pointer-events: none;
+                touch-action: none;
+              }
+
+              .validator-nodes-text {
+                font-weight: 500;
+                font-size: 14px;
+                color: #3f4045;
+              }
+
+              .validator-node-pub-key {
+                color: #2b9af4;
+              }
+
+              .validator-name {
+                max-width: 250px;
+              }
+
+              .validator-name .validator-nodes-text {
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+              }
+
+              .validator-nodes-details-title {
+                display: flex;
+                flex-wrap: nowrap;
+                font-size: 12px;
+                color: #a2a2a8;
+              }
+
+              .validator-nodes-text.uptime {
+                color: #72727a;
+              }
+
+              .validator-nodes-text.stake-text {
+                font-weight: 700;
+              }
+
+              .validator-nodes-content-row {
+                padding-top: 16px;
+                padding-bottom: 16px;
+              }
+
+              .validator-nodes-content-row &gt; .validator-nodes-content-cell {
+                padding: 0 22px;
+                border-right: 1px solid #e5e5e6;
+              }
+
+              .validator-nodes-content-row
+                &gt; .validator-nodes-content-cell:last-child {
+                border-right: none;
+              }
+
+              .agent-name-badge {
+                background-color: #f0f0f1;
+                color: #72727a;
+                font-weight: 500;
+                font-size: 12px;
+                font-family: "Roboto Mono", monospace;
+              }
+
+              .validators-node-label {
+                margin-right: 24px;
+                max-width: 138px;
+              }
+
+              .cumulative-stake-chart {
+                min-width: 100px;
+              }
+
+              .cumulative-stake-holders-row {
+                background-color: #fff6ed;
+              }
+              .cumulative-stake-holders-row .warning-text {
+                color: #995200;
+                padding: 16px 50px;
+                font-size: 12px;
+              }
+
+              @media (min-width: 1200px) {
+                .validator-name {
+                  max-width: 370px;
+                }
+              }
+            
+  </style>,
+]
 `;
 
 exports[`<ValidatorRow /> renders simple 'active' Validators row 1`] = `
 Array [
   <tr
-    className="jsx-4079813474 table-row validator-nodes-row mx-0 "
+    className="table-row validator-nodes-row mx-0 "
   >
     <td
       className="collapse-row-arrow"
@@ -479,6 +1142,49 @@ Array [
             onMouseOver={[Function]}
           >
             Active
+            <style>
+              
+            .validating-label {
+              padding: 2px 8px;
+              border-radius: 50px;
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 150%;
+            }
+
+            .validating-label.active {
+              background-color: #c8f6e0;
+              color: #008d6a;
+            }
+
+            .validating-label.proposal {
+              background-color: #6ad1e3;
+              color: #11869a;
+            }
+
+            .validating-label.joining {
+              background-color: #ffc107;
+              color: #ffffff;
+            }
+
+            .validating-label.leaving {
+              background-color: #dc3545;
+              color: #ffffff;
+            }
+            .validating-label.idle {
+              background-color: #e5e5e6;
+              color: #72727a;
+            }
+            .validating-label.on-hold {
+              background-color: #2d9cdb;
+              color: #ffffff;
+            }
+            .validating-label.newcomer {
+              background-color: #f2994a;
+              color: #ffffff;
+            }
+          
+            </style>
           </span>
         </div>
         <div
@@ -543,10 +1249,10 @@ Array [
     </td>
     <td>
       <div
-        className="jsx-2437284421 cumulative-stake-chart"
+        className="cumulative-stake-chart"
       >
         <div
-          className="jsx-2437284421 total-value"
+          className="total-value"
           style={
             Object {
               "width": "0%",
@@ -554,7 +1260,7 @@ Array [
           }
         />
         <div
-          className="jsx-2437284421 current-value"
+          className="current-value"
           style={
             Object {
               "width": "50.14%",
@@ -562,22 +1268,198 @@ Array [
           }
         />
         <div
-          className="jsx-2437284421 cumulative-stake-label"
+          className="cumulative-stake-label"
         >
           50.14%
         </div>
+        <style>
+          
+          .cumulative-stake-chart {
+            width: 100%;
+            height: 100%;
+            background-color: #f0f9ff;
+            position: relative;
+            display: flex;
+          }
+          .total-value,
+          .current-value {
+            display: block;
+            height: 75px;
+          }
+          .total-value {
+            background-color: #d6edff;
+          }
+          .current-value {
+            background-color: #8fcdff;
+          }
+          .cumulative-stake-label {
+            position: absolute;
+            top: 0;
+            right: 24px;
+            bottom: 0;
+            display: flex;
+            align-items: center;
+            color: #0072ce;
+            font-size: 14px;
+            font-weight: 500;
+            max-width: 75px;
+          }
+        
+        </style>
       </div>
     </td>
   </tr>,
+  <style>
+    
+          .table-row {
+            background-color: #ffffff;
+            flex-wrap: nowrap;
+            white-space: nowrap;
+            box-shadow: inset 0px -1px 0px #f0f0f0;
+          }
+          .table-row td {
+            border-top: none;
+            vertical-align: middle;
+          }
+
+          .table-row td.order {
+            color: #a2a2a8;
+            font-size: 14px;
+            font-weight: 600;
+          }
+
+          .table-row .row {
+            flex-wrap: nowrap;
+          }
+
+          .table-row.expanded {
+            box-shadow: inset 4px 0px 0px #0598eb, inset 0px -1px 0px #f0f0f0,
+              inset 0px 1px 0px #2b9af4, inset -1px 0px 0px #2b9af4;
+            transition: height 0.5s 0.5s, opacity 0.5s;
+            margin-top: 16px;
+            margin-bottom: 16px;
+          }
+
+          .table-row.expanded + .table-expand-row {
+            box-shadow: inset 4px 0px 0px #0598eb, inset 0px -1px 0px #2b9af4,
+              inset -1px 0px 0px #2b9af4;
+            transition: height 0.5s 0.5s, opacity 0.5s;
+            height: auto;
+            opacity: 1;
+          }
+
+          .table-row.expanded:first-child {
+            margin-top: 0;
+          }
+        
+  </style>,
   <tr
-    className="jsx-1966533806 cumulative-stake-holders-row"
+    className="cumulative-stake-holders-row"
   >
     <td
-      className="jsx-1966533806 warning-text text-center"
+      className="warning-text text-center"
       colSpan={8}
     >
       Validators 1 - 1 hold a cumulative stake above 33%. Delegating to the validators below improves the decentralization of the network.
     </td>
   </tr>,
+  <style>
+    
+              @import url("https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@500&display=swap");
+
+              .collapse-row-arrow {
+                cursor: pointer;
+              }
+
+              .collapse-row-arrow.disable {
+                cursor: default;
+                opacity: 0.3;
+                pointer-events: none;
+                touch-action: none;
+              }
+
+              .validator-nodes-text {
+                font-weight: 500;
+                font-size: 14px;
+                color: #3f4045;
+              }
+
+              .validator-node-pub-key {
+                color: #2b9af4;
+              }
+
+              .validator-name {
+                max-width: 250px;
+              }
+
+              .validator-name .validator-nodes-text {
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+              }
+
+              .validator-nodes-details-title {
+                display: flex;
+                flex-wrap: nowrap;
+                font-size: 12px;
+                color: #a2a2a8;
+              }
+
+              .validator-nodes-text.uptime {
+                color: #72727a;
+              }
+
+              .validator-nodes-text.stake-text {
+                font-weight: 700;
+              }
+
+              .validator-nodes-content-row {
+                padding-top: 16px;
+                padding-bottom: 16px;
+              }
+
+              .validator-nodes-content-row &gt; .validator-nodes-content-cell {
+                padding: 0 22px;
+                border-right: 1px solid #e5e5e6;
+              }
+
+              .validator-nodes-content-row
+                &gt; .validator-nodes-content-cell:last-child {
+                border-right: none;
+              }
+
+              .agent-name-badge {
+                background-color: #f0f0f1;
+                color: #72727a;
+                font-weight: 500;
+                font-size: 12px;
+                font-family: "Roboto Mono", monospace;
+              }
+
+              .validators-node-label {
+                margin-right: 24px;
+                max-width: 138px;
+              }
+
+              .cumulative-stake-chart {
+                min-width: 100px;
+              }
+
+              .cumulative-stake-holders-row {
+                background-color: #fff6ed;
+              }
+              .cumulative-stake-holders-row .warning-text {
+                color: #995200;
+                padding: 16px 50px;
+                font-size: 12px;
+              }
+
+              @media (min-width: 1200px) {
+                .validator-name {
+                  max-width: 370px;
+                }
+              }
+            
+  </style>,
 ]
 `;

--- a/frontend/src/components/nodes/__test__/__snapshots__/ValidatorsList.test.tsx.snap
+++ b/frontend/src/components/nodes/__test__/__snapshots__/ValidatorsList.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<ValidatorsList /> renders validators list 1`] = `
 Array [
   <tr
-    className="jsx-4079813474 table-row validator-nodes-row mx-0 "
+    className="table-row validator-nodes-row mx-0 "
   >
     <td
       className="collapse-row-arrow"
@@ -57,6 +57,49 @@ Array [
             onMouseOver={[Function]}
           >
             Active
+            <style>
+              
+            .validating-label {
+              padding: 2px 8px;
+              border-radius: 50px;
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 150%;
+            }
+
+            .validating-label.active {
+              background-color: #c8f6e0;
+              color: #008d6a;
+            }
+
+            .validating-label.proposal {
+              background-color: #6ad1e3;
+              color: #11869a;
+            }
+
+            .validating-label.joining {
+              background-color: #ffc107;
+              color: #ffffff;
+            }
+
+            .validating-label.leaving {
+              background-color: #dc3545;
+              color: #ffffff;
+            }
+            .validating-label.idle {
+              background-color: #e5e5e6;
+              color: #72727a;
+            }
+            .validating-label.on-hold {
+              background-color: #2d9cdb;
+              color: #ffffff;
+            }
+            .validating-label.newcomer {
+              background-color: #f2994a;
+              color: #ffffff;
+            }
+          
+            </style>
           </span>
         </div>
         <div
@@ -121,10 +164,10 @@ Array [
     </td>
     <td>
       <div
-        className="jsx-2437284421 cumulative-stake-chart"
+        className="cumulative-stake-chart"
       >
         <div
-          className="jsx-2437284421 total-value"
+          className="total-value"
           style={
             Object {
               "width": "0%",
@@ -132,7 +175,7 @@ Array [
           }
         />
         <div
-          className="jsx-2437284421 current-value"
+          className="current-value"
           style={
             Object {
               "width": "50.14%",
@@ -140,25 +183,201 @@ Array [
           }
         />
         <div
-          className="jsx-2437284421 cumulative-stake-label"
+          className="cumulative-stake-label"
         >
           50.14%
         </div>
+        <style>
+          
+          .cumulative-stake-chart {
+            width: 100%;
+            height: 100%;
+            background-color: #f0f9ff;
+            position: relative;
+            display: flex;
+          }
+          .total-value,
+          .current-value {
+            display: block;
+            height: 75px;
+          }
+          .total-value {
+            background-color: #d6edff;
+          }
+          .current-value {
+            background-color: #8fcdff;
+          }
+          .cumulative-stake-label {
+            position: absolute;
+            top: 0;
+            right: 24px;
+            bottom: 0;
+            display: flex;
+            align-items: center;
+            color: #0072ce;
+            font-size: 14px;
+            font-weight: 500;
+            max-width: 75px;
+          }
+        
+        </style>
       </div>
     </td>
   </tr>,
+  <style>
+    
+          .table-row {
+            background-color: #ffffff;
+            flex-wrap: nowrap;
+            white-space: nowrap;
+            box-shadow: inset 0px -1px 0px #f0f0f0;
+          }
+          .table-row td {
+            border-top: none;
+            vertical-align: middle;
+          }
+
+          .table-row td.order {
+            color: #a2a2a8;
+            font-size: 14px;
+            font-weight: 600;
+          }
+
+          .table-row .row {
+            flex-wrap: nowrap;
+          }
+
+          .table-row.expanded {
+            box-shadow: inset 4px 0px 0px #0598eb, inset 0px -1px 0px #f0f0f0,
+              inset 0px 1px 0px #2b9af4, inset -1px 0px 0px #2b9af4;
+            transition: height 0.5s 0.5s, opacity 0.5s;
+            margin-top: 16px;
+            margin-bottom: 16px;
+          }
+
+          .table-row.expanded + .table-expand-row {
+            box-shadow: inset 4px 0px 0px #0598eb, inset 0px -1px 0px #2b9af4,
+              inset -1px 0px 0px #2b9af4;
+            transition: height 0.5s 0.5s, opacity 0.5s;
+            height: auto;
+            opacity: 1;
+          }
+
+          .table-row.expanded:first-child {
+            margin-top: 0;
+          }
+        
+  </style>,
   <tr
-    className="jsx-1966533806 cumulative-stake-holders-row"
+    className="cumulative-stake-holders-row"
   >
     <td
-      className="jsx-1966533806 warning-text text-center"
+      className="warning-text text-center"
       colSpan={8}
     >
       Validators 1 - 25 hold a cumulative stake above 33%. Delegating to the validators below improves the decentralization of the network.
     </td>
   </tr>,
+  <style>
+    
+              @import url("https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@500&display=swap");
+
+              .collapse-row-arrow {
+                cursor: pointer;
+              }
+
+              .collapse-row-arrow.disable {
+                cursor: default;
+                opacity: 0.3;
+                pointer-events: none;
+                touch-action: none;
+              }
+
+              .validator-nodes-text {
+                font-weight: 500;
+                font-size: 14px;
+                color: #3f4045;
+              }
+
+              .validator-node-pub-key {
+                color: #2b9af4;
+              }
+
+              .validator-name {
+                max-width: 250px;
+              }
+
+              .validator-name .validator-nodes-text {
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+              }
+
+              .validator-nodes-details-title {
+                display: flex;
+                flex-wrap: nowrap;
+                font-size: 12px;
+                color: #a2a2a8;
+              }
+
+              .validator-nodes-text.uptime {
+                color: #72727a;
+              }
+
+              .validator-nodes-text.stake-text {
+                font-weight: 700;
+              }
+
+              .validator-nodes-content-row {
+                padding-top: 16px;
+                padding-bottom: 16px;
+              }
+
+              .validator-nodes-content-row &gt; .validator-nodes-content-cell {
+                padding: 0 22px;
+                border-right: 1px solid #e5e5e6;
+              }
+
+              .validator-nodes-content-row
+                &gt; .validator-nodes-content-cell:last-child {
+                border-right: none;
+              }
+
+              .agent-name-badge {
+                background-color: #f0f0f1;
+                color: #72727a;
+                font-weight: 500;
+                font-size: 12px;
+                font-family: "Roboto Mono", monospace;
+              }
+
+              .validators-node-label {
+                margin-right: 24px;
+                max-width: 138px;
+              }
+
+              .cumulative-stake-chart {
+                min-width: 100px;
+              }
+
+              .cumulative-stake-holders-row {
+                background-color: #fff6ed;
+              }
+              .cumulative-stake-holders-row .warning-text {
+                color: #995200;
+                padding: 16px 50px;
+                font-size: 12px;
+              }
+
+              @media (min-width: 1200px) {
+                .validator-name {
+                  max-width: 370px;
+                }
+              }
+            
+  </style>,
   <tr
-    className="jsx-4079813474 table-row validator-nodes-row mx-0 "
+    className="table-row validator-nodes-row mx-0 "
   >
     <td
       className="collapse-row-arrow"
@@ -212,6 +431,49 @@ Array [
             onMouseOver={[Function]}
           >
             Active
+            <style>
+              
+            .validating-label {
+              padding: 2px 8px;
+              border-radius: 50px;
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 150%;
+            }
+
+            .validating-label.active {
+              background-color: #c8f6e0;
+              color: #008d6a;
+            }
+
+            .validating-label.proposal {
+              background-color: #6ad1e3;
+              color: #11869a;
+            }
+
+            .validating-label.joining {
+              background-color: #ffc107;
+              color: #ffffff;
+            }
+
+            .validating-label.leaving {
+              background-color: #dc3545;
+              color: #ffffff;
+            }
+            .validating-label.idle {
+              background-color: #e5e5e6;
+              color: #72727a;
+            }
+            .validating-label.on-hold {
+              background-color: #2d9cdb;
+              color: #ffffff;
+            }
+            .validating-label.newcomer {
+              background-color: #f2994a;
+              color: #ffffff;
+            }
+          
+            </style>
           </span>
         </div>
         <div
@@ -276,10 +538,10 @@ Array [
     </td>
     <td>
       <div
-        className="jsx-2437284421 cumulative-stake-chart"
+        className="cumulative-stake-chart"
       >
         <div
-          className="jsx-2437284421 total-value"
+          className="total-value"
           style={
             Object {
               "width": "50.15%",
@@ -287,7 +549,7 @@ Array [
           }
         />
         <div
-          className="jsx-2437284421 current-value"
+          className="current-value"
           style={
             Object {
               "width": "24.57%",
@@ -295,15 +557,191 @@ Array [
           }
         />
         <div
-          className="jsx-2437284421 cumulative-stake-label"
+          className="cumulative-stake-label"
         >
           74.72%
         </div>
+        <style>
+          
+          .cumulative-stake-chart {
+            width: 100%;
+            height: 100%;
+            background-color: #f0f9ff;
+            position: relative;
+            display: flex;
+          }
+          .total-value,
+          .current-value {
+            display: block;
+            height: 75px;
+          }
+          .total-value {
+            background-color: #d6edff;
+          }
+          .current-value {
+            background-color: #8fcdff;
+          }
+          .cumulative-stake-label {
+            position: absolute;
+            top: 0;
+            right: 24px;
+            bottom: 0;
+            display: flex;
+            align-items: center;
+            color: #0072ce;
+            font-size: 14px;
+            font-weight: 500;
+            max-width: 75px;
+          }
+        
+        </style>
       </div>
     </td>
   </tr>,
+  <style>
+    
+          .table-row {
+            background-color: #ffffff;
+            flex-wrap: nowrap;
+            white-space: nowrap;
+            box-shadow: inset 0px -1px 0px #f0f0f0;
+          }
+          .table-row td {
+            border-top: none;
+            vertical-align: middle;
+          }
+
+          .table-row td.order {
+            color: #a2a2a8;
+            font-size: 14px;
+            font-weight: 600;
+          }
+
+          .table-row .row {
+            flex-wrap: nowrap;
+          }
+
+          .table-row.expanded {
+            box-shadow: inset 4px 0px 0px #0598eb, inset 0px -1px 0px #f0f0f0,
+              inset 0px 1px 0px #2b9af4, inset -1px 0px 0px #2b9af4;
+            transition: height 0.5s 0.5s, opacity 0.5s;
+            margin-top: 16px;
+            margin-bottom: 16px;
+          }
+
+          .table-row.expanded + .table-expand-row {
+            box-shadow: inset 4px 0px 0px #0598eb, inset 0px -1px 0px #2b9af4,
+              inset -1px 0px 0px #2b9af4;
+            transition: height 0.5s 0.5s, opacity 0.5s;
+            height: auto;
+            opacity: 1;
+          }
+
+          .table-row.expanded:first-child {
+            margin-top: 0;
+          }
+        
+  </style>,
+  <style>
+    
+              @import url("https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@500&display=swap");
+
+              .collapse-row-arrow {
+                cursor: pointer;
+              }
+
+              .collapse-row-arrow.disable {
+                cursor: default;
+                opacity: 0.3;
+                pointer-events: none;
+                touch-action: none;
+              }
+
+              .validator-nodes-text {
+                font-weight: 500;
+                font-size: 14px;
+                color: #3f4045;
+              }
+
+              .validator-node-pub-key {
+                color: #2b9af4;
+              }
+
+              .validator-name {
+                max-width: 250px;
+              }
+
+              .validator-name .validator-nodes-text {
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+              }
+
+              .validator-nodes-details-title {
+                display: flex;
+                flex-wrap: nowrap;
+                font-size: 12px;
+                color: #a2a2a8;
+              }
+
+              .validator-nodes-text.uptime {
+                color: #72727a;
+              }
+
+              .validator-nodes-text.stake-text {
+                font-weight: 700;
+              }
+
+              .validator-nodes-content-row {
+                padding-top: 16px;
+                padding-bottom: 16px;
+              }
+
+              .validator-nodes-content-row &gt; .validator-nodes-content-cell {
+                padding: 0 22px;
+                border-right: 1px solid #e5e5e6;
+              }
+
+              .validator-nodes-content-row
+                &gt; .validator-nodes-content-cell:last-child {
+                border-right: none;
+              }
+
+              .agent-name-badge {
+                background-color: #f0f0f1;
+                color: #72727a;
+                font-weight: 500;
+                font-size: 12px;
+                font-family: "Roboto Mono", monospace;
+              }
+
+              .validators-node-label {
+                margin-right: 24px;
+                max-width: 138px;
+              }
+
+              .cumulative-stake-chart {
+                min-width: 100px;
+              }
+
+              .cumulative-stake-holders-row {
+                background-color: #fff6ed;
+              }
+              .cumulative-stake-holders-row .warning-text {
+                color: #995200;
+                padding: 16px 50px;
+                font-size: 12px;
+              }
+
+              @media (min-width: 1200px) {
+                .validator-name {
+                  max-width: 370px;
+                }
+              }
+            
+  </style>,
   <tr
-    className="jsx-4079813474 table-row validator-nodes-row mx-0 "
+    className="table-row validator-nodes-row mx-0 "
   >
     <td
       className="collapse-row-arrow"
@@ -359,6 +797,49 @@ Array [
             onMouseOver={[Function]}
           >
             Active
+            <style>
+              
+            .validating-label {
+              padding: 2px 8px;
+              border-radius: 50px;
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 150%;
+            }
+
+            .validating-label.active {
+              background-color: #c8f6e0;
+              color: #008d6a;
+            }
+
+            .validating-label.proposal {
+              background-color: #6ad1e3;
+              color: #11869a;
+            }
+
+            .validating-label.joining {
+              background-color: #ffc107;
+              color: #ffffff;
+            }
+
+            .validating-label.leaving {
+              background-color: #dc3545;
+              color: #ffffff;
+            }
+            .validating-label.idle {
+              background-color: #e5e5e6;
+              color: #72727a;
+            }
+            .validating-label.on-hold {
+              background-color: #2d9cdb;
+              color: #ffffff;
+            }
+            .validating-label.newcomer {
+              background-color: #f2994a;
+              color: #ffffff;
+            }
+          
+            </style>
           </span>
         </div>
         <div
@@ -423,10 +904,10 @@ Array [
     </td>
     <td>
       <div
-        className="jsx-2437284421 cumulative-stake-chart"
+        className="cumulative-stake-chart"
       >
         <div
-          className="jsx-2437284421 total-value"
+          className="total-value"
           style={
             Object {
               "width": "74.72999999999999%",
@@ -434,7 +915,7 @@ Array [
           }
         />
         <div
-          className="jsx-2437284421 current-value"
+          className="current-value"
           style={
             Object {
               "width": "20.980000000000004%",
@@ -442,15 +923,191 @@ Array [
           }
         />
         <div
-          className="jsx-2437284421 cumulative-stake-label"
+          className="cumulative-stake-label"
         >
           95.71%
         </div>
+        <style>
+          
+          .cumulative-stake-chart {
+            width: 100%;
+            height: 100%;
+            background-color: #f0f9ff;
+            position: relative;
+            display: flex;
+          }
+          .total-value,
+          .current-value {
+            display: block;
+            height: 75px;
+          }
+          .total-value {
+            background-color: #d6edff;
+          }
+          .current-value {
+            background-color: #8fcdff;
+          }
+          .cumulative-stake-label {
+            position: absolute;
+            top: 0;
+            right: 24px;
+            bottom: 0;
+            display: flex;
+            align-items: center;
+            color: #0072ce;
+            font-size: 14px;
+            font-weight: 500;
+            max-width: 75px;
+          }
+        
+        </style>
       </div>
     </td>
   </tr>,
+  <style>
+    
+          .table-row {
+            background-color: #ffffff;
+            flex-wrap: nowrap;
+            white-space: nowrap;
+            box-shadow: inset 0px -1px 0px #f0f0f0;
+          }
+          .table-row td {
+            border-top: none;
+            vertical-align: middle;
+          }
+
+          .table-row td.order {
+            color: #a2a2a8;
+            font-size: 14px;
+            font-weight: 600;
+          }
+
+          .table-row .row {
+            flex-wrap: nowrap;
+          }
+
+          .table-row.expanded {
+            box-shadow: inset 4px 0px 0px #0598eb, inset 0px -1px 0px #f0f0f0,
+              inset 0px 1px 0px #2b9af4, inset -1px 0px 0px #2b9af4;
+            transition: height 0.5s 0.5s, opacity 0.5s;
+            margin-top: 16px;
+            margin-bottom: 16px;
+          }
+
+          .table-row.expanded + .table-expand-row {
+            box-shadow: inset 4px 0px 0px #0598eb, inset 0px -1px 0px #2b9af4,
+              inset -1px 0px 0px #2b9af4;
+            transition: height 0.5s 0.5s, opacity 0.5s;
+            height: auto;
+            opacity: 1;
+          }
+
+          .table-row.expanded:first-child {
+            margin-top: 0;
+          }
+        
+  </style>,
+  <style>
+    
+              @import url("https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@500&display=swap");
+
+              .collapse-row-arrow {
+                cursor: pointer;
+              }
+
+              .collapse-row-arrow.disable {
+                cursor: default;
+                opacity: 0.3;
+                pointer-events: none;
+                touch-action: none;
+              }
+
+              .validator-nodes-text {
+                font-weight: 500;
+                font-size: 14px;
+                color: #3f4045;
+              }
+
+              .validator-node-pub-key {
+                color: #2b9af4;
+              }
+
+              .validator-name {
+                max-width: 250px;
+              }
+
+              .validator-name .validator-nodes-text {
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+              }
+
+              .validator-nodes-details-title {
+                display: flex;
+                flex-wrap: nowrap;
+                font-size: 12px;
+                color: #a2a2a8;
+              }
+
+              .validator-nodes-text.uptime {
+                color: #72727a;
+              }
+
+              .validator-nodes-text.stake-text {
+                font-weight: 700;
+              }
+
+              .validator-nodes-content-row {
+                padding-top: 16px;
+                padding-bottom: 16px;
+              }
+
+              .validator-nodes-content-row &gt; .validator-nodes-content-cell {
+                padding: 0 22px;
+                border-right: 1px solid #e5e5e6;
+              }
+
+              .validator-nodes-content-row
+                &gt; .validator-nodes-content-cell:last-child {
+                border-right: none;
+              }
+
+              .agent-name-badge {
+                background-color: #f0f0f1;
+                color: #72727a;
+                font-weight: 500;
+                font-size: 12px;
+                font-family: "Roboto Mono", monospace;
+              }
+
+              .validators-node-label {
+                margin-right: 24px;
+                max-width: 138px;
+              }
+
+              .cumulative-stake-chart {
+                min-width: 100px;
+              }
+
+              .cumulative-stake-holders-row {
+                background-color: #fff6ed;
+              }
+              .cumulative-stake-holders-row .warning-text {
+                color: #995200;
+                padding: 16px 50px;
+                font-size: 12px;
+              }
+
+              @media (min-width: 1200px) {
+                .validator-name {
+                  max-width: 370px;
+                }
+              }
+            
+  </style>,
   <tr
-    className="jsx-4079813474 table-row validator-nodes-row mx-0 "
+    className="table-row validator-nodes-row mx-0 "
   >
     <td
       className="collapse-row-arrow"
@@ -504,6 +1161,49 @@ Array [
             onMouseOver={[Function]}
           >
             Joining
+            <style>
+              
+            .validating-label {
+              padding: 2px 8px;
+              border-radius: 50px;
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 150%;
+            }
+
+            .validating-label.active {
+              background-color: #c8f6e0;
+              color: #008d6a;
+            }
+
+            .validating-label.proposal {
+              background-color: #6ad1e3;
+              color: #11869a;
+            }
+
+            .validating-label.joining {
+              background-color: #ffc107;
+              color: #ffffff;
+            }
+
+            .validating-label.leaving {
+              background-color: #dc3545;
+              color: #ffffff;
+            }
+            .validating-label.idle {
+              background-color: #e5e5e6;
+              color: #72727a;
+            }
+            .validating-label.on-hold {
+              background-color: #2d9cdb;
+              color: #ffffff;
+            }
+            .validating-label.newcomer {
+              background-color: #f2994a;
+              color: #ffffff;
+            }
+          
+            </style>
           </span>
         </div>
         <div
@@ -568,10 +1268,10 @@ Array [
     </td>
     <td>
       <div
-        className="jsx-2437284421 cumulative-stake-chart"
+        className="cumulative-stake-chart"
       >
         <div
-          className="jsx-2437284421 total-value"
+          className="total-value"
           style={
             Object {
               "width": "-4.41%",
@@ -579,7 +1279,7 @@ Array [
           }
         />
         <div
-          className="jsx-2437284421 current-value"
+          className="current-value"
           style={
             Object {
               "width": "0%",
@@ -587,15 +1287,191 @@ Array [
           }
         />
         <div
-          className="jsx-2437284421 cumulative-stake-label"
+          className="cumulative-stake-label"
         >
           N/A
         </div>
+        <style>
+          
+          .cumulative-stake-chart {
+            width: 100%;
+            height: 100%;
+            background-color: #f0f9ff;
+            position: relative;
+            display: flex;
+          }
+          .total-value,
+          .current-value {
+            display: block;
+            height: 75px;
+          }
+          .total-value {
+            background-color: #d6edff;
+          }
+          .current-value {
+            background-color: #8fcdff;
+          }
+          .cumulative-stake-label {
+            position: absolute;
+            top: 0;
+            right: 24px;
+            bottom: 0;
+            display: flex;
+            align-items: center;
+            color: #0072ce;
+            font-size: 14px;
+            font-weight: 500;
+            max-width: 75px;
+          }
+        
+        </style>
       </div>
     </td>
   </tr>,
+  <style>
+    
+          .table-row {
+            background-color: #ffffff;
+            flex-wrap: nowrap;
+            white-space: nowrap;
+            box-shadow: inset 0px -1px 0px #f0f0f0;
+          }
+          .table-row td {
+            border-top: none;
+            vertical-align: middle;
+          }
+
+          .table-row td.order {
+            color: #a2a2a8;
+            font-size: 14px;
+            font-weight: 600;
+          }
+
+          .table-row .row {
+            flex-wrap: nowrap;
+          }
+
+          .table-row.expanded {
+            box-shadow: inset 4px 0px 0px #0598eb, inset 0px -1px 0px #f0f0f0,
+              inset 0px 1px 0px #2b9af4, inset -1px 0px 0px #2b9af4;
+            transition: height 0.5s 0.5s, opacity 0.5s;
+            margin-top: 16px;
+            margin-bottom: 16px;
+          }
+
+          .table-row.expanded + .table-expand-row {
+            box-shadow: inset 4px 0px 0px #0598eb, inset 0px -1px 0px #2b9af4,
+              inset -1px 0px 0px #2b9af4;
+            transition: height 0.5s 0.5s, opacity 0.5s;
+            height: auto;
+            opacity: 1;
+          }
+
+          .table-row.expanded:first-child {
+            margin-top: 0;
+          }
+        
+  </style>,
+  <style>
+    
+              @import url("https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@500&display=swap");
+
+              .collapse-row-arrow {
+                cursor: pointer;
+              }
+
+              .collapse-row-arrow.disable {
+                cursor: default;
+                opacity: 0.3;
+                pointer-events: none;
+                touch-action: none;
+              }
+
+              .validator-nodes-text {
+                font-weight: 500;
+                font-size: 14px;
+                color: #3f4045;
+              }
+
+              .validator-node-pub-key {
+                color: #2b9af4;
+              }
+
+              .validator-name {
+                max-width: 250px;
+              }
+
+              .validator-name .validator-nodes-text {
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+              }
+
+              .validator-nodes-details-title {
+                display: flex;
+                flex-wrap: nowrap;
+                font-size: 12px;
+                color: #a2a2a8;
+              }
+
+              .validator-nodes-text.uptime {
+                color: #72727a;
+              }
+
+              .validator-nodes-text.stake-text {
+                font-weight: 700;
+              }
+
+              .validator-nodes-content-row {
+                padding-top: 16px;
+                padding-bottom: 16px;
+              }
+
+              .validator-nodes-content-row &gt; .validator-nodes-content-cell {
+                padding: 0 22px;
+                border-right: 1px solid #e5e5e6;
+              }
+
+              .validator-nodes-content-row
+                &gt; .validator-nodes-content-cell:last-child {
+                border-right: none;
+              }
+
+              .agent-name-badge {
+                background-color: #f0f0f1;
+                color: #72727a;
+                font-weight: 500;
+                font-size: 12px;
+                font-family: "Roboto Mono", monospace;
+              }
+
+              .validators-node-label {
+                margin-right: 24px;
+                max-width: 138px;
+              }
+
+              .cumulative-stake-chart {
+                min-width: 100px;
+              }
+
+              .cumulative-stake-holders-row {
+                background-color: #fff6ed;
+              }
+              .cumulative-stake-holders-row .warning-text {
+                color: #995200;
+                padding: 16px 50px;
+                font-size: 12px;
+              }
+
+              @media (min-width: 1200px) {
+                .validator-name {
+                  max-width: 370px;
+                }
+              }
+            
+  </style>,
   <tr
-    className="jsx-4079813474 table-row validator-nodes-row mx-0 "
+    className="table-row validator-nodes-row mx-0 "
   >
     <td
       className="collapse-row-arrow"
@@ -651,6 +1527,49 @@ Array [
             onMouseOver={[Function]}
           >
             Kickout
+            <style>
+              
+            .validating-label {
+              padding: 2px 8px;
+              border-radius: 50px;
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 150%;
+            }
+
+            .validating-label.active {
+              background-color: #c8f6e0;
+              color: #008d6a;
+            }
+
+            .validating-label.proposal {
+              background-color: #6ad1e3;
+              color: #11869a;
+            }
+
+            .validating-label.joining {
+              background-color: #ffc107;
+              color: #ffffff;
+            }
+
+            .validating-label.leaving {
+              background-color: #dc3545;
+              color: #ffffff;
+            }
+            .validating-label.idle {
+              background-color: #e5e5e6;
+              color: #72727a;
+            }
+            .validating-label.on-hold {
+              background-color: #2d9cdb;
+              color: #ffffff;
+            }
+            .validating-label.newcomer {
+              background-color: #f2994a;
+              color: #ffffff;
+            }
+          
+            </style>
           </span>
         </div>
         <div
@@ -715,10 +1634,10 @@ Array [
     </td>
     <td>
       <div
-        className="jsx-2437284421 cumulative-stake-chart"
+        className="cumulative-stake-chart"
       >
         <div
-          className="jsx-2437284421 total-value"
+          className="total-value"
           style={
             Object {
               "width": "95.72%",
@@ -726,7 +1645,7 @@ Array [
           }
         />
         <div
-          className="jsx-2437284421 current-value"
+          className="current-value"
           style={
             Object {
               "width": "4.280000000000001%",
@@ -734,12 +1653,188 @@ Array [
           }
         />
         <div
-          className="jsx-2437284421 cumulative-stake-label"
+          className="cumulative-stake-label"
         >
           100%
         </div>
+        <style>
+          
+          .cumulative-stake-chart {
+            width: 100%;
+            height: 100%;
+            background-color: #f0f9ff;
+            position: relative;
+            display: flex;
+          }
+          .total-value,
+          .current-value {
+            display: block;
+            height: 75px;
+          }
+          .total-value {
+            background-color: #d6edff;
+          }
+          .current-value {
+            background-color: #8fcdff;
+          }
+          .cumulative-stake-label {
+            position: absolute;
+            top: 0;
+            right: 24px;
+            bottom: 0;
+            display: flex;
+            align-items: center;
+            color: #0072ce;
+            font-size: 14px;
+            font-weight: 500;
+            max-width: 75px;
+          }
+        
+        </style>
       </div>
     </td>
   </tr>,
+  <style>
+    
+          .table-row {
+            background-color: #ffffff;
+            flex-wrap: nowrap;
+            white-space: nowrap;
+            box-shadow: inset 0px -1px 0px #f0f0f0;
+          }
+          .table-row td {
+            border-top: none;
+            vertical-align: middle;
+          }
+
+          .table-row td.order {
+            color: #a2a2a8;
+            font-size: 14px;
+            font-weight: 600;
+          }
+
+          .table-row .row {
+            flex-wrap: nowrap;
+          }
+
+          .table-row.expanded {
+            box-shadow: inset 4px 0px 0px #0598eb, inset 0px -1px 0px #f0f0f0,
+              inset 0px 1px 0px #2b9af4, inset -1px 0px 0px #2b9af4;
+            transition: height 0.5s 0.5s, opacity 0.5s;
+            margin-top: 16px;
+            margin-bottom: 16px;
+          }
+
+          .table-row.expanded + .table-expand-row {
+            box-shadow: inset 4px 0px 0px #0598eb, inset 0px -1px 0px #2b9af4,
+              inset -1px 0px 0px #2b9af4;
+            transition: height 0.5s 0.5s, opacity 0.5s;
+            height: auto;
+            opacity: 1;
+          }
+
+          .table-row.expanded:first-child {
+            margin-top: 0;
+          }
+        
+  </style>,
+  <style>
+    
+              @import url("https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@500&display=swap");
+
+              .collapse-row-arrow {
+                cursor: pointer;
+              }
+
+              .collapse-row-arrow.disable {
+                cursor: default;
+                opacity: 0.3;
+                pointer-events: none;
+                touch-action: none;
+              }
+
+              .validator-nodes-text {
+                font-weight: 500;
+                font-size: 14px;
+                color: #3f4045;
+              }
+
+              .validator-node-pub-key {
+                color: #2b9af4;
+              }
+
+              .validator-name {
+                max-width: 250px;
+              }
+
+              .validator-name .validator-nodes-text {
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+              }
+
+              .validator-nodes-details-title {
+                display: flex;
+                flex-wrap: nowrap;
+                font-size: 12px;
+                color: #a2a2a8;
+              }
+
+              .validator-nodes-text.uptime {
+                color: #72727a;
+              }
+
+              .validator-nodes-text.stake-text {
+                font-weight: 700;
+              }
+
+              .validator-nodes-content-row {
+                padding-top: 16px;
+                padding-bottom: 16px;
+              }
+
+              .validator-nodes-content-row &gt; .validator-nodes-content-cell {
+                padding: 0 22px;
+                border-right: 1px solid #e5e5e6;
+              }
+
+              .validator-nodes-content-row
+                &gt; .validator-nodes-content-cell:last-child {
+                border-right: none;
+              }
+
+              .agent-name-badge {
+                background-color: #f0f0f1;
+                color: #72727a;
+                font-weight: 500;
+                font-size: 12px;
+                font-family: "Roboto Mono", monospace;
+              }
+
+              .validators-node-label {
+                margin-right: 24px;
+                max-width: 138px;
+              }
+
+              .cumulative-stake-chart {
+                min-width: 100px;
+              }
+
+              .cumulative-stake-holders-row {
+                background-color: #fff6ed;
+              }
+              .cumulative-stake-holders-row .warning-text {
+                color: #995200;
+                padding: 16px 50px;
+                font-size: 12px;
+              }
+
+              @media (min-width: 1200px) {
+                .validator-name {
+                  max-width: 370px;
+                }
+              }
+            
+  </style>,
 ]
 `;

--- a/frontend/src/components/transactions/__tests__/__snapshots__/ActionMessage.test.tsx.snap
+++ b/frontend/src/components/transactions/__tests__/__snapshots__/ActionMessage.test.tsx.snap
@@ -7,7 +7,7 @@ Array [
     onClick={[Function]}
   >
     <a
-      className="jsx-3150401870 account-link"
+      className="account-link"
       href="/accounts/receiver.test"
       onClick={[Function]}
       onMouseEnter={[Function]}
@@ -15,6 +15,13 @@ Array [
       receiver.test
     </a>
   </span>,
+  <style>
+    
+        .account-link {
+          white-space: nowrap;
+        }
+      
+  </style>,
   ": ed25519:BgXFiJS...",
   <p>
     with permission FullAccess
@@ -29,7 +36,7 @@ Array [
     onClick={[Function]}
   >
     <a
-      className="jsx-3150401870 account-link"
+      className="account-link"
       href="/accounts/stake"
       onClick={[Function]}
       onMouseEnter={[Function]}
@@ -37,6 +44,13 @@ Array [
       stake
     </a>
   </span>,
+  <style>
+    
+        .account-link {
+          white-space: nowrap;
+        }
+      
+  </style>,
   ": ed25519:BgXFiJS...",
   <p>
     with permission to call any methods
@@ -51,7 +65,7 @@ Array [
     onClick={[Function]}
   >
     <a
-      className="jsx-3150401870 account-link"
+      className="account-link"
       href="/accounts/stake"
       onClick={[Function]}
       onMouseEnter={[Function]}
@@ -59,6 +73,13 @@ Array [
       stake
     </a>
   </span>,
+  <style>
+    
+        .account-link {
+          white-space: nowrap;
+        }
+      
+  </style>,
   ": ed25519:BgXFiJS...",
   <p>
     with permission to call (add_request, delete_request, confirm, add_request_and_confirm) methods
@@ -73,7 +94,7 @@ Array [
     onClick={[Function]}
   >
     <a
-      className="jsx-3150401870 account-link"
+      className="account-link"
       href="/accounts/receiver.test"
       onClick={[Function]}
       onMouseEnter={[Function]}
@@ -81,6 +102,13 @@ Array [
       receiver.test
     </a>
   </span>,
+  <style>
+    
+        .account-link {
+          white-space: nowrap;
+        }
+      
+  </style>,
 ]
 `;
 
@@ -91,7 +119,7 @@ Array [
     onClick={[Function]}
   >
     <a
-      className="jsx-3150401870 account-link"
+      className="account-link"
       href="/accounts/receiver.test"
       onClick={[Function]}
       onMouseEnter={[Function]}
@@ -99,12 +127,19 @@ Array [
       receiver.test
     </a>
   </span>,
+  <style>
+    
+        .account-link {
+          white-space: nowrap;
+        }
+      
+  </style>,
   " and transfer remaining funds to ",
   <span
     onClick={[Function]}
   >
     <a
-      className="jsx-3150401870 account-link"
+      className="account-link"
       href="/accounts/near"
       onClick={[Function]}
       onMouseEnter={[Function]}
@@ -112,6 +147,13 @@ Array [
       near
     </a>
   </span>,
+  <style>
+    
+        .account-link {
+          white-space: nowrap;
+        }
+      
+  </style>,
 ]
 `;
 
@@ -124,7 +166,7 @@ Array [
     onClick={[Function]}
   >
     <a
-      className="jsx-3150401870 account-link"
+      className="account-link"
       href="/accounts/receiver.test"
       onClick={[Function]}
       onMouseEnter={[Function]}
@@ -132,6 +174,13 @@ Array [
       receiver.test
     </a>
   </span>,
+  <style>
+    
+        .account-link {
+          white-space: nowrap;
+        }
+      
+  </style>,
 ]
 `;
 
@@ -142,7 +191,7 @@ Array [
     onClick={[Function]}
   >
     <a
-      className="jsx-3150401870 account-link"
+      className="account-link"
       href="/accounts/receiver.test"
       onClick={[Function]}
       onMouseEnter={[Function]}
@@ -150,6 +199,13 @@ Array [
       receiver.test
     </a>
   </span>,
+  <style>
+    
+        .account-link {
+          white-space: nowrap;
+        }
+      
+  </style>,
 ]
 `;
 
@@ -160,7 +216,7 @@ Array [
     onClick={[Function]}
   >
     <a
-      className="jsx-3150401870 account-link"
+      className="account-link"
       href="/accounts/receiver2.test"
       onClick={[Function]}
       onMouseEnter={[Function]}
@@ -168,6 +224,13 @@ Array [
       receiver2.test
     </a>
   </span>,
+  <style>
+    
+        .account-link {
+          white-space: nowrap;
+        }
+      
+  </style>,
   <dl>
     <dt>
       Arguments:
@@ -184,7 +247,7 @@ Array [
           }
         >
           <textarea
-            className="jsx-2493677144 code-preview"
+            className="code-preview"
             readOnly={true}
             value="{
   \\"text\\": \\"when ico?\\"
@@ -205,6 +268,19 @@ Array [
           </div>
         </div>
       </div>
+      <style>
+        
+        @import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap");
+        .code-preview {
+          font-family: "Source Code Pro", monospace;
+          background: #424957;
+          color: white;
+          padding: 20px;
+          width: 100%;
+          height: 99%;
+        }
+      
+      </style>
     </dd>
   </dl>,
 ]
@@ -246,7 +322,7 @@ Array [
     onClick={[Function]}
   >
     <a
-      className="jsx-3150401870 account-link"
+      className="account-link"
       href="/accounts/receiver.test"
       onClick={[Function]}
       onMouseEnter={[Function]}
@@ -254,5 +330,12 @@ Array [
       receiver.test
     </a>
   </span>,
+  <style>
+    
+        .account-link {
+          white-space: nowrap;
+        }
+      
+  </style>,
 ]
 `;

--- a/frontend/src/components/transactions/__tests__/__snapshots__/ActionRow.test.tsx.snap
+++ b/frontend/src/components/transactions/__tests__/__snapshots__/ActionRow.test.tsx.snap
@@ -1,693 +1,1505 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ActionRow /> renders compact for receipt 1`] = `
-<div
-  className="action-compact-row mx-0  row no-gutters"
->
+Array [
   <div
-    className="col-auto"
+    className="action-compact-row mx-0  row no-gutters"
   >
     <div
-      className="jsx-1246332424 action-row-img"
-    >
-      <svg
-        viewBox="0 0 18 18"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="m0 9 6 6L9 0zm12-6L9 18l9-9z"
-          fill="#ccc"
-        />
-      </svg>
-    </div>
-  </div>
-  <div
-    className="action-row-details col"
-  >
-    <div
-      className="action-row-message row no-gutters"
+      className="col-auto"
     >
       <div
-        className="col-md-8 col-7"
+        className="action-row-img"
+      >
+        <svg
+          viewBox="0 0 18 18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m0 9 6 6L9 0zm12-6L9 18l9-9z"
+            fill="#ccc"
+          />
+        </svg>
+      </div>
+    </div>
+    <div
+      className="action-row-details col"
+    >
+      <div
+        className="action-row-message row no-gutters"
       >
         <div
-          className="row no-gutters"
+          className="col-md-8 col-7"
         >
           <div
-            className="action-row-title col"
+            className="row no-gutters"
           >
-            Called method: 'on_staking_pool_withdraw' in contract: 
-            <span
-              onClick={[Function]}
+            <div
+              className="action-row-title col"
             >
-              <a
-                className="jsx-3150401870 account-link"
-                href="/accounts/5ce78003b590264df3f259983f3c3e0917fc10ea.lockup.near"
+              Called method: 'on_staking_pool_withdraw' in contract: 
+              <span
                 onClick={[Function]}
-                onMouseEnter={[Function]}
               >
-                5ce78…ockup.near
-              </a>
-            </span>
+                <a
+                  className="account-link"
+                  href="/accounts/5ce78003b590264df3f259983f3c3e0917fc10ea.lockup.near"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  5ce78…ockup.near
+                </a>
+              </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+  <style>
+    
+            .action-sparse-row {
+              padding-top: 10px;
+              padding-bottom: 10px;
+              border-top: solid 2px #f8f8f8;
+            }
+            .action-sparse-row .action-sparse-row {
+              border-top: 0;
+            }
+
+            .action-compact-row .action-row-message {
+              margin-bottom: 1em;
+            }
+
+            .action-compact-row .action-row-details {
+              border-bottom: 2px solid #f8f8f8;
+              margin: 0.1em 0 0;
+              padding-bottom: 8px;
+            }
+
+            .action-row-details .action-row-details {
+              border: 0;
+            }
+
+            .action-compact-row .action-row-img {
+              width: 24px;
+              height: 24px;
+              border: solid 2px #f8f8f8;
+              background-color: #ffffff;
+              border-radius: 50%;
+              margin-right: 8px;
+              text-align: center;
+              line-height: 1.1;
+            }
+
+            .action-sparse-row .action-row-img {
+              margin: 10px;
+              display: inline;
+              height: 20px;
+              width: 20px;
+            }
+
+            .action-sparse-row .action-row-img svg {
+              height: 16px;
+              width: 16px;
+            }
+
+            .action-row-bottom {
+              border-bottom: solid 2px #f8f8f8;
+            }
+
+            .action-compact-row .action-row-img svg {
+              height: 12px;
+              width: 12px;
+            }
+
+            .action-sparse-row .action-row-toggler {
+              width: 10px;
+              margin: 10px;
+            }
+
+            .action-row-title {
+              font-size: 14px;
+              font-weight: 500;
+              color: #24272a;
+            }
+
+            .action-row-title a {
+              color: #666;
+            }
+
+            .action-row-title a:hover {
+              color: #24272a;
+            }
+
+            .action-row-text {
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 1.5;
+              color: #999999;
+            }
+
+            .action-row-text a {
+              color: #999999;
+            }
+
+            .action-row-text a:hover {
+              color: #24272a;
+            }
+
+            .action-row-txid {
+              font-size: 14px;
+              font-weight: 500;
+              line-height: 1.29;
+              color: #0072ce;
+            }
+
+            .action-row-timer {
+              font-size: 12px;
+              color: #999999;
+              font-weight: 100;
+            }
+
+            .action-row-timer-status {
+              font-weight: 500;
+            }
+
+            pre {
+              white-space: pre-wrap; /* Since CSS 2.1 */
+              white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+              white-space: -pre-wrap; /* Opera 4-6 */
+              white-space: -o-pre-wrap; /* Opera 7 */
+              word-wrap: break-word; /* Internet Explorer 5.5+ */
+            }
+          
+  </style>,
+]
 `;
 
 exports[`<ActionRow /> renders compact for transaction 1`] = `
-<div
-  className="action-compact-row mx-0  row no-gutters"
->
+Array [
   <div
-    className="col-auto"
+    className="action-compact-row mx-0  row no-gutters"
   >
     <div
-      className="jsx-1246332424 action-row-img"
-    >
-      <svg
-        viewBox="0 0 18 18"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M18 18v-3.6L8.92 5.32A4.5 4.5 0 1 0 4.5 9a4.47 4.47 0 0 0 .82-.08L14.4 18zM3 4.5A1.5 1.5 0 1 1 4.5 6 1.5 1.5 0 0 1 3 4.5z"
-          fill="#5ace84"
-        />
-      </svg>
-    </div>
-  </div>
-  <div
-    className="action-row-details col"
-  >
-    <div
-      className="action-row-message row no-gutters"
+      className="col-auto"
     >
       <div
-        className="col-md-8 col-7"
+        className="action-row-img"
+      >
+        <svg
+          viewBox="0 0 18 18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M18 18v-3.6L8.92 5.32A4.5 4.5 0 1 0 4.5 9a4.47 4.47 0 0 0 .82-.08L14.4 18zM3 4.5A1.5 1.5 0 1 1 4.5 6 1.5 1.5 0 0 1 3 4.5z"
+            fill="#5ace84"
+          />
+        </svg>
+      </div>
+    </div>
+    <div
+      className="action-row-details col"
+    >
+      <div
+        className="action-row-message row no-gutters"
       >
         <div
-          className="row no-gutters"
+          className="col-md-8 col-7"
         >
           <div
-            className="action-row-title col"
+            className="row no-gutters"
           >
-            New key added for 
-            <span
-              onClick={[Function]}
+            <div
+              className="action-row-title col"
             >
-              <a
-                className="jsx-3150401870 account-link"
-                href="/accounts/receiver.test"
+              New key added for 
+              <span
                 onClick={[Function]}
-                onMouseEnter={[Function]}
               >
-                receiver.test
-              </a>
-            </span>
-            : ed25519:8LXEySy...
-            <p>
-              with permission FullAccess
-            </p>
+                <a
+                  className="account-link"
+                  href="/accounts/receiver.test"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  receiver.test
+                </a>
+              </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
+              : ed25519:8LXEySy...
+              <p>
+                with permission FullAccess
+              </p>
+            </div>
+          </div>
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="action-row-text col"
+            >
+              by
+               
+              <span
+                onClick={[Function]}
+              >
+                <a
+                  className="account-link"
+                  href="/accounts/signer.test"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  signer.test
+                </a>
+              </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
+            </div>
           </div>
         </div>
         <div
-          className="row no-gutters"
+          className="ml-auto text-right col-md-4 col-5"
         >
           <div
-            className="action-row-text col"
+            className="row"
           >
-            by
-             
-            <span
-              onClick={[Function]}
+            <div
+              className="action-row-txid col"
             >
-              <a
-                className="jsx-3150401870 account-link"
-                href="/accounts/signer.test"
+              <span
                 onClick={[Function]}
-                onMouseEnter={[Function]}
               >
-                signer.test
-              </a>
-            </span>
+                <a
+                  className="transaction-link"
+                  href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  BvJeW6g...
+                </a>
+              </span>
+            </div>
+          </div>
+          <div
+            className="row"
+          >
+            <div
+              className="action-row-timer col"
+            >
+              <span
+                className="action-row-timer-status"
+              >
+                Fetching Status...
+                /Checking Finality...
+              </span>
+               
+              <span>
+                1s ago
+              </span>
+            </div>
           </div>
         </div>
       </div>
-      <div
-        className="ml-auto text-right col-md-4 col-5"
-      >
-        <div
-          className="row"
-        >
-          <div
-            className="action-row-txid col"
-          >
-            <span
-              onClick={[Function]}
-            >
-              <a
-                className="transaction-link"
-                href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                BvJeW6g...
-              </a>
-            </span>
-          </div>
-        </div>
-        <div
-          className="row"
-        >
-          <div
-            className="action-row-timer col"
-          >
-            <span
-              className="jsx-1246332424 action-row-timer-status"
-            >
-              Fetching Status...
-              /Checking Finality...
-            </span>
-             
-            <span>
-              1s ago
-            </span>
-          </div>
-        </div>
-      </div>
     </div>
-  </div>
-</div>
+  </div>,
+  <style>
+    
+            .action-sparse-row {
+              padding-top: 10px;
+              padding-bottom: 10px;
+              border-top: solid 2px #f8f8f8;
+            }
+            .action-sparse-row .action-sparse-row {
+              border-top: 0;
+            }
+
+            .action-compact-row .action-row-message {
+              margin-bottom: 1em;
+            }
+
+            .action-compact-row .action-row-details {
+              border-bottom: 2px solid #f8f8f8;
+              margin: 0.1em 0 0;
+              padding-bottom: 8px;
+            }
+
+            .action-row-details .action-row-details {
+              border: 0;
+            }
+
+            .action-compact-row .action-row-img {
+              width: 24px;
+              height: 24px;
+              border: solid 2px #f8f8f8;
+              background-color: #ffffff;
+              border-radius: 50%;
+              margin-right: 8px;
+              text-align: center;
+              line-height: 1.1;
+            }
+
+            .action-sparse-row .action-row-img {
+              margin: 10px;
+              display: inline;
+              height: 20px;
+              width: 20px;
+            }
+
+            .action-sparse-row .action-row-img svg {
+              height: 16px;
+              width: 16px;
+            }
+
+            .action-row-bottom {
+              border-bottom: solid 2px #f8f8f8;
+            }
+
+            .action-compact-row .action-row-img svg {
+              height: 12px;
+              width: 12px;
+            }
+
+            .action-sparse-row .action-row-toggler {
+              width: 10px;
+              margin: 10px;
+            }
+
+            .action-row-title {
+              font-size: 14px;
+              font-weight: 500;
+              color: #24272a;
+            }
+
+            .action-row-title a {
+              color: #666;
+            }
+
+            .action-row-title a:hover {
+              color: #24272a;
+            }
+
+            .action-row-text {
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 1.5;
+              color: #999999;
+            }
+
+            .action-row-text a {
+              color: #999999;
+            }
+
+            .action-row-text a:hover {
+              color: #24272a;
+            }
+
+            .action-row-txid {
+              font-size: 14px;
+              font-weight: 500;
+              line-height: 1.29;
+              color: #0072ce;
+            }
+
+            .action-row-timer {
+              font-size: 12px;
+              color: #999999;
+              font-weight: 100;
+            }
+
+            .action-row-timer-status {
+              font-weight: 500;
+            }
+
+            pre {
+              white-space: pre-wrap; /* Since CSS 2.1 */
+              white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+              white-space: -pre-wrap; /* Opera 4-6 */
+              white-space: -o-pre-wrap; /* Opera 7 */
+              word-wrap: break-word; /* Internet Explorer 5.5+ */
+            }
+          
+  </style>,
+]
 `;
 
 exports[`<ActionRow /> renders functioncall with detail 1`] = `
-<div
-  className="action-sparse-row mx-0  row no-gutters"
->
+Array [
   <div
-    className="col-auto"
+    className="action-sparse-row mx-0  row no-gutters"
   >
     <div
-      className="jsx-1246332424 action-row-img"
-    >
-      <svg
-        viewBox="0 0 18 18"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="m0 9 6 6L9 0zm12-6L9 18l9-9z"
-          fill="#ccc"
-        />
-      </svg>
-    </div>
-  </div>
-  <div
-    className="action-row-details col"
-  >
-    <div
-      className="action-row-message row no-gutters"
+      className="col-auto"
     >
       <div
-        className="col-md-8 col-7"
+        className="action-row-img"
+      >
+        <svg
+          viewBox="0 0 18 18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m0 9 6 6L9 0zm12-6L9 18l9-9z"
+            fill="#ccc"
+          />
+        </svg>
+      </div>
+    </div>
+    <div
+      className="action-row-details col"
+    >
+      <div
+        className="action-row-message row no-gutters"
       >
         <div
-          className="row no-gutters"
+          className="col-md-8 col-7"
         >
           <div
-            className="action-row-title col"
+            className="row no-gutters"
           >
-            Called method: 'incrementCounter' in contract: 
-            <span
-              onClick={[Function]}
+            <div
+              className="action-row-title col"
             >
-              <a
-                className="jsx-3150401870 account-link"
-                href="/accounts/receiver.test"
+              Called method: 'incrementCounter' in contract: 
+              <span
                 onClick={[Function]}
-                onMouseEnter={[Function]}
               >
-                receiver.test
-              </a>
-            </span>
-            <dl>
-              <dt>
-                Arguments:
-              </dt>
-              <dd>
-                <div>
-                  <div
-                    style={
-                      Object {
-                        "display": "block",
-                        "height": "0px",
-                        "overflow": "hidden",
-                      }
-                    }
-                  >
-                    <textarea
-                      className="jsx-2493677144 code-preview"
-                      readOnly={true}
-                      value="{
-  \\"value\\": 1
-}"
-                    />
-                  </div>
-                  <div
-                    onClick={[Function]}
-                  >
+                <a
+                  className="account-link"
+                  href="/accounts/receiver.test"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  receiver.test
+                </a>
+              </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
+              <dl>
+                <dt>
+                  Arguments:
+                </dt>
+                <dd>
+                  <div>
                     <div
                       style={
                         Object {
-                          "float": "left",
+                          "display": "block",
+                          "height": "0px",
+                          "overflow": "hidden",
                         }
                       }
                     >
-                      Show more
+                      <textarea
+                        className="code-preview"
+                        readOnly={true}
+                        value="{
+  \\"value\\": 1
+}"
+                      />
+                    </div>
+                    <div
+                      onClick={[Function]}
+                    >
+                      <div
+                        style={
+                          Object {
+                            "float": "left",
+                          }
+                        }
+                      >
+                        Show more
+                      </div>
                     </div>
                   </div>
-                </div>
-              </dd>
-            </dl>
+                  <style>
+                    
+        @import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap");
+        .code-preview {
+          font-family: "Source Code Pro", monospace;
+          background: #424957;
+          color: white;
+          padding: 20px;
+          width: 100%;
+          height: 99%;
+        }
+      
+                  </style>
+                </dd>
+              </dl>
+            </div>
           </div>
-        </div>
-        <div
-          className="row no-gutters"
-        >
           <div
-            className="action-row-text col"
+            className="row no-gutters"
           >
-            by
-             
-            <span
-              onClick={[Function]}
+            <div
+              className="action-row-text col"
             >
-              <a
-                className="jsx-3150401870 account-link"
-                href="/accounts/signer.test"
+              by
+               
+              <span
                 onClick={[Function]}
-                onMouseEnter={[Function]}
               >
-                signer.test
-              </a>
-            </span>
+                <a
+                  className="account-link"
+                  href="/accounts/signer.test"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  signer.test
+                </a>
+              </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
+            </div>
           </div>
         </div>
-      </div>
-      <div
-        className="ml-auto text-right col-md-4 col-5"
-      >
         <div
-          className="row"
+          className="ml-auto text-right col-md-4 col-5"
         >
           <div
-            className="action-row-txid col"
-          />
-        </div>
-        <div
-          className="row"
-        >
-          <div
-            className="action-row-timer col"
+            className="row"
           >
-            <span
-              className="jsx-1246332424 action-row-timer-status"
+            <div
+              className="action-row-txid col"
+            />
+          </div>
+          <div
+            className="row"
+          >
+            <div
+              className="action-row-timer col"
             >
-              Fetching Status...
-              /Checking Finality...
-            </span>
-             
-            <span>
-              1s ago
-            </span>
+              <span
+                className="action-row-timer-status"
+              >
+                Fetching Status...
+                /Checking Finality...
+              </span>
+               
+              <span>
+                1s ago
+              </span>
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+  <style>
+    
+            .action-sparse-row {
+              padding-top: 10px;
+              padding-bottom: 10px;
+              border-top: solid 2px #f8f8f8;
+            }
+            .action-sparse-row .action-sparse-row {
+              border-top: 0;
+            }
+
+            .action-compact-row .action-row-message {
+              margin-bottom: 1em;
+            }
+
+            .action-compact-row .action-row-details {
+              border-bottom: 2px solid #f8f8f8;
+              margin: 0.1em 0 0;
+              padding-bottom: 8px;
+            }
+
+            .action-row-details .action-row-details {
+              border: 0;
+            }
+
+            .action-compact-row .action-row-img {
+              width: 24px;
+              height: 24px;
+              border: solid 2px #f8f8f8;
+              background-color: #ffffff;
+              border-radius: 50%;
+              margin-right: 8px;
+              text-align: center;
+              line-height: 1.1;
+            }
+
+            .action-sparse-row .action-row-img {
+              margin: 10px;
+              display: inline;
+              height: 20px;
+              width: 20px;
+            }
+
+            .action-sparse-row .action-row-img svg {
+              height: 16px;
+              width: 16px;
+            }
+
+            .action-row-bottom {
+              border-bottom: solid 2px #f8f8f8;
+            }
+
+            .action-compact-row .action-row-img svg {
+              height: 12px;
+              width: 12px;
+            }
+
+            .action-sparse-row .action-row-toggler {
+              width: 10px;
+              margin: 10px;
+            }
+
+            .action-row-title {
+              font-size: 14px;
+              font-weight: 500;
+              color: #24272a;
+            }
+
+            .action-row-title a {
+              color: #666;
+            }
+
+            .action-row-title a:hover {
+              color: #24272a;
+            }
+
+            .action-row-text {
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 1.5;
+              color: #999999;
+            }
+
+            .action-row-text a {
+              color: #999999;
+            }
+
+            .action-row-text a:hover {
+              color: #24272a;
+            }
+
+            .action-row-txid {
+              font-size: 14px;
+              font-weight: 500;
+              line-height: 1.29;
+              color: #0072ce;
+            }
+
+            .action-row-timer {
+              font-size: 12px;
+              color: #999999;
+              font-weight: 100;
+            }
+
+            .action-row-timer-status {
+              font-weight: 500;
+            }
+
+            pre {
+              white-space: pre-wrap; /* Since CSS 2.1 */
+              white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+              white-space: -pre-wrap; /* Opera 4-6 */
+              white-space: -o-pre-wrap; /* Opera 7 */
+              word-wrap: break-word; /* Internet Explorer 5.5+ */
+            }
+          
+  </style>,
+]
 `;
 
 exports[`<ActionRow /> renders sparsely ActionRow for receipt 1`] = `
-<div
-  className="action-sparse-row mx-0  row no-gutters"
->
+Array [
   <div
-    className="col-auto"
+    className="action-sparse-row mx-0  row no-gutters"
   >
     <div
-      className="jsx-1246332424 action-row-img"
-    >
-      <svg
-        viewBox="0 0 18 18"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="m0 9 6 6L9 0zm12-6L9 18l9-9z"
-          fill="#ccc"
-        />
-      </svg>
-    </div>
-  </div>
-  <div
-    className="action-row-details col"
-  >
-    <div
-      className="action-row-message row no-gutters"
+      className="col-auto"
     >
       <div
-        className="col-md-8 col-7"
+        className="action-row-img"
+      >
+        <svg
+          viewBox="0 0 18 18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m0 9 6 6L9 0zm12-6L9 18l9-9z"
+            fill="#ccc"
+          />
+        </svg>
+      </div>
+    </div>
+    <div
+      className="action-row-details col"
+    >
+      <div
+        className="action-row-message row no-gutters"
       >
         <div
-          className="row no-gutters"
+          className="col-md-8 col-7"
         >
           <div
-            className="action-row-title col"
+            className="row no-gutters"
           >
-            Called method: 'submit_approved_solution' in contract: 
-            <span
-              onClick={[Function]}
+            <div
+              className="action-row-title col"
             >
-              <a
-                className="jsx-3150401870 account-link"
-                href="/accounts/app.nearcrowd.near"
+              Called method: 'submit_approved_solution' in contract: 
+              <span
                 onClick={[Function]}
-                onMouseEnter={[Function]}
               >
-                app.nearcrowd.near
-              </a>
-            </span>
+                <a
+                  className="account-link"
+                  href="/accounts/app.nearcrowd.near"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  app.nearcrowd.near
+                </a>
+              </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
+            </div>
+          </div>
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="action-row-text col"
+            >
+              by
+               
+              <span
+                onClick={[Function]}
+              >
+                <a
+                  className="account-link"
+                  href="/accounts/elonmusk_tesla.near"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  elonmusk_tesla.near
+                </a>
+              </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
+            </div>
           </div>
         </div>
         <div
-          className="row no-gutters"
+          className="ml-auto text-right col-md-4 col-5"
         >
           <div
-            className="action-row-text col"
+            className="row"
           >
-            by
-             
-            <span
-              onClick={[Function]}
+            <div
+              className="action-row-txid col"
             >
-              <a
-                className="jsx-3150401870 account-link"
-                href="/accounts/elonmusk_tesla.near"
+              <span
                 onClick={[Function]}
-                onMouseEnter={[Function]}
               >
-                elonmusk_tesla.near
-              </a>
-            </span>
+                <a
+                  className="receipt-hash-link"
+                  href="/transactions/2WDYbcuRyyRXJvrXkfFej9Vrv3s3GNTxVQAqKFTiEtGh#7uADRkZL3b8HRbCRe3ML6yRyVZ46HHp1pEJKbxewq5Hg"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  7uADRkZ...
+                </a>
+              </span>
+              <style>
+                
+        .receipt-hash-link.disabled {
+          cursor: default;
+          color: #24272a;
+        }
+      
+              </style>
+            </div>
+          </div>
+          <div
+            className="row"
+          >
+            <div
+              className="action-row-timer col"
+            >
+              <span
+                className="action-row-timer-status"
+              >
+                Succeeded
+                /Checking Finality...
+              </span>
+               
+              <span>
+                in 2y
+              </span>
+            </div>
           </div>
         </div>
       </div>
-      <div
-        className="ml-auto text-right col-md-4 col-5"
-      >
-        <div
-          className="row"
-        >
-          <div
-            className="action-row-txid col"
-          >
-            <span
-              onClick={[Function]}
-            >
-              <a
-                className="jsx-4207953579 receipt-hash-link"
-                href="/transactions/2WDYbcuRyyRXJvrXkfFej9Vrv3s3GNTxVQAqKFTiEtGh#7uADRkZL3b8HRbCRe3ML6yRyVZ46HHp1pEJKbxewq5Hg"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                7uADRkZ...
-              </a>
-            </span>
-          </div>
-        </div>
-        <div
-          className="row"
-        >
-          <div
-            className="action-row-timer col"
-          >
-            <span
-              className="jsx-1246332424 action-row-timer-status"
-            >
-              Succeeded
-              /Checking Finality...
-            </span>
-             
-            <span>
-              in 2y
-            </span>
-          </div>
-        </div>
-      </div>
     </div>
-  </div>
-</div>
+  </div>,
+  <style>
+    
+            .action-sparse-row {
+              padding-top: 10px;
+              padding-bottom: 10px;
+              border-top: solid 2px #f8f8f8;
+            }
+            .action-sparse-row .action-sparse-row {
+              border-top: 0;
+            }
+
+            .action-compact-row .action-row-message {
+              margin-bottom: 1em;
+            }
+
+            .action-compact-row .action-row-details {
+              border-bottom: 2px solid #f8f8f8;
+              margin: 0.1em 0 0;
+              padding-bottom: 8px;
+            }
+
+            .action-row-details .action-row-details {
+              border: 0;
+            }
+
+            .action-compact-row .action-row-img {
+              width: 24px;
+              height: 24px;
+              border: solid 2px #f8f8f8;
+              background-color: #ffffff;
+              border-radius: 50%;
+              margin-right: 8px;
+              text-align: center;
+              line-height: 1.1;
+            }
+
+            .action-sparse-row .action-row-img {
+              margin: 10px;
+              display: inline;
+              height: 20px;
+              width: 20px;
+            }
+
+            .action-sparse-row .action-row-img svg {
+              height: 16px;
+              width: 16px;
+            }
+
+            .action-row-bottom {
+              border-bottom: solid 2px #f8f8f8;
+            }
+
+            .action-compact-row .action-row-img svg {
+              height: 12px;
+              width: 12px;
+            }
+
+            .action-sparse-row .action-row-toggler {
+              width: 10px;
+              margin: 10px;
+            }
+
+            .action-row-title {
+              font-size: 14px;
+              font-weight: 500;
+              color: #24272a;
+            }
+
+            .action-row-title a {
+              color: #666;
+            }
+
+            .action-row-title a:hover {
+              color: #24272a;
+            }
+
+            .action-row-text {
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 1.5;
+              color: #999999;
+            }
+
+            .action-row-text a {
+              color: #999999;
+            }
+
+            .action-row-text a:hover {
+              color: #24272a;
+            }
+
+            .action-row-txid {
+              font-size: 14px;
+              font-weight: 500;
+              line-height: 1.29;
+              color: #0072ce;
+            }
+
+            .action-row-timer {
+              font-size: 12px;
+              color: #999999;
+              font-weight: 100;
+            }
+
+            .action-row-timer-status {
+              font-weight: 500;
+            }
+
+            pre {
+              white-space: pre-wrap; /* Since CSS 2.1 */
+              white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+              white-space: -pre-wrap; /* Opera 4-6 */
+              white-space: -o-pre-wrap; /* Opera 7 */
+              word-wrap: break-word; /* Internet Explorer 5.5+ */
+            }
+          
+  </style>,
+]
 `;
 
 exports[`<ActionRow /> renders sparsely ActionRow for transaction by default 1`] = `
-<div
-  className="action-sparse-row mx-0  row no-gutters"
->
+Array [
   <div
-    className="col-auto"
+    className="action-sparse-row mx-0  row no-gutters"
   >
     <div
-      className="jsx-1246332424 action-row-img"
-    >
-      <svg
-        viewBox="0 0 18 18"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="m11.26 9-.34-.45a4.5 4.5 0 1 0-3.84 0L6.74 9A7 7 0 0 0 0 16v2h18v-2a7 7 0 0 0-6.74-7z"
-          fill="#0071ce"
-        />
-      </svg>
-    </div>
-  </div>
-  <div
-    className="action-row-details col"
-  >
-    <div
-      className="action-row-message row no-gutters"
+      className="col-auto"
     >
       <div
-        className="col-md-8 col-7"
+        className="action-row-img"
+      >
+        <svg
+          viewBox="0 0 18 18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m11.26 9-.34-.45a4.5 4.5 0 1 0-3.84 0L6.74 9A7 7 0 0 0 0 16v2h18v-2a7 7 0 0 0-6.74-7z"
+            fill="#0071ce"
+          />
+        </svg>
+      </div>
+    </div>
+    <div
+      className="action-row-details col"
+    >
+      <div
+        className="action-row-message row no-gutters"
       >
         <div
-          className="row no-gutters"
+          className="col-md-8 col-7"
         >
           <div
-            className="action-row-title col"
+            className="row no-gutters"
           >
-            New account created: 
-            <span
-              onClick={[Function]}
+            <div
+              className="action-row-title col"
             >
-              <a
-                className="jsx-3150401870 account-link"
-                href="/accounts/receiver.test"
+              New account created: 
+              <span
                 onClick={[Function]}
-                onMouseEnter={[Function]}
               >
-                receiver.test
-              </a>
-            </span>
+                <a
+                  className="account-link"
+                  href="/accounts/receiver.test"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  receiver.test
+                </a>
+              </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
+            </div>
+          </div>
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="action-row-text col"
+            >
+              by
+               
+              <span
+                onClick={[Function]}
+              >
+                <a
+                  className="account-link"
+                  href="/accounts/signer.test"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  signer.test
+                </a>
+              </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
+            </div>
           </div>
         </div>
         <div
-          className="row no-gutters"
+          className="ml-auto text-right col-md-4 col-5"
         >
           <div
-            className="action-row-text col"
+            className="row"
           >
-            by
-             
-            <span
-              onClick={[Function]}
+            <div
+              className="action-row-txid col"
             >
-              <a
-                className="jsx-3150401870 account-link"
-                href="/accounts/signer.test"
+              <span
                 onClick={[Function]}
-                onMouseEnter={[Function]}
               >
-                signer.test
-              </a>
-            </span>
+                <a
+                  className="transaction-link"
+                  href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  BvJeW6g...
+                </a>
+              </span>
+            </div>
+          </div>
+          <div
+            className="row"
+          >
+            <div
+              className="action-row-timer col"
+            >
+              <span
+                className="action-row-timer-status"
+              >
+                Fetching Status...
+                /Checking Finality...
+              </span>
+               
+              <span>
+                1s ago
+              </span>
+            </div>
           </div>
         </div>
       </div>
-      <div
-        className="ml-auto text-right col-md-4 col-5"
-      >
-        <div
-          className="row"
-        >
-          <div
-            className="action-row-txid col"
-          >
-            <span
-              onClick={[Function]}
-            >
-              <a
-                className="transaction-link"
-                href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                BvJeW6g...
-              </a>
-            </span>
-          </div>
-        </div>
-        <div
-          className="row"
-        >
-          <div
-            className="action-row-timer col"
-          >
-            <span
-              className="jsx-1246332424 action-row-timer-status"
-            >
-              Fetching Status...
-              /Checking Finality...
-            </span>
-             
-            <span>
-              1s ago
-            </span>
-          </div>
-        </div>
-      </div>
     </div>
-  </div>
-</div>
+  </div>,
+  <style>
+    
+            .action-sparse-row {
+              padding-top: 10px;
+              padding-bottom: 10px;
+              border-top: solid 2px #f8f8f8;
+            }
+            .action-sparse-row .action-sparse-row {
+              border-top: 0;
+            }
+
+            .action-compact-row .action-row-message {
+              margin-bottom: 1em;
+            }
+
+            .action-compact-row .action-row-details {
+              border-bottom: 2px solid #f8f8f8;
+              margin: 0.1em 0 0;
+              padding-bottom: 8px;
+            }
+
+            .action-row-details .action-row-details {
+              border: 0;
+            }
+
+            .action-compact-row .action-row-img {
+              width: 24px;
+              height: 24px;
+              border: solid 2px #f8f8f8;
+              background-color: #ffffff;
+              border-radius: 50%;
+              margin-right: 8px;
+              text-align: center;
+              line-height: 1.1;
+            }
+
+            .action-sparse-row .action-row-img {
+              margin: 10px;
+              display: inline;
+              height: 20px;
+              width: 20px;
+            }
+
+            .action-sparse-row .action-row-img svg {
+              height: 16px;
+              width: 16px;
+            }
+
+            .action-row-bottom {
+              border-bottom: solid 2px #f8f8f8;
+            }
+
+            .action-compact-row .action-row-img svg {
+              height: 12px;
+              width: 12px;
+            }
+
+            .action-sparse-row .action-row-toggler {
+              width: 10px;
+              margin: 10px;
+            }
+
+            .action-row-title {
+              font-size: 14px;
+              font-weight: 500;
+              color: #24272a;
+            }
+
+            .action-row-title a {
+              color: #666;
+            }
+
+            .action-row-title a:hover {
+              color: #24272a;
+            }
+
+            .action-row-text {
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 1.5;
+              color: #999999;
+            }
+
+            .action-row-text a {
+              color: #999999;
+            }
+
+            .action-row-text a:hover {
+              color: #24272a;
+            }
+
+            .action-row-txid {
+              font-size: 14px;
+              font-weight: 500;
+              line-height: 1.29;
+              color: #0072ce;
+            }
+
+            .action-row-timer {
+              font-size: 12px;
+              color: #999999;
+              font-weight: 100;
+            }
+
+            .action-row-timer-status {
+              font-weight: 500;
+            }
+
+            pre {
+              white-space: pre-wrap; /* Since CSS 2.1 */
+              white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+              white-space: -pre-wrap; /* Opera 4-6 */
+              white-space: -o-pre-wrap; /* Opera 7 */
+              word-wrap: break-word; /* Internet Explorer 5.5+ */
+            }
+          
+  </style>,
+]
 `;
 
 exports[`<ActionRow /> renders sparsely ActionRow for transaction with status 1`] = `
-<div
-  className="action-sparse-row mx-0  row no-gutters"
->
+Array [
   <div
-    className="col-auto"
+    className="action-sparse-row mx-0  row no-gutters"
   >
     <div
-      className="jsx-1246332424 action-row-img"
-    >
-      <svg
-        viewBox="0 0 18 18"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="m11.26 9-.34-.45a4.5 4.5 0 1 0-3.84 0L6.74 9A7 7 0 0 0 0 16v2h18v-2a7 7 0 0 0-6.74-7z"
-          fill="#0071ce"
-        />
-      </svg>
-    </div>
-  </div>
-  <div
-    className="action-row-details col"
-  >
-    <div
-      className="action-row-message row no-gutters"
+      className="col-auto"
     >
       <div
-        className="col-md-8 col-7"
+        className="action-row-img"
+      >
+        <svg
+          viewBox="0 0 18 18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m11.26 9-.34-.45a4.5 4.5 0 1 0-3.84 0L6.74 9A7 7 0 0 0 0 16v2h18v-2a7 7 0 0 0-6.74-7z"
+            fill="#0071ce"
+          />
+        </svg>
+      </div>
+    </div>
+    <div
+      className="action-row-details col"
+    >
+      <div
+        className="action-row-message row no-gutters"
       >
         <div
-          className="row no-gutters"
+          className="col-md-8 col-7"
         >
           <div
-            className="action-row-title col"
+            className="row no-gutters"
           >
-            New account created: 
-            <span
-              onClick={[Function]}
+            <div
+              className="action-row-title col"
             >
-              <a
-                className="jsx-3150401870 account-link"
-                href="/accounts/receiver.test"
+              New account created: 
+              <span
                 onClick={[Function]}
-                onMouseEnter={[Function]}
               >
-                receiver.test
-              </a>
-            </span>
+                <a
+                  className="account-link"
+                  href="/accounts/receiver.test"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  receiver.test
+                </a>
+              </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
+            </div>
+          </div>
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="action-row-text col"
+            >
+              by
+               
+              <span
+                onClick={[Function]}
+              >
+                <a
+                  className="account-link"
+                  href="/accounts/signer.test"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  signer.test
+                </a>
+              </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
+            </div>
           </div>
         </div>
         <div
-          className="row no-gutters"
+          className="ml-auto text-right col-md-4 col-5"
         >
           <div
-            className="action-row-text col"
+            className="row"
           >
-            by
-             
-            <span
-              onClick={[Function]}
+            <div
+              className="action-row-txid col"
             >
-              <a
-                className="jsx-3150401870 account-link"
-                href="/accounts/signer.test"
+              <span
                 onClick={[Function]}
-                onMouseEnter={[Function]}
               >
-                signer.test
-              </a>
-            </span>
+                <a
+                  className="transaction-link"
+                  href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  BvJeW6g...
+                </a>
+              </span>
+            </div>
+          </div>
+          <div
+            className="row"
+          >
+            <div
+              className="action-row-timer col"
+            >
+              <span
+                className="action-row-timer-status"
+              >
+                Succeeded
+                /Checking Finality...
+              </span>
+               
+              <span>
+                1s ago
+              </span>
+            </div>
           </div>
         </div>
       </div>
-      <div
-        className="ml-auto text-right col-md-4 col-5"
-      >
-        <div
-          className="row"
-        >
-          <div
-            className="action-row-txid col"
-          >
-            <span
-              onClick={[Function]}
-            >
-              <a
-                className="transaction-link"
-                href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                BvJeW6g...
-              </a>
-            </span>
-          </div>
-        </div>
-        <div
-          className="row"
-        >
-          <div
-            className="action-row-timer col"
-          >
-            <span
-              className="jsx-1246332424 action-row-timer-status"
-            >
-              Succeeded
-              /Checking Finality...
-            </span>
-             
-            <span>
-              1s ago
-            </span>
-          </div>
-        </div>
-      </div>
     </div>
-  </div>
-</div>
+  </div>,
+  <style>
+    
+            .action-sparse-row {
+              padding-top: 10px;
+              padding-bottom: 10px;
+              border-top: solid 2px #f8f8f8;
+            }
+            .action-sparse-row .action-sparse-row {
+              border-top: 0;
+            }
+
+            .action-compact-row .action-row-message {
+              margin-bottom: 1em;
+            }
+
+            .action-compact-row .action-row-details {
+              border-bottom: 2px solid #f8f8f8;
+              margin: 0.1em 0 0;
+              padding-bottom: 8px;
+            }
+
+            .action-row-details .action-row-details {
+              border: 0;
+            }
+
+            .action-compact-row .action-row-img {
+              width: 24px;
+              height: 24px;
+              border: solid 2px #f8f8f8;
+              background-color: #ffffff;
+              border-radius: 50%;
+              margin-right: 8px;
+              text-align: center;
+              line-height: 1.1;
+            }
+
+            .action-sparse-row .action-row-img {
+              margin: 10px;
+              display: inline;
+              height: 20px;
+              width: 20px;
+            }
+
+            .action-sparse-row .action-row-img svg {
+              height: 16px;
+              width: 16px;
+            }
+
+            .action-row-bottom {
+              border-bottom: solid 2px #f8f8f8;
+            }
+
+            .action-compact-row .action-row-img svg {
+              height: 12px;
+              width: 12px;
+            }
+
+            .action-sparse-row .action-row-toggler {
+              width: 10px;
+              margin: 10px;
+            }
+
+            .action-row-title {
+              font-size: 14px;
+              font-weight: 500;
+              color: #24272a;
+            }
+
+            .action-row-title a {
+              color: #666;
+            }
+
+            .action-row-title a:hover {
+              color: #24272a;
+            }
+
+            .action-row-text {
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 1.5;
+              color: #999999;
+            }
+
+            .action-row-text a {
+              color: #999999;
+            }
+
+            .action-row-text a:hover {
+              color: #24272a;
+            }
+
+            .action-row-txid {
+              font-size: 14px;
+              font-weight: 500;
+              line-height: 1.29;
+              color: #0072ce;
+            }
+
+            .action-row-timer {
+              font-size: 12px;
+              color: #999999;
+              font-weight: 100;
+            }
+
+            .action-row-timer-status {
+              font-weight: 500;
+            }
+
+            pre {
+              white-space: pre-wrap; /* Since CSS 2.1 */
+              white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+              white-space: -pre-wrap; /* Opera 4-6 */
+              white-space: -o-pre-wrap; /* Opera 7 */
+              word-wrap: break-word; /* Internet Explorer 5.5+ */
+            }
+          
+  </style>,
+]
 `;

--- a/frontend/src/components/transactions/__tests__/__snapshots__/ActionsList.test.tsx.snap
+++ b/frontend/src/components/transactions/__tests__/__snapshots__/ActionsList.test.tsx.snap
@@ -26,124 +26,265 @@ exports[`<ActionsList /> renders ActionsList for Receipts without transactionHas
 `;
 
 exports[`<ActionsList /> renders compact for Receipts 1`] = `
-<div
-  className="action-compact-row mx-0  row no-gutters"
->
+Array [
   <div
-    className="col-auto"
+    className="action-compact-row mx-0  row no-gutters"
   >
     <div
-      className="jsx-1246332424 action-row-img"
-    >
-      <svg
-        viewBox="0 0 18 18"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="m0 9 6 6L9 0zm12-6L9 18l9-9z"
-          fill="#ccc"
-        />
-      </svg>
-    </div>
-  </div>
-  <div
-    className="action-row-details col"
-  >
-    <div
-      className="action-row-message row no-gutters"
+      className="col-auto"
     >
       <div
-        className="col-md-8 col-7"
+        className="action-row-img"
+      >
+        <svg
+          viewBox="0 0 18 18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m0 9 6 6L9 0zm12-6L9 18l9-9z"
+            fill="#ccc"
+          />
+        </svg>
+      </div>
+    </div>
+    <div
+      className="action-row-details col"
+    >
+      <div
+        className="action-row-message row no-gutters"
       >
         <div
-          className="row no-gutters"
+          className="col-md-8 col-7"
         >
           <div
-            className="action-row-title col"
+            className="row no-gutters"
           >
-            Called method: 'submit_approved_solution' in contract: 
-            <span
-              onClick={[Function]}
+            <div
+              className="action-row-title col"
             >
-              <a
-                className="jsx-3150401870 account-link"
-                href="/accounts/app.nearcrowd.near"
+              Called method: 'submit_approved_solution' in contract: 
+              <span
                 onClick={[Function]}
-                onMouseEnter={[Function]}
               >
-                app.nearcrowd.near
-              </a>
-            </span>
+                <a
+                  className="account-link"
+                  href="/accounts/app.nearcrowd.near"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  app.nearcrowd.near
+                </a>
+              </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
+            </div>
+          </div>
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="action-row-text col"
+            >
+              by
+               
+              <span
+                onClick={[Function]}
+              >
+                <a
+                  className="account-link"
+                  href="/accounts/elonmusk_tesla.near"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  elonmusk_tesla.near
+                </a>
+              </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
+            </div>
           </div>
         </div>
         <div
-          className="row no-gutters"
+          className="ml-auto text-right col-md-4 col-5"
         >
           <div
-            className="action-row-text col"
+            className="row"
           >
-            by
-             
-            <span
-              onClick={[Function]}
+            <div
+              className="action-row-txid col"
             >
-              <a
-                className="jsx-3150401870 account-link"
-                href="/accounts/elonmusk_tesla.near"
+              <span
                 onClick={[Function]}
-                onMouseEnter={[Function]}
               >
-                elonmusk_tesla.near
-              </a>
-            </span>
+                <a
+                  className="receipt-hash-link"
+                  href="/transactions/2WDYbcuRyyRXJvrXkfFej9Vrv3s3GNTxVQAqKFTiEtGh#7uADRkZL3b8HRbCRe3ML6yRyVZ46HHp1pEJKbxewq5Hg"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  7uADRkZ...
+                </a>
+              </span>
+              <style>
+                
+        .receipt-hash-link.disabled {
+          cursor: default;
+          color: #24272a;
+        }
+      
+              </style>
+            </div>
+          </div>
+          <div
+            className="row"
+          >
+            <div
+              className="action-row-timer col"
+            >
+              <span
+                className="action-row-timer-status"
+              >
+                Fetching Status...
+                /Checking Finality...
+              </span>
+               
+              <span>
+                in 2y
+              </span>
+            </div>
           </div>
         </div>
       </div>
-      <div
-        className="ml-auto text-right col-md-4 col-5"
-      >
-        <div
-          className="row"
-        >
-          <div
-            className="action-row-txid col"
-          >
-            <span
-              onClick={[Function]}
-            >
-              <a
-                className="jsx-4207953579 receipt-hash-link"
-                href="/transactions/2WDYbcuRyyRXJvrXkfFej9Vrv3s3GNTxVQAqKFTiEtGh#7uADRkZL3b8HRbCRe3ML6yRyVZ46HHp1pEJKbxewq5Hg"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                7uADRkZ...
-              </a>
-            </span>
-          </div>
-        </div>
-        <div
-          className="row"
-        >
-          <div
-            className="action-row-timer col"
-          >
-            <span
-              className="jsx-1246332424 action-row-timer-status"
-            >
-              Fetching Status...
-              /Checking Finality...
-            </span>
-             
-            <span>
-              in 2y
-            </span>
-          </div>
-        </div>
-      </div>
     </div>
-  </div>
-</div>
+  </div>,
+  <style>
+    
+            .action-sparse-row {
+              padding-top: 10px;
+              padding-bottom: 10px;
+              border-top: solid 2px #f8f8f8;
+            }
+            .action-sparse-row .action-sparse-row {
+              border-top: 0;
+            }
+
+            .action-compact-row .action-row-message {
+              margin-bottom: 1em;
+            }
+
+            .action-compact-row .action-row-details {
+              border-bottom: 2px solid #f8f8f8;
+              margin: 0.1em 0 0;
+              padding-bottom: 8px;
+            }
+
+            .action-row-details .action-row-details {
+              border: 0;
+            }
+
+            .action-compact-row .action-row-img {
+              width: 24px;
+              height: 24px;
+              border: solid 2px #f8f8f8;
+              background-color: #ffffff;
+              border-radius: 50%;
+              margin-right: 8px;
+              text-align: center;
+              line-height: 1.1;
+            }
+
+            .action-sparse-row .action-row-img {
+              margin: 10px;
+              display: inline;
+              height: 20px;
+              width: 20px;
+            }
+
+            .action-sparse-row .action-row-img svg {
+              height: 16px;
+              width: 16px;
+            }
+
+            .action-row-bottom {
+              border-bottom: solid 2px #f8f8f8;
+            }
+
+            .action-compact-row .action-row-img svg {
+              height: 12px;
+              width: 12px;
+            }
+
+            .action-sparse-row .action-row-toggler {
+              width: 10px;
+              margin: 10px;
+            }
+
+            .action-row-title {
+              font-size: 14px;
+              font-weight: 500;
+              color: #24272a;
+            }
+
+            .action-row-title a {
+              color: #666;
+            }
+
+            .action-row-title a:hover {
+              color: #24272a;
+            }
+
+            .action-row-text {
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 1.5;
+              color: #999999;
+            }
+
+            .action-row-text a {
+              color: #999999;
+            }
+
+            .action-row-text a:hover {
+              color: #24272a;
+            }
+
+            .action-row-txid {
+              font-size: 14px;
+              font-weight: 500;
+              line-height: 1.29;
+              color: #0072ce;
+            }
+
+            .action-row-timer {
+              font-size: 12px;
+              color: #999999;
+              font-weight: 100;
+            }
+
+            .action-row-timer-status {
+              font-weight: 500;
+            }
+
+            pre {
+              white-space: pre-wrap; /* Since CSS 2.1 */
+              white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+              white-space: -pre-wrap; /* Opera 4-6 */
+              white-space: -o-pre-wrap; /* Opera 7 */
+              word-wrap: break-word; /* Internet Explorer 5.5+ */
+            }
+          
+  </style>,
+]
 `;
 
 exports[`<ActionsList /> renders compact for Transaction 1`] = `
@@ -155,7 +296,7 @@ Array [
       className="col-auto"
     >
       <div
-        className="jsx-1246332424 action-row-img"
+        className="action-row-img"
       >
         <svg
           viewBox="0 0 18 18"
@@ -188,7 +329,7 @@ Array [
                 onClick={[Function]}
               >
                 <a
-                  className="jsx-3150401870 account-link"
+                  className="account-link"
                   href="/accounts/receiver.test"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
@@ -196,6 +337,13 @@ Array [
                   receiver.test
                 </a>
               </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
             </div>
           </div>
           <div
@@ -210,7 +358,7 @@ Array [
                 onClick={[Function]}
               >
                 <a
-                  className="jsx-3150401870 account-link"
+                  className="account-link"
                   href="/accounts/signer.test"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
@@ -218,6 +366,13 @@ Array [
                   signer.test
                 </a>
               </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
             </div>
           </div>
         </div>
@@ -251,7 +406,7 @@ Array [
               className="action-row-timer col"
             >
               <span
-                className="jsx-1246332424 action-row-timer-status"
+                className="action-row-timer-status"
               >
                 Fetching Status...
                 /Checking Finality...
@@ -266,6 +421,123 @@ Array [
       </div>
     </div>
   </div>,
+  <style>
+    
+            .action-sparse-row {
+              padding-top: 10px;
+              padding-bottom: 10px;
+              border-top: solid 2px #f8f8f8;
+            }
+            .action-sparse-row .action-sparse-row {
+              border-top: 0;
+            }
+
+            .action-compact-row .action-row-message {
+              margin-bottom: 1em;
+            }
+
+            .action-compact-row .action-row-details {
+              border-bottom: 2px solid #f8f8f8;
+              margin: 0.1em 0 0;
+              padding-bottom: 8px;
+            }
+
+            .action-row-details .action-row-details {
+              border: 0;
+            }
+
+            .action-compact-row .action-row-img {
+              width: 24px;
+              height: 24px;
+              border: solid 2px #f8f8f8;
+              background-color: #ffffff;
+              border-radius: 50%;
+              margin-right: 8px;
+              text-align: center;
+              line-height: 1.1;
+            }
+
+            .action-sparse-row .action-row-img {
+              margin: 10px;
+              display: inline;
+              height: 20px;
+              width: 20px;
+            }
+
+            .action-sparse-row .action-row-img svg {
+              height: 16px;
+              width: 16px;
+            }
+
+            .action-row-bottom {
+              border-bottom: solid 2px #f8f8f8;
+            }
+
+            .action-compact-row .action-row-img svg {
+              height: 12px;
+              width: 12px;
+            }
+
+            .action-sparse-row .action-row-toggler {
+              width: 10px;
+              margin: 10px;
+            }
+
+            .action-row-title {
+              font-size: 14px;
+              font-weight: 500;
+              color: #24272a;
+            }
+
+            .action-row-title a {
+              color: #666;
+            }
+
+            .action-row-title a:hover {
+              color: #24272a;
+            }
+
+            .action-row-text {
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 1.5;
+              color: #999999;
+            }
+
+            .action-row-text a {
+              color: #999999;
+            }
+
+            .action-row-text a:hover {
+              color: #24272a;
+            }
+
+            .action-row-txid {
+              font-size: 14px;
+              font-weight: 500;
+              line-height: 1.29;
+              color: #0072ce;
+            }
+
+            .action-row-timer {
+              font-size: 12px;
+              color: #999999;
+              font-weight: 100;
+            }
+
+            .action-row-timer-status {
+              font-weight: 500;
+            }
+
+            pre {
+              white-space: pre-wrap; /* Since CSS 2.1 */
+              white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+              white-space: -pre-wrap; /* Opera 4-6 */
+              white-space: -o-pre-wrap; /* Opera 7 */
+              word-wrap: break-word; /* Internet Explorer 5.5+ */
+            }
+          
+  </style>,
   <div
     className="action-compact-row mx-0  row no-gutters"
   >
@@ -273,7 +545,7 @@ Array [
       className="col-auto"
     >
       <div
-        className="jsx-1246332424 action-row-img"
+        className="action-row-img"
       >
         <svg
           viewBox="0 0 18 18"
@@ -306,7 +578,7 @@ Array [
                 onClick={[Function]}
               >
                 <a
-                  className="jsx-3150401870 account-link"
+                  className="account-link"
                   href="/accounts/receiver.test"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
@@ -314,6 +586,13 @@ Array [
                   receiver.test
                 </a>
               </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
               : ed25519:8LXEySy...
               <p>
                 with permission FullAccess
@@ -332,7 +611,7 @@ Array [
                 onClick={[Function]}
               >
                 <a
-                  className="jsx-3150401870 account-link"
+                  className="account-link"
                   href="/accounts/signer.test"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
@@ -340,6 +619,13 @@ Array [
                   signer.test
                 </a>
               </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
             </div>
           </div>
         </div>
@@ -373,7 +659,7 @@ Array [
               className="action-row-timer col"
             >
               <span
-                className="jsx-1246332424 action-row-timer-status"
+                className="action-row-timer-status"
               >
                 Fetching Status...
                 /Checking Finality...
@@ -388,282 +674,686 @@ Array [
       </div>
     </div>
   </div>,
+  <style>
+    
+            .action-sparse-row {
+              padding-top: 10px;
+              padding-bottom: 10px;
+              border-top: solid 2px #f8f8f8;
+            }
+            .action-sparse-row .action-sparse-row {
+              border-top: 0;
+            }
+
+            .action-compact-row .action-row-message {
+              margin-bottom: 1em;
+            }
+
+            .action-compact-row .action-row-details {
+              border-bottom: 2px solid #f8f8f8;
+              margin: 0.1em 0 0;
+              padding-bottom: 8px;
+            }
+
+            .action-row-details .action-row-details {
+              border: 0;
+            }
+
+            .action-compact-row .action-row-img {
+              width: 24px;
+              height: 24px;
+              border: solid 2px #f8f8f8;
+              background-color: #ffffff;
+              border-radius: 50%;
+              margin-right: 8px;
+              text-align: center;
+              line-height: 1.1;
+            }
+
+            .action-sparse-row .action-row-img {
+              margin: 10px;
+              display: inline;
+              height: 20px;
+              width: 20px;
+            }
+
+            .action-sparse-row .action-row-img svg {
+              height: 16px;
+              width: 16px;
+            }
+
+            .action-row-bottom {
+              border-bottom: solid 2px #f8f8f8;
+            }
+
+            .action-compact-row .action-row-img svg {
+              height: 12px;
+              width: 12px;
+            }
+
+            .action-sparse-row .action-row-toggler {
+              width: 10px;
+              margin: 10px;
+            }
+
+            .action-row-title {
+              font-size: 14px;
+              font-weight: 500;
+              color: #24272a;
+            }
+
+            .action-row-title a {
+              color: #666;
+            }
+
+            .action-row-title a:hover {
+              color: #24272a;
+            }
+
+            .action-row-text {
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 1.5;
+              color: #999999;
+            }
+
+            .action-row-text a {
+              color: #999999;
+            }
+
+            .action-row-text a:hover {
+              color: #24272a;
+            }
+
+            .action-row-txid {
+              font-size: 14px;
+              font-weight: 500;
+              line-height: 1.29;
+              color: #0072ce;
+            }
+
+            .action-row-timer {
+              font-size: 12px;
+              color: #999999;
+              font-weight: 100;
+            }
+
+            .action-row-timer-status {
+              font-weight: 500;
+            }
+
+            pre {
+              white-space: pre-wrap; /* Since CSS 2.1 */
+              white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+              white-space: -pre-wrap; /* Opera 4-6 */
+              white-space: -o-pre-wrap; /* Opera 7 */
+              word-wrap: break-word; /* Internet Explorer 5.5+ */
+            }
+          
+  </style>,
 ]
 `;
 
 exports[`<ActionsList /> renders functioncall by default 1`] = `
-<div
-  className="action-sparse-row mx-0  row no-gutters"
->
+Array [
   <div
-    className="col-auto"
+    className="action-sparse-row mx-0  row no-gutters"
   >
     <div
-      className="jsx-1246332424 action-row-img"
-    >
-      <svg
-        viewBox="0 0 18 18"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="m0 9 6 6L9 0zm12-6L9 18l9-9z"
-          fill="#ccc"
-        />
-      </svg>
-    </div>
-  </div>
-  <div
-    className="action-row-details col"
-  >
-    <div
-      className="action-row-message row no-gutters"
+      className="col-auto"
     >
       <div
-        className="col-md-8 col-7"
+        className="action-row-img"
+      >
+        <svg
+          viewBox="0 0 18 18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m0 9 6 6L9 0zm12-6L9 18l9-9z"
+            fill="#ccc"
+          />
+        </svg>
+      </div>
+    </div>
+    <div
+      className="action-row-details col"
+    >
+      <div
+        className="action-row-message row no-gutters"
       >
         <div
-          className="row no-gutters"
+          className="col-md-8 col-7"
         >
           <div
-            className="action-row-title col"
+            className="row no-gutters"
           >
-            Called method: 'addMessage' in contract: 
-            <span
-              onClick={[Function]}
+            <div
+              className="action-row-title col"
             >
-              <a
-                className="jsx-3150401870 account-link"
-                href="/accounts/receiver2.test"
+              Called method: 'addMessage' in contract: 
+              <span
                 onClick={[Function]}
-                onMouseEnter={[Function]}
               >
-                receiver2.test
-              </a>
-            </span>
-            <dl>
-              <dt>
-                Arguments:
-              </dt>
-              <dd>
-                <div>
-                  <div
-                    style={
-                      Object {
-                        "display": "block",
-                        "height": "0px",
-                        "overflow": "hidden",
-                      }
-                    }
-                  >
-                    <textarea
-                      className="jsx-2493677144 code-preview"
-                      readOnly={true}
-                      value="{
-  \\"text\\": \\"when ico?\\"
-}"
-                    />
-                  </div>
-                  <div
-                    onClick={[Function]}
-                  >
+                <a
+                  className="account-link"
+                  href="/accounts/receiver2.test"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  receiver2.test
+                </a>
+              </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
+              <dl>
+                <dt>
+                  Arguments:
+                </dt>
+                <dd>
+                  <div>
                     <div
                       style={
                         Object {
-                          "float": "left",
+                          "display": "block",
+                          "height": "0px",
+                          "overflow": "hidden",
                         }
                       }
                     >
-                      Show more
+                      <textarea
+                        className="code-preview"
+                        readOnly={true}
+                        value="{
+  \\"text\\": \\"when ico?\\"
+}"
+                      />
+                    </div>
+                    <div
+                      onClick={[Function]}
+                    >
+                      <div
+                        style={
+                          Object {
+                            "float": "left",
+                          }
+                        }
+                      >
+                        Show more
+                      </div>
                     </div>
                   </div>
-                </div>
-              </dd>
-            </dl>
+                  <style>
+                    
+        @import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap");
+        .code-preview {
+          font-family: "Source Code Pro", monospace;
+          background: #424957;
+          color: white;
+          padding: 20px;
+          width: 100%;
+          height: 99%;
+        }
+      
+                  </style>
+                </dd>
+              </dl>
+            </div>
           </div>
-        </div>
-        <div
-          className="row no-gutters"
-        >
           <div
-            className="action-row-text col"
+            className="row no-gutters"
           >
-            by
-             
-            <span
-              onClick={[Function]}
+            <div
+              className="action-row-text col"
             >
-              <a
-                className="jsx-3150401870 account-link"
-                href="/accounts/signer2.test"
+              by
+               
+              <span
                 onClick={[Function]}
-                onMouseEnter={[Function]}
               >
-                signer2.test
-              </a>
-            </span>
+                <a
+                  className="account-link"
+                  href="/accounts/signer2.test"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  signer2.test
+                </a>
+              </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
+            </div>
           </div>
         </div>
-      </div>
-      <div
-        className="ml-auto text-right col-md-4 col-5"
-      >
         <div
-          className="row"
+          className="ml-auto text-right col-md-4 col-5"
         >
           <div
-            className="action-row-txid col"
+            className="row"
           >
-            <span
-              onClick={[Function]}
+            <div
+              className="action-row-txid col"
             >
-              <a
-                className="transaction-link"
-                href="/transactions/222eW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
+              <span
                 onClick={[Function]}
-                onMouseEnter={[Function]}
               >
-                222eW6g...
-              </a>
-            </span>
+                <a
+                  className="transaction-link"
+                  href="/transactions/222eW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  222eW6g...
+                </a>
+              </span>
+            </div>
           </div>
-        </div>
-        <div
-          className="row"
-        >
           <div
-            className="action-row-timer col"
+            className="row"
           >
-            <span
-              className="jsx-1246332424 action-row-timer-status"
+            <div
+              className="action-row-timer col"
             >
-              Fetching Status...
-              /Checking Finality...
-            </span>
-             
-            <span>
-              1s ago
-            </span>
+              <span
+                className="action-row-timer-status"
+              >
+                Fetching Status...
+                /Checking Finality...
+              </span>
+               
+              <span>
+                1s ago
+              </span>
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+  <style>
+    
+            .action-sparse-row {
+              padding-top: 10px;
+              padding-bottom: 10px;
+              border-top: solid 2px #f8f8f8;
+            }
+            .action-sparse-row .action-sparse-row {
+              border-top: 0;
+            }
+
+            .action-compact-row .action-row-message {
+              margin-bottom: 1em;
+            }
+
+            .action-compact-row .action-row-details {
+              border-bottom: 2px solid #f8f8f8;
+              margin: 0.1em 0 0;
+              padding-bottom: 8px;
+            }
+
+            .action-row-details .action-row-details {
+              border: 0;
+            }
+
+            .action-compact-row .action-row-img {
+              width: 24px;
+              height: 24px;
+              border: solid 2px #f8f8f8;
+              background-color: #ffffff;
+              border-radius: 50%;
+              margin-right: 8px;
+              text-align: center;
+              line-height: 1.1;
+            }
+
+            .action-sparse-row .action-row-img {
+              margin: 10px;
+              display: inline;
+              height: 20px;
+              width: 20px;
+            }
+
+            .action-sparse-row .action-row-img svg {
+              height: 16px;
+              width: 16px;
+            }
+
+            .action-row-bottom {
+              border-bottom: solid 2px #f8f8f8;
+            }
+
+            .action-compact-row .action-row-img svg {
+              height: 12px;
+              width: 12px;
+            }
+
+            .action-sparse-row .action-row-toggler {
+              width: 10px;
+              margin: 10px;
+            }
+
+            .action-row-title {
+              font-size: 14px;
+              font-weight: 500;
+              color: #24272a;
+            }
+
+            .action-row-title a {
+              color: #666;
+            }
+
+            .action-row-title a:hover {
+              color: #24272a;
+            }
+
+            .action-row-text {
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 1.5;
+              color: #999999;
+            }
+
+            .action-row-text a {
+              color: #999999;
+            }
+
+            .action-row-text a:hover {
+              color: #24272a;
+            }
+
+            .action-row-txid {
+              font-size: 14px;
+              font-weight: 500;
+              line-height: 1.29;
+              color: #0072ce;
+            }
+
+            .action-row-timer {
+              font-size: 12px;
+              color: #999999;
+              font-weight: 100;
+            }
+
+            .action-row-timer-status {
+              font-weight: 500;
+            }
+
+            pre {
+              white-space: pre-wrap; /* Since CSS 2.1 */
+              white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+              white-space: -pre-wrap; /* Opera 4-6 */
+              white-space: -o-pre-wrap; /* Opera 7 */
+              word-wrap: break-word; /* Internet Explorer 5.5+ */
+            }
+          
+  </style>,
+]
 `;
 
 exports[`<ActionsList /> renders sparsely by default for Receipts 1`] = `
-<div
-  className="action-sparse-row mx-0  row no-gutters"
->
+Array [
   <div
-    className="col-auto"
+    className="action-sparse-row mx-0  row no-gutters"
   >
     <div
-      className="jsx-1246332424 action-row-img"
-    >
-      <svg
-        viewBox="0 0 18 18"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="m0 9 6 6L9 0zm12-6L9 18l9-9z"
-          fill="#ccc"
-        />
-      </svg>
-    </div>
-  </div>
-  <div
-    className="action-row-details col"
-  >
-    <div
-      className="action-row-message row no-gutters"
+      className="col-auto"
     >
       <div
-        className="col-md-8 col-7"
+        className="action-row-img"
+      >
+        <svg
+          viewBox="0 0 18 18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m0 9 6 6L9 0zm12-6L9 18l9-9z"
+            fill="#ccc"
+          />
+        </svg>
+      </div>
+    </div>
+    <div
+      className="action-row-details col"
+    >
+      <div
+        className="action-row-message row no-gutters"
       >
         <div
-          className="row no-gutters"
+          className="col-md-8 col-7"
         >
           <div
-            className="action-row-title col"
+            className="row no-gutters"
           >
-            Called method: 'on_staking_pool_withdraw' in contract: 
-            <span
-              onClick={[Function]}
+            <div
+              className="action-row-title col"
             >
-              <a
-                className="jsx-3150401870 account-link"
-                href="/accounts/5ce78003b590264df3f259983f3c3e0917fc10ea.lockup.near"
+              Called method: 'on_staking_pool_withdraw' in contract: 
+              <span
                 onClick={[Function]}
-                onMouseEnter={[Function]}
               >
-                5ce78…ockup.near
-              </a>
-            </span>
+                <a
+                  className="account-link"
+                  href="/accounts/5ce78003b590264df3f259983f3c3e0917fc10ea.lockup.near"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  5ce78…ockup.near
+                </a>
+              </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
+            </div>
+          </div>
+          <div
+            className="row no-gutters"
+          >
+            <div
+              className="action-row-text col"
+            >
+              by
+               
+              <span
+                onClick={[Function]}
+              >
+                <a
+                  className="account-link"
+                  href="/accounts/5ce78003b590264df3f259983f3c3e0917fc10ea.lockup.near"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  5ce78…ockup.near
+                </a>
+              </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
+            </div>
           </div>
         </div>
         <div
-          className="row no-gutters"
+          className="ml-auto text-right col-md-4 col-5"
         >
           <div
-            className="action-row-text col"
+            className="row"
           >
-            by
-             
-            <span
-              onClick={[Function]}
+            <div
+              className="action-row-txid col"
             >
-              <a
-                className="jsx-3150401870 account-link"
-                href="/accounts/5ce78003b590264df3f259983f3c3e0917fc10ea.lockup.near"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
+              <span
+                className="receipt-hash-link disabled"
+                title="BvG4qfnrxVfpqXrSgxxnfdrHYTKFjTcf2LtgEeX5Mzyz"
               >
-                5ce78…ockup.near
-              </a>
-            </span>
+                BvG4qfn...
+              </span>
+              <style>
+                
+        .receipt-hash-link.disabled {
+          cursor: default;
+          color: #24272a;
+        }
+      
+              </style>
+            </div>
+          </div>
+          <div
+            className="row"
+          >
+            <div
+              className="action-row-timer col"
+            >
+              <span
+                className="action-row-timer-status"
+              >
+                Fetching Status...
+                /Checking Finality...
+              </span>
+               
+              <span>
+                in 2y
+              </span>
+            </div>
           </div>
         </div>
       </div>
-      <div
-        className="ml-auto text-right col-md-4 col-5"
-      >
-        <div
-          className="row"
-        >
-          <div
-            className="action-row-txid col"
-          >
-            <span
-              className="jsx-4207953579 receipt-hash-link disabled"
-              title="BvG4qfnrxVfpqXrSgxxnfdrHYTKFjTcf2LtgEeX5Mzyz"
-            >
-              BvG4qfn...
-            </span>
-          </div>
-        </div>
-        <div
-          className="row"
-        >
-          <div
-            className="action-row-timer col"
-          >
-            <span
-              className="jsx-1246332424 action-row-timer-status"
-            >
-              Fetching Status...
-              /Checking Finality...
-            </span>
-             
-            <span>
-              in 2y
-            </span>
-          </div>
-        </div>
-      </div>
     </div>
-  </div>
-</div>
+  </div>,
+  <style>
+    
+            .action-sparse-row {
+              padding-top: 10px;
+              padding-bottom: 10px;
+              border-top: solid 2px #f8f8f8;
+            }
+            .action-sparse-row .action-sparse-row {
+              border-top: 0;
+            }
+
+            .action-compact-row .action-row-message {
+              margin-bottom: 1em;
+            }
+
+            .action-compact-row .action-row-details {
+              border-bottom: 2px solid #f8f8f8;
+              margin: 0.1em 0 0;
+              padding-bottom: 8px;
+            }
+
+            .action-row-details .action-row-details {
+              border: 0;
+            }
+
+            .action-compact-row .action-row-img {
+              width: 24px;
+              height: 24px;
+              border: solid 2px #f8f8f8;
+              background-color: #ffffff;
+              border-radius: 50%;
+              margin-right: 8px;
+              text-align: center;
+              line-height: 1.1;
+            }
+
+            .action-sparse-row .action-row-img {
+              margin: 10px;
+              display: inline;
+              height: 20px;
+              width: 20px;
+            }
+
+            .action-sparse-row .action-row-img svg {
+              height: 16px;
+              width: 16px;
+            }
+
+            .action-row-bottom {
+              border-bottom: solid 2px #f8f8f8;
+            }
+
+            .action-compact-row .action-row-img svg {
+              height: 12px;
+              width: 12px;
+            }
+
+            .action-sparse-row .action-row-toggler {
+              width: 10px;
+              margin: 10px;
+            }
+
+            .action-row-title {
+              font-size: 14px;
+              font-weight: 500;
+              color: #24272a;
+            }
+
+            .action-row-title a {
+              color: #666;
+            }
+
+            .action-row-title a:hover {
+              color: #24272a;
+            }
+
+            .action-row-text {
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 1.5;
+              color: #999999;
+            }
+
+            .action-row-text a {
+              color: #999999;
+            }
+
+            .action-row-text a:hover {
+              color: #24272a;
+            }
+
+            .action-row-txid {
+              font-size: 14px;
+              font-weight: 500;
+              line-height: 1.29;
+              color: #0072ce;
+            }
+
+            .action-row-timer {
+              font-size: 12px;
+              color: #999999;
+              font-weight: 100;
+            }
+
+            .action-row-timer-status {
+              font-weight: 500;
+            }
+
+            pre {
+              white-space: pre-wrap; /* Since CSS 2.1 */
+              white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+              white-space: -pre-wrap; /* Opera 4-6 */
+              white-space: -o-pre-wrap; /* Opera 7 */
+              word-wrap: break-word; /* Internet Explorer 5.5+ */
+            }
+          
+  </style>,
+]
 `;
 
 exports[`<ActionsList /> renders sparsely by default for Transactions 1`] = `
@@ -675,7 +1365,7 @@ Array [
       className="col-auto"
     >
       <div
-        className="jsx-1246332424 action-row-img"
+        className="action-row-img"
       >
         <svg
           viewBox="0 0 18 18"
@@ -708,7 +1398,7 @@ Array [
                 onClick={[Function]}
               >
                 <a
-                  className="jsx-3150401870 account-link"
+                  className="account-link"
                   href="/accounts/receiver.test"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
@@ -716,6 +1406,13 @@ Array [
                   receiver.test
                 </a>
               </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
             </div>
           </div>
           <div
@@ -730,7 +1427,7 @@ Array [
                 onClick={[Function]}
               >
                 <a
-                  className="jsx-3150401870 account-link"
+                  className="account-link"
                   href="/accounts/signer.test"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
@@ -738,6 +1435,13 @@ Array [
                   signer.test
                 </a>
               </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
             </div>
           </div>
         </div>
@@ -771,7 +1475,7 @@ Array [
               className="action-row-timer col"
             >
               <span
-                className="jsx-1246332424 action-row-timer-status"
+                className="action-row-timer-status"
               >
                 Fetching Status...
                 /Checking Finality...
@@ -786,6 +1490,123 @@ Array [
       </div>
     </div>
   </div>,
+  <style>
+    
+            .action-sparse-row {
+              padding-top: 10px;
+              padding-bottom: 10px;
+              border-top: solid 2px #f8f8f8;
+            }
+            .action-sparse-row .action-sparse-row {
+              border-top: 0;
+            }
+
+            .action-compact-row .action-row-message {
+              margin-bottom: 1em;
+            }
+
+            .action-compact-row .action-row-details {
+              border-bottom: 2px solid #f8f8f8;
+              margin: 0.1em 0 0;
+              padding-bottom: 8px;
+            }
+
+            .action-row-details .action-row-details {
+              border: 0;
+            }
+
+            .action-compact-row .action-row-img {
+              width: 24px;
+              height: 24px;
+              border: solid 2px #f8f8f8;
+              background-color: #ffffff;
+              border-radius: 50%;
+              margin-right: 8px;
+              text-align: center;
+              line-height: 1.1;
+            }
+
+            .action-sparse-row .action-row-img {
+              margin: 10px;
+              display: inline;
+              height: 20px;
+              width: 20px;
+            }
+
+            .action-sparse-row .action-row-img svg {
+              height: 16px;
+              width: 16px;
+            }
+
+            .action-row-bottom {
+              border-bottom: solid 2px #f8f8f8;
+            }
+
+            .action-compact-row .action-row-img svg {
+              height: 12px;
+              width: 12px;
+            }
+
+            .action-sparse-row .action-row-toggler {
+              width: 10px;
+              margin: 10px;
+            }
+
+            .action-row-title {
+              font-size: 14px;
+              font-weight: 500;
+              color: #24272a;
+            }
+
+            .action-row-title a {
+              color: #666;
+            }
+
+            .action-row-title a:hover {
+              color: #24272a;
+            }
+
+            .action-row-text {
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 1.5;
+              color: #999999;
+            }
+
+            .action-row-text a {
+              color: #999999;
+            }
+
+            .action-row-text a:hover {
+              color: #24272a;
+            }
+
+            .action-row-txid {
+              font-size: 14px;
+              font-weight: 500;
+              line-height: 1.29;
+              color: #0072ce;
+            }
+
+            .action-row-timer {
+              font-size: 12px;
+              color: #999999;
+              font-weight: 100;
+            }
+
+            .action-row-timer-status {
+              font-weight: 500;
+            }
+
+            pre {
+              white-space: pre-wrap; /* Since CSS 2.1 */
+              white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+              white-space: -pre-wrap; /* Opera 4-6 */
+              white-space: -o-pre-wrap; /* Opera 7 */
+              word-wrap: break-word; /* Internet Explorer 5.5+ */
+            }
+          
+  </style>,
   <div
     className="action-sparse-row mx-0  row no-gutters"
   >
@@ -793,7 +1614,7 @@ Array [
       className="col-auto"
     >
       <div
-        className="jsx-1246332424 action-row-img"
+        className="action-row-img"
       >
         <svg
           viewBox="0 0 18 18"
@@ -826,7 +1647,7 @@ Array [
                 onClick={[Function]}
               >
                 <a
-                  className="jsx-3150401870 account-link"
+                  className="account-link"
                   href="/accounts/receiver.test"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
@@ -834,6 +1655,13 @@ Array [
                   receiver.test
                 </a>
               </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
               : ed25519:8LXEySy...
               <p>
                 with permission FullAccess
@@ -852,7 +1680,7 @@ Array [
                 onClick={[Function]}
               >
                 <a
-                  className="jsx-3150401870 account-link"
+                  className="account-link"
                   href="/accounts/signer.test"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
@@ -860,6 +1688,13 @@ Array [
                   signer.test
                 </a>
               </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
             </div>
           </div>
         </div>
@@ -893,7 +1728,7 @@ Array [
               className="action-row-timer col"
             >
               <span
-                className="jsx-1246332424 action-row-timer-status"
+                className="action-row-timer-status"
               >
                 Fetching Status...
                 /Checking Finality...
@@ -908,5 +1743,122 @@ Array [
       </div>
     </div>
   </div>,
+  <style>
+    
+            .action-sparse-row {
+              padding-top: 10px;
+              padding-bottom: 10px;
+              border-top: solid 2px #f8f8f8;
+            }
+            .action-sparse-row .action-sparse-row {
+              border-top: 0;
+            }
+
+            .action-compact-row .action-row-message {
+              margin-bottom: 1em;
+            }
+
+            .action-compact-row .action-row-details {
+              border-bottom: 2px solid #f8f8f8;
+              margin: 0.1em 0 0;
+              padding-bottom: 8px;
+            }
+
+            .action-row-details .action-row-details {
+              border: 0;
+            }
+
+            .action-compact-row .action-row-img {
+              width: 24px;
+              height: 24px;
+              border: solid 2px #f8f8f8;
+              background-color: #ffffff;
+              border-radius: 50%;
+              margin-right: 8px;
+              text-align: center;
+              line-height: 1.1;
+            }
+
+            .action-sparse-row .action-row-img {
+              margin: 10px;
+              display: inline;
+              height: 20px;
+              width: 20px;
+            }
+
+            .action-sparse-row .action-row-img svg {
+              height: 16px;
+              width: 16px;
+            }
+
+            .action-row-bottom {
+              border-bottom: solid 2px #f8f8f8;
+            }
+
+            .action-compact-row .action-row-img svg {
+              height: 12px;
+              width: 12px;
+            }
+
+            .action-sparse-row .action-row-toggler {
+              width: 10px;
+              margin: 10px;
+            }
+
+            .action-row-title {
+              font-size: 14px;
+              font-weight: 500;
+              color: #24272a;
+            }
+
+            .action-row-title a {
+              color: #666;
+            }
+
+            .action-row-title a:hover {
+              color: #24272a;
+            }
+
+            .action-row-text {
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 1.5;
+              color: #999999;
+            }
+
+            .action-row-text a {
+              color: #999999;
+            }
+
+            .action-row-text a:hover {
+              color: #24272a;
+            }
+
+            .action-row-txid {
+              font-size: 14px;
+              font-weight: 500;
+              line-height: 1.29;
+              color: #0072ce;
+            }
+
+            .action-row-timer {
+              font-size: 12px;
+              color: #999999;
+              font-weight: 100;
+            }
+
+            .action-row-timer-status {
+              font-weight: 500;
+            }
+
+            pre {
+              white-space: pre-wrap; /* Since CSS 2.1 */
+              white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+              white-space: -pre-wrap; /* Opera 4-6 */
+              white-space: -o-pre-wrap; /* Opera 7 */
+              word-wrap: break-word; /* Internet Explorer 5.5+ */
+            }
+          
+  </style>,
 ]
 `;

--- a/frontend/src/components/transactions/__tests__/__snapshots__/ReceiptRow.test.tsx.snap
+++ b/frontend/src/components/transactions/__tests__/__snapshots__/ReceiptRow.test.tsx.snap
@@ -14,9 +14,7 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
       <div
         className="receipt-row-title receipt-hash-title col"
       >
-        <b
-          className="jsx-1757047684"
-        >
+        <b>
           Receipt
           :
         </b>
@@ -38,7 +36,7 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
           onClick={[Function]}
         >
           <a
-            className="jsx-4207953579 receipt-hash-link"
+            className="receipt-hash-link"
             href="/transactions/T1111111111111111111111111111111111111111111#R1111111111111111111111111111111111111111111"
             onClick={[Function]}
             onMouseEnter={[Function]}
@@ -46,6 +44,14 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
             R1111111111111111111111111111111111111111111
           </a>
         </span>
+        <style>
+          
+        .receipt-hash-link.disabled {
+          cursor: default;
+          color: #24272a;
+        }
+      
+        </style>
       </div>
     </div>
     <div
@@ -91,7 +97,7 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
           onClick={[Function]}
         >
           <a
-            className="jsx-3150401870 account-link"
+            className="account-link"
             href="/accounts/signer.test"
             onClick={[Function]}
             onMouseEnter={[Function]}
@@ -99,6 +105,13 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
             signer.test
           </a>
         </span>
+        <style>
+          
+        .account-link {
+          white-space: nowrap;
+        }
+      
+        </style>
       </div>
     </div>
     <div
@@ -118,7 +131,7 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
           onClick={[Function]}
         >
           <a
-            className="jsx-3150401870 account-link"
+            className="account-link"
             href="/accounts/receiver.test"
             onClick={[Function]}
             onMouseEnter={[Function]}
@@ -126,6 +139,13 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
             receiver.test
           </a>
         </span>
+        <style>
+          
+        .account-link {
+          white-space: nowrap;
+        }
+      
+        </style>
       </div>
     </div>
     <div
@@ -180,7 +200,7 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
             className="col-auto"
           >
             <div
-              className="jsx-1246332424 action-row-img"
+              className="action-row-img"
             >
               <svg
                 viewBox="0 0 18 18"
@@ -213,7 +233,7 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
                       onClick={[Function]}
                     >
                       <a
-                        className="jsx-3150401870 account-link"
+                        className="account-link"
                         href="/accounts/receiver.test"
                         onClick={[Function]}
                         onMouseEnter={[Function]}
@@ -221,6 +241,13 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
                         receiver.test
                       </a>
                     </span>
+                    <style>
+                      
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                    </style>
                     <dl>
                       <dt>
                         Arguments:
@@ -237,7 +264,7 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
                             }
                           >
                             <textarea
-                              className="jsx-2493677144 code-preview"
+                              className="code-preview"
                               readOnly={true}
                               value="{
   \\"listing_id\\": \\"000028066\\",
@@ -259,6 +286,19 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
                             </div>
                           </div>
                         </div>
+                        <style>
+                          
+        @import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap");
+        .code-preview {
+          font-family: "Source Code Pro", monospace;
+          background: #424957;
+          color: white;
+          padding: 20px;
+          width: 100%;
+          height: 99%;
+        }
+      
+                        </style>
                       </dd>
                     </dl>
                   </div>
@@ -267,6 +307,123 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+            .action-sparse-row {
+              padding-top: 10px;
+              padding-bottom: 10px;
+              border-top: solid 2px #f8f8f8;
+            }
+            .action-sparse-row .action-sparse-row {
+              border-top: 0;
+            }
+
+            .action-compact-row .action-row-message {
+              margin-bottom: 1em;
+            }
+
+            .action-compact-row .action-row-details {
+              border-bottom: 2px solid #f8f8f8;
+              margin: 0.1em 0 0;
+              padding-bottom: 8px;
+            }
+
+            .action-row-details .action-row-details {
+              border: 0;
+            }
+
+            .action-compact-row .action-row-img {
+              width: 24px;
+              height: 24px;
+              border: solid 2px #f8f8f8;
+              background-color: #ffffff;
+              border-radius: 50%;
+              margin-right: 8px;
+              text-align: center;
+              line-height: 1.1;
+            }
+
+            .action-sparse-row .action-row-img {
+              margin: 10px;
+              display: inline;
+              height: 20px;
+              width: 20px;
+            }
+
+            .action-sparse-row .action-row-img svg {
+              height: 16px;
+              width: 16px;
+            }
+
+            .action-row-bottom {
+              border-bottom: solid 2px #f8f8f8;
+            }
+
+            .action-compact-row .action-row-img svg {
+              height: 12px;
+              width: 12px;
+            }
+
+            .action-sparse-row .action-row-toggler {
+              width: 10px;
+              margin: 10px;
+            }
+
+            .action-row-title {
+              font-size: 14px;
+              font-weight: 500;
+              color: #24272a;
+            }
+
+            .action-row-title a {
+              color: #666;
+            }
+
+            .action-row-title a:hover {
+              color: #24272a;
+            }
+
+            .action-row-text {
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 1.5;
+              color: #999999;
+            }
+
+            .action-row-text a {
+              color: #999999;
+            }
+
+            .action-row-text a:hover {
+              color: #24272a;
+            }
+
+            .action-row-txid {
+              font-size: 14px;
+              font-weight: 500;
+              line-height: 1.29;
+              color: #0072ce;
+            }
+
+            .action-row-timer {
+              font-size: 12px;
+              color: #999999;
+              font-weight: 100;
+            }
+
+            .action-row-timer-status {
+              font-weight: 500;
+            }
+
+            pre {
+              white-space: pre-wrap; /* Since CSS 2.1 */
+              white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+              white-space: -pre-wrap; /* Opera 4-6 */
+              white-space: -o-pre-wrap; /* Opera 7 */
+              word-wrap: break-word; /* Internet Explorer 5.5+ */
+            }
+          
+        </style>
       </div>
     </div>
     <div
@@ -304,9 +461,7 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
       <div
         className="receipt-row-text col"
       >
-        <pre
-          className="jsx-1757047684"
-        >
+        <pre>
           000028066 listings not found
         </pre>
       </div>
@@ -330,9 +485,7 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
               <div
                 className="receipt-row-title receipt-hash-title col"
               >
-                <b
-                  className="jsx-1757047684"
-                >
+                <b>
                   Receipt
                   :
                 </b>
@@ -354,7 +507,7 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
                   onClick={[Function]}
                 >
                   <a
-                    className="jsx-4207953579 receipt-hash-link"
+                    className="receipt-hash-link"
                     href="/transactions/T1111111111111111111111111111111111111111111#R2222222222222222222222222222222222222222222"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
@@ -362,6 +515,14 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
                     R2222222222222222222222222222222222222222222
                   </a>
                 </span>
+                <style>
+                  
+        .receipt-hash-link.disabled {
+          cursor: default;
+          color: #24272a;
+        }
+      
+                </style>
               </div>
             </div>
             <div
@@ -407,7 +568,7 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
                   onClick={[Function]}
                 >
                   <a
-                    className="jsx-3150401870 account-link"
+                    className="account-link"
                     href="/accounts/system"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
@@ -415,6 +576,13 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
                     system
                   </a>
                 </span>
+                <style>
+                  
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                </style>
               </div>
             </div>
             <div
@@ -434,7 +602,7 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
                   onClick={[Function]}
                 >
                   <a
-                    className="jsx-3150401870 account-link"
+                    className="account-link"
                     href="/accounts/receiver.test"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
@@ -442,6 +610,13 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
                     receiver.test
                   </a>
                 </span>
+                <style>
+                  
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                </style>
               </div>
             </div>
             <div
@@ -496,7 +671,7 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
                     className="col-auto"
                   >
                     <div
-                      className="jsx-1246332424 action-row-img"
+                      className="action-row-img"
                     >
                       <svg
                         viewBox="0 0 18 18"
@@ -540,7 +715,7 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
                               onClick={[Function]}
                             >
                               <a
-                                className="jsx-3150401870 account-link"
+                                className="account-link"
                                 href="/accounts/receiver.test"
                                 onClick={[Function]}
                                 onMouseEnter={[Function]}
@@ -548,12 +723,136 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
                                 receiver.test
                               </a>
                             </span>
+                            <style>
+                              
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                            </style>
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
                 </div>
+                <style>
+                  
+            .action-sparse-row {
+              padding-top: 10px;
+              padding-bottom: 10px;
+              border-top: solid 2px #f8f8f8;
+            }
+            .action-sparse-row .action-sparse-row {
+              border-top: 0;
+            }
+
+            .action-compact-row .action-row-message {
+              margin-bottom: 1em;
+            }
+
+            .action-compact-row .action-row-details {
+              border-bottom: 2px solid #f8f8f8;
+              margin: 0.1em 0 0;
+              padding-bottom: 8px;
+            }
+
+            .action-row-details .action-row-details {
+              border: 0;
+            }
+
+            .action-compact-row .action-row-img {
+              width: 24px;
+              height: 24px;
+              border: solid 2px #f8f8f8;
+              background-color: #ffffff;
+              border-radius: 50%;
+              margin-right: 8px;
+              text-align: center;
+              line-height: 1.1;
+            }
+
+            .action-sparse-row .action-row-img {
+              margin: 10px;
+              display: inline;
+              height: 20px;
+              width: 20px;
+            }
+
+            .action-sparse-row .action-row-img svg {
+              height: 16px;
+              width: 16px;
+            }
+
+            .action-row-bottom {
+              border-bottom: solid 2px #f8f8f8;
+            }
+
+            .action-compact-row .action-row-img svg {
+              height: 12px;
+              width: 12px;
+            }
+
+            .action-sparse-row .action-row-toggler {
+              width: 10px;
+              margin: 10px;
+            }
+
+            .action-row-title {
+              font-size: 14px;
+              font-weight: 500;
+              color: #24272a;
+            }
+
+            .action-row-title a {
+              color: #666;
+            }
+
+            .action-row-title a:hover {
+              color: #24272a;
+            }
+
+            .action-row-text {
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 1.5;
+              color: #999999;
+            }
+
+            .action-row-text a {
+              color: #999999;
+            }
+
+            .action-row-text a:hover {
+              color: #24272a;
+            }
+
+            .action-row-txid {
+              font-size: 14px;
+              font-weight: 500;
+              line-height: 1.29;
+              color: #0072ce;
+            }
+
+            .action-row-timer {
+              font-size: 12px;
+              color: #999999;
+              font-weight: 100;
+            }
+
+            .action-row-timer-status {
+              font-weight: 500;
+            }
+
+            pre {
+              white-space: pre-wrap; /* Since CSS 2.1 */
+              white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+              white-space: -pre-wrap; /* Opera 4-6 */
+              white-space: -o-pre-wrap; /* Opera 7 */
+              word-wrap: break-word; /* Internet Explorer 5.5+ */
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -575,10 +874,120 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
               </div>
             </div>
           </div>
+          <style>
+            
+          .receipt-row {
+            padding-top: 10px;
+            padding-bottom: 30px;
+          }
+
+          .receipt-row-section {
+            padding-top: 10px;
+            padding-left: 1.5rem;
+            border-left: 2px solid #e5e5e5;
+          }
+
+          .executed-receipt-row .receipt-row {
+            padding-left: 1.5rem;
+            padding-bottom: 0;
+            border-left: 2px solid #e5e5e5;
+          }
+
+          .receipt-hash-title {
+            padding-bottom: 10px;
+          }
+
+          .receipt-row-title {
+            font-size: 14px;
+            line-height: 1.29;
+            color: #24272a;
+          }
+
+          .receipt-row-text {
+            font-size: 12px;
+            line-height: 1.5;
+            color: #999999;
+          }
+
+          .receipt-row-receipt-hash {
+            font-size: 14px;
+            font-weight: 500;
+            line-height: 1.29;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+          }
+
+          .receipt-row-receipt-hash.truncate-link {
+            color: #007bff;
+          }
+
+          .receipt-row-status {
+            font-size: 12px;
+            color: #999999;
+            font-weight: 500;
+          }
+        
+          </style>
         </div>
       </div>
     </div>
   </div>
+  <style>
+    
+          .receipt-row {
+            padding-top: 10px;
+            padding-bottom: 30px;
+          }
+
+          .receipt-row-section {
+            padding-top: 10px;
+            padding-left: 1.5rem;
+            border-left: 2px solid #e5e5e5;
+          }
+
+          .executed-receipt-row .receipt-row {
+            padding-left: 1.5rem;
+            padding-bottom: 0;
+            border-left: 2px solid #e5e5e5;
+          }
+
+          .receipt-hash-title {
+            padding-bottom: 10px;
+          }
+
+          .receipt-row-title {
+            font-size: 14px;
+            line-height: 1.29;
+            color: #24272a;
+          }
+
+          .receipt-row-text {
+            font-size: 12px;
+            line-height: 1.5;
+            color: #999999;
+          }
+
+          .receipt-row-receipt-hash {
+            font-size: 14px;
+            font-weight: 500;
+            line-height: 1.29;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+          }
+
+          .receipt-row-receipt-hash.truncate-link {
+            color: #007bff;
+          }
+
+          .receipt-row-status {
+            font-size: 12px;
+            color: #999999;
+            font-weight: 500;
+          }
+        
+  </style>
 </div>
 `;
 
@@ -596,9 +1005,7 @@ exports[`<ReceiptRow /> renders receipt with many outcome receipts 1`] = `
       <div
         className="receipt-row-title receipt-hash-title col"
       >
-        <b
-          className="jsx-1757047684"
-        >
+        <b>
           Receipt
           :
         </b>
@@ -620,7 +1027,7 @@ exports[`<ReceiptRow /> renders receipt with many outcome receipts 1`] = `
           onClick={[Function]}
         >
           <a
-            className="jsx-4207953579 receipt-hash-link"
+            className="receipt-hash-link"
             href="/transactions/T1111111111111111111111111111111111111111111#R1111111111111111111111111111111111111111111"
             onClick={[Function]}
             onMouseEnter={[Function]}
@@ -628,6 +1035,14 @@ exports[`<ReceiptRow /> renders receipt with many outcome receipts 1`] = `
             R1111111111111111111111111111111111111111111
           </a>
         </span>
+        <style>
+          
+        .receipt-hash-link.disabled {
+          cursor: default;
+          color: #24272a;
+        }
+      
+        </style>
       </div>
     </div>
     <div
@@ -673,7 +1088,7 @@ exports[`<ReceiptRow /> renders receipt with many outcome receipts 1`] = `
           onClick={[Function]}
         >
           <a
-            className="jsx-3150401870 account-link"
+            className="account-link"
             href="/accounts/signer.test"
             onClick={[Function]}
             onMouseEnter={[Function]}
@@ -681,6 +1096,13 @@ exports[`<ReceiptRow /> renders receipt with many outcome receipts 1`] = `
             signer.test
           </a>
         </span>
+        <style>
+          
+        .account-link {
+          white-space: nowrap;
+        }
+      
+        </style>
       </div>
     </div>
     <div
@@ -700,7 +1122,7 @@ exports[`<ReceiptRow /> renders receipt with many outcome receipts 1`] = `
           onClick={[Function]}
         >
           <a
-            className="jsx-3150401870 account-link"
+            className="account-link"
             href="/accounts/receiver.test"
             onClick={[Function]}
             onMouseEnter={[Function]}
@@ -708,6 +1130,13 @@ exports[`<ReceiptRow /> renders receipt with many outcome receipts 1`] = `
             receiver.test
           </a>
         </span>
+        <style>
+          
+        .account-link {
+          white-space: nowrap;
+        }
+      
+        </style>
       </div>
     </div>
     <div
@@ -762,7 +1191,7 @@ exports[`<ReceiptRow /> renders receipt with many outcome receipts 1`] = `
             className="col-auto"
           >
             <div
-              className="jsx-1246332424 action-row-img"
+              className="action-row-img"
             >
               <svg
                 viewBox="0 0 18 18"
@@ -795,7 +1224,7 @@ exports[`<ReceiptRow /> renders receipt with many outcome receipts 1`] = `
                       onClick={[Function]}
                     >
                       <a
-                        className="jsx-3150401870 account-link"
+                        className="account-link"
                         href="/accounts/receiver.test"
                         onClick={[Function]}
                         onMouseEnter={[Function]}
@@ -803,6 +1232,13 @@ exports[`<ReceiptRow /> renders receipt with many outcome receipts 1`] = `
                         receiver.test
                       </a>
                     </span>
+                    <style>
+                      
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                    </style>
                     <dl>
                       <dt>
                         Arguments:
@@ -819,7 +1255,7 @@ exports[`<ReceiptRow /> renders receipt with many outcome receipts 1`] = `
                             }
                           >
                             <textarea
-                              className="jsx-2493677144 code-preview"
+                              className="code-preview"
                               readOnly={true}
                               value="{
   \\"receiver_id\\": \\"farm.berryclub.ek.near\\",
@@ -843,6 +1279,19 @@ exports[`<ReceiptRow /> renders receipt with many outcome receipts 1`] = `
                             </div>
                           </div>
                         </div>
+                        <style>
+                          
+        @import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap");
+        .code-preview {
+          font-family: "Source Code Pro", monospace;
+          background: #424957;
+          color: white;
+          padding: 20px;
+          width: 100%;
+          height: 99%;
+        }
+      
+                        </style>
                       </dd>
                     </dl>
                   </div>
@@ -851,6 +1300,123 @@ exports[`<ReceiptRow /> renders receipt with many outcome receipts 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+            .action-sparse-row {
+              padding-top: 10px;
+              padding-bottom: 10px;
+              border-top: solid 2px #f8f8f8;
+            }
+            .action-sparse-row .action-sparse-row {
+              border-top: 0;
+            }
+
+            .action-compact-row .action-row-message {
+              margin-bottom: 1em;
+            }
+
+            .action-compact-row .action-row-details {
+              border-bottom: 2px solid #f8f8f8;
+              margin: 0.1em 0 0;
+              padding-bottom: 8px;
+            }
+
+            .action-row-details .action-row-details {
+              border: 0;
+            }
+
+            .action-compact-row .action-row-img {
+              width: 24px;
+              height: 24px;
+              border: solid 2px #f8f8f8;
+              background-color: #ffffff;
+              border-radius: 50%;
+              margin-right: 8px;
+              text-align: center;
+              line-height: 1.1;
+            }
+
+            .action-sparse-row .action-row-img {
+              margin: 10px;
+              display: inline;
+              height: 20px;
+              width: 20px;
+            }
+
+            .action-sparse-row .action-row-img svg {
+              height: 16px;
+              width: 16px;
+            }
+
+            .action-row-bottom {
+              border-bottom: solid 2px #f8f8f8;
+            }
+
+            .action-compact-row .action-row-img svg {
+              height: 12px;
+              width: 12px;
+            }
+
+            .action-sparse-row .action-row-toggler {
+              width: 10px;
+              margin: 10px;
+            }
+
+            .action-row-title {
+              font-size: 14px;
+              font-weight: 500;
+              color: #24272a;
+            }
+
+            .action-row-title a {
+              color: #666;
+            }
+
+            .action-row-title a:hover {
+              color: #24272a;
+            }
+
+            .action-row-text {
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 1.5;
+              color: #999999;
+            }
+
+            .action-row-text a {
+              color: #999999;
+            }
+
+            .action-row-text a:hover {
+              color: #24272a;
+            }
+
+            .action-row-txid {
+              font-size: 14px;
+              font-weight: 500;
+              line-height: 1.29;
+              color: #0072ce;
+            }
+
+            .action-row-timer {
+              font-size: 12px;
+              color: #999999;
+              font-weight: 100;
+            }
+
+            .action-row-timer-status {
+              font-weight: 500;
+            }
+
+            pre {
+              white-space: pre-wrap; /* Since CSS 2.1 */
+              white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+              white-space: -pre-wrap; /* Opera 4-6 */
+              white-space: -o-pre-wrap; /* Opera 7 */
+              word-wrap: break-word; /* Internet Explorer 5.5+ */
+            }
+          
+        </style>
       </div>
     </div>
     <div
@@ -875,9 +1441,7 @@ exports[`<ReceiptRow /> renders receipt with many outcome receipts 1`] = `
       <div
         className="receipt-row-text col"
       >
-        <pre
-          className="jsx-1757047684"
-        >
+        <pre>
           Transfer 9807229473212706028 from signer.test to receiver.test
 Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
         </pre>
@@ -902,9 +1466,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
               <div
                 className="receipt-row-title receipt-hash-title col"
               >
-                <b
-                  className="jsx-1757047684"
-                >
+                <b>
                   Receipt
                   :
                 </b>
@@ -926,7 +1488,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                   onClick={[Function]}
                 >
                   <a
-                    className="jsx-4207953579 receipt-hash-link"
+                    className="receipt-hash-link"
                     href="/transactions/T1111111111111111111111111111111111111111111#R222222222222222222222222222222222222222222"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
@@ -934,6 +1496,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                     R222222222222222222222222222222222222222222
                   </a>
                 </span>
+                <style>
+                  
+        .receipt-hash-link.disabled {
+          cursor: default;
+          color: #24272a;
+        }
+      
+                </style>
               </div>
             </div>
             <div
@@ -979,7 +1549,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                   onClick={[Function]}
                 >
                   <a
-                    className="jsx-3150401870 account-link"
+                    className="account-link"
                     href="/accounts/signer1.test"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
@@ -987,6 +1557,13 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                     signer1.test
                   </a>
                 </span>
+                <style>
+                  
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                </style>
               </div>
             </div>
             <div
@@ -1006,7 +1583,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                   onClick={[Function]}
                 >
                   <a
-                    className="jsx-3150401870 account-link"
+                    className="account-link"
                     href="/accounts/receiver.test"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
@@ -1014,6 +1591,13 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                     receiver.test
                   </a>
                 </span>
+                <style>
+                  
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                </style>
               </div>
             </div>
             <div
@@ -1068,7 +1652,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                     className="col-auto"
                   >
                     <div
-                      className="jsx-1246332424 action-row-img"
+                      className="action-row-img"
                     >
                       <svg
                         viewBox="0 0 18 18"
@@ -1101,7 +1685,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                               onClick={[Function]}
                             >
                               <a
-                                className="jsx-3150401870 account-link"
+                                className="account-link"
                                 href="/accounts/receiver.test"
                                 onClick={[Function]}
                                 onMouseEnter={[Function]}
@@ -1109,6 +1693,13 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                                 receiver.test
                               </a>
                             </span>
+                            <style>
+                              
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                            </style>
                             <dl>
                               <dt>
                                 Arguments:
@@ -1125,7 +1716,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                                     }
                                   >
                                     <textarea
-                                      className="jsx-2493677144 code-preview"
+                                      className="code-preview"
                                       readOnly={true}
                                       value="{
   \\"sender_id\\": \\"leonardwcai.near\\",
@@ -1148,6 +1739,19 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                                     </div>
                                   </div>
                                 </div>
+                                <style>
+                                  
+        @import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap");
+        .code-preview {
+          font-family: "Source Code Pro", monospace;
+          background: #424957;
+          color: white;
+          padding: 20px;
+          width: 100%;
+          height: 99%;
+        }
+      
+                                </style>
                               </dd>
                             </dl>
                           </div>
@@ -1156,6 +1760,123 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                     </div>
                   </div>
                 </div>
+                <style>
+                  
+            .action-sparse-row {
+              padding-top: 10px;
+              padding-bottom: 10px;
+              border-top: solid 2px #f8f8f8;
+            }
+            .action-sparse-row .action-sparse-row {
+              border-top: 0;
+            }
+
+            .action-compact-row .action-row-message {
+              margin-bottom: 1em;
+            }
+
+            .action-compact-row .action-row-details {
+              border-bottom: 2px solid #f8f8f8;
+              margin: 0.1em 0 0;
+              padding-bottom: 8px;
+            }
+
+            .action-row-details .action-row-details {
+              border: 0;
+            }
+
+            .action-compact-row .action-row-img {
+              width: 24px;
+              height: 24px;
+              border: solid 2px #f8f8f8;
+              background-color: #ffffff;
+              border-radius: 50%;
+              margin-right: 8px;
+              text-align: center;
+              line-height: 1.1;
+            }
+
+            .action-sparse-row .action-row-img {
+              margin: 10px;
+              display: inline;
+              height: 20px;
+              width: 20px;
+            }
+
+            .action-sparse-row .action-row-img svg {
+              height: 16px;
+              width: 16px;
+            }
+
+            .action-row-bottom {
+              border-bottom: solid 2px #f8f8f8;
+            }
+
+            .action-compact-row .action-row-img svg {
+              height: 12px;
+              width: 12px;
+            }
+
+            .action-sparse-row .action-row-toggler {
+              width: 10px;
+              margin: 10px;
+            }
+
+            .action-row-title {
+              font-size: 14px;
+              font-weight: 500;
+              color: #24272a;
+            }
+
+            .action-row-title a {
+              color: #666;
+            }
+
+            .action-row-title a:hover {
+              color: #24272a;
+            }
+
+            .action-row-text {
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 1.5;
+              color: #999999;
+            }
+
+            .action-row-text a {
+              color: #999999;
+            }
+
+            .action-row-text a:hover {
+              color: #24272a;
+            }
+
+            .action-row-txid {
+              font-size: 14px;
+              font-weight: 500;
+              line-height: 1.29;
+              color: #0072ce;
+            }
+
+            .action-row-timer {
+              font-size: 12px;
+              color: #999999;
+              font-weight: 100;
+            }
+
+            .action-row-timer-status {
+              font-weight: 500;
+            }
+
+            pre {
+              white-space: pre-wrap; /* Since CSS 2.1 */
+              white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+              white-space: -pre-wrap; /* Opera 4-6 */
+              white-space: -o-pre-wrap; /* Opera 7 */
+              word-wrap: break-word; /* Internet Explorer 5.5+ */
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -1180,7 +1901,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                     }
                   >
                     <textarea
-                      className="jsx-2493677144 code-preview"
+                      className="code-preview"
                       readOnly={true}
                       value="\\"0\\""
                     />
@@ -1199,6 +1920,19 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                     </div>
                   </div>
                 </div>
+                <style>
+                  
+        @import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap");
+        .code-preview {
+          font-family: "Source Code Pro", monospace;
+          background: #424957;
+          color: white;
+          padding: 20px;
+          width: 100%;
+          height: 99%;
+        }
+      
+                </style>
               </div>
             </div>
             <div
@@ -1229,9 +1963,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                       <div
                         className="receipt-row-title receipt-hash-title col"
                       >
-                        <b
-                          className="jsx-1757047684"
-                        >
+                        <b>
                           Receipt
                           :
                         </b>
@@ -1253,7 +1985,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                           onClick={[Function]}
                         >
                           <a
-                            className="jsx-4207953579 receipt-hash-link"
+                            className="receipt-hash-link"
                             href="/transactions/T1111111111111111111111111111111111111111111#R555555555555555555555555555555555555555555"
                             onClick={[Function]}
                             onMouseEnter={[Function]}
@@ -1261,6 +1993,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                             R555555555555555555555555555555555555555555
                           </a>
                         </span>
+                        <style>
+                          
+        .receipt-hash-link.disabled {
+          cursor: default;
+          color: #24272a;
+        }
+      
+                        </style>
                       </div>
                     </div>
                     <div
@@ -1306,7 +2046,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                           onClick={[Function]}
                         >
                           <a
-                            className="jsx-3150401870 account-link"
+                            className="account-link"
                             href="/accounts/system"
                             onClick={[Function]}
                             onMouseEnter={[Function]}
@@ -1314,6 +2054,13 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                             system
                           </a>
                         </span>
+                        <style>
+                          
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                        </style>
                       </div>
                     </div>
                     <div
@@ -1333,7 +2080,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                           onClick={[Function]}
                         >
                           <a
-                            className="jsx-3150401870 account-link"
+                            className="account-link"
                             href="/accounts/receiver.test"
                             onClick={[Function]}
                             onMouseEnter={[Function]}
@@ -1341,6 +2088,13 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                             receiver.test
                           </a>
                         </span>
+                        <style>
+                          
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                        </style>
                       </div>
                     </div>
                     <div
@@ -1395,7 +2149,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                             className="col-auto"
                           >
                             <div
-                              className="jsx-1246332424 action-row-img"
+                              className="action-row-img"
                             >
                               <svg
                                 viewBox="0 0 18 18"
@@ -1439,7 +2193,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                                       onClick={[Function]}
                                     >
                                       <a
-                                        className="jsx-3150401870 account-link"
+                                        className="account-link"
                                         href="/accounts/receiver.test"
                                         onClick={[Function]}
                                         onMouseEnter={[Function]}
@@ -1447,12 +2201,136 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                                         receiver.test
                                       </a>
                                     </span>
+                                    <style>
+                                      
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                                    </style>
                                   </div>
                                 </div>
                               </div>
                             </div>
                           </div>
                         </div>
+                        <style>
+                          
+            .action-sparse-row {
+              padding-top: 10px;
+              padding-bottom: 10px;
+              border-top: solid 2px #f8f8f8;
+            }
+            .action-sparse-row .action-sparse-row {
+              border-top: 0;
+            }
+
+            .action-compact-row .action-row-message {
+              margin-bottom: 1em;
+            }
+
+            .action-compact-row .action-row-details {
+              border-bottom: 2px solid #f8f8f8;
+              margin: 0.1em 0 0;
+              padding-bottom: 8px;
+            }
+
+            .action-row-details .action-row-details {
+              border: 0;
+            }
+
+            .action-compact-row .action-row-img {
+              width: 24px;
+              height: 24px;
+              border: solid 2px #f8f8f8;
+              background-color: #ffffff;
+              border-radius: 50%;
+              margin-right: 8px;
+              text-align: center;
+              line-height: 1.1;
+            }
+
+            .action-sparse-row .action-row-img {
+              margin: 10px;
+              display: inline;
+              height: 20px;
+              width: 20px;
+            }
+
+            .action-sparse-row .action-row-img svg {
+              height: 16px;
+              width: 16px;
+            }
+
+            .action-row-bottom {
+              border-bottom: solid 2px #f8f8f8;
+            }
+
+            .action-compact-row .action-row-img svg {
+              height: 12px;
+              width: 12px;
+            }
+
+            .action-sparse-row .action-row-toggler {
+              width: 10px;
+              margin: 10px;
+            }
+
+            .action-row-title {
+              font-size: 14px;
+              font-weight: 500;
+              color: #24272a;
+            }
+
+            .action-row-title a {
+              color: #666;
+            }
+
+            .action-row-title a:hover {
+              color: #24272a;
+            }
+
+            .action-row-text {
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 1.5;
+              color: #999999;
+            }
+
+            .action-row-text a {
+              color: #999999;
+            }
+
+            .action-row-text a:hover {
+              color: #24272a;
+            }
+
+            .action-row-txid {
+              font-size: 14px;
+              font-weight: 500;
+              line-height: 1.29;
+              color: #0072ce;
+            }
+
+            .action-row-timer {
+              font-size: 12px;
+              color: #999999;
+              font-weight: 100;
+            }
+
+            .action-row-timer-status {
+              font-weight: 500;
+            }
+
+            pre {
+              white-space: pre-wrap; /* Since CSS 2.1 */
+              white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+              white-space: -pre-wrap; /* Opera 4-6 */
+              white-space: -o-pre-wrap; /* Opera 7 */
+              word-wrap: break-word; /* Internet Explorer 5.5+ */
+            }
+          
+                        </style>
                       </div>
                     </div>
                     <div
@@ -1474,10 +2352,120 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                       </div>
                     </div>
                   </div>
+                  <style>
+                    
+          .receipt-row {
+            padding-top: 10px;
+            padding-bottom: 30px;
+          }
+
+          .receipt-row-section {
+            padding-top: 10px;
+            padding-left: 1.5rem;
+            border-left: 2px solid #e5e5e5;
+          }
+
+          .executed-receipt-row .receipt-row {
+            padding-left: 1.5rem;
+            padding-bottom: 0;
+            border-left: 2px solid #e5e5e5;
+          }
+
+          .receipt-hash-title {
+            padding-bottom: 10px;
+          }
+
+          .receipt-row-title {
+            font-size: 14px;
+            line-height: 1.29;
+            color: #24272a;
+          }
+
+          .receipt-row-text {
+            font-size: 12px;
+            line-height: 1.5;
+            color: #999999;
+          }
+
+          .receipt-row-receipt-hash {
+            font-size: 14px;
+            font-weight: 500;
+            line-height: 1.29;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+          }
+
+          .receipt-row-receipt-hash.truncate-link {
+            color: #007bff;
+          }
+
+          .receipt-row-status {
+            font-size: 12px;
+            color: #999999;
+            font-weight: 500;
+          }
+        
+                  </style>
                 </div>
               </div>
             </div>
           </div>
+          <style>
+            
+          .receipt-row {
+            padding-top: 10px;
+            padding-bottom: 30px;
+          }
+
+          .receipt-row-section {
+            padding-top: 10px;
+            padding-left: 1.5rem;
+            border-left: 2px solid #e5e5e5;
+          }
+
+          .executed-receipt-row .receipt-row {
+            padding-left: 1.5rem;
+            padding-bottom: 0;
+            border-left: 2px solid #e5e5e5;
+          }
+
+          .receipt-hash-title {
+            padding-bottom: 10px;
+          }
+
+          .receipt-row-title {
+            font-size: 14px;
+            line-height: 1.29;
+            color: #24272a;
+          }
+
+          .receipt-row-text {
+            font-size: 12px;
+            line-height: 1.5;
+            color: #999999;
+          }
+
+          .receipt-row-receipt-hash {
+            font-size: 14px;
+            font-weight: 500;
+            line-height: 1.29;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+          }
+
+          .receipt-row-receipt-hash.truncate-link {
+            color: #007bff;
+          }
+
+          .receipt-row-status {
+            font-size: 12px;
+            color: #999999;
+            font-weight: 500;
+          }
+        
+          </style>
         </div>
       </div>
     </div>
@@ -1500,9 +2488,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
               <div
                 className="receipt-row-title receipt-hash-title col"
               >
-                <b
-                  className="jsx-1757047684"
-                >
+                <b>
                   Receipt
                   :
                 </b>
@@ -1524,7 +2510,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                   onClick={[Function]}
                 >
                   <a
-                    className="jsx-4207953579 receipt-hash-link"
+                    className="receipt-hash-link"
                     href="/transactions/T1111111111111111111111111111111111111111111#R3333333333333333333333333333333333333333333"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
@@ -1532,6 +2518,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                     R3333333333333333333333333333333333333333333
                   </a>
                 </span>
+                <style>
+                  
+        .receipt-hash-link.disabled {
+          cursor: default;
+          color: #24272a;
+        }
+      
+                </style>
               </div>
             </div>
             <div
@@ -1577,7 +2571,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                   onClick={[Function]}
                 >
                   <a
-                    className="jsx-3150401870 account-link"
+                    className="account-link"
                     href="/accounts/signer1.test"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
@@ -1585,6 +2579,13 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                     signer1.test
                   </a>
                 </span>
+                <style>
+                  
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                </style>
               </div>
             </div>
             <div
@@ -1604,7 +2605,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                   onClick={[Function]}
                 >
                   <a
-                    className="jsx-3150401870 account-link"
+                    className="account-link"
                     href="/accounts/receiver1.test"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
@@ -1612,6 +2613,13 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                     receiver1.test
                   </a>
                 </span>
+                <style>
+                  
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                </style>
               </div>
             </div>
             <div
@@ -1666,7 +2674,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                     className="col-auto"
                   >
                     <div
-                      className="jsx-1246332424 action-row-img"
+                      className="action-row-img"
                     >
                       <svg
                         viewBox="0 0 18 18"
@@ -1699,7 +2707,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                               onClick={[Function]}
                             >
                               <a
-                                className="jsx-3150401870 account-link"
+                                className="account-link"
                                 href="/accounts/receiver1.test"
                                 onClick={[Function]}
                                 onMouseEnter={[Function]}
@@ -1707,6 +2715,13 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                                 receiver1.test
                               </a>
                             </span>
+                            <style>
+                              
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                            </style>
                             <dl>
                               <dt>
                                 Arguments:
@@ -1723,7 +2738,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                                     }
                                   >
                                     <textarea
-                                      className="jsx-2493677144 code-preview"
+                                      className="code-preview"
                                       readOnly={true}
                                       value="{
   \\"sender_id\\": \\"leonardwcai.near\\",
@@ -1746,6 +2761,19 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                                     </div>
                                   </div>
                                 </div>
+                                <style>
+                                  
+        @import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap");
+        .code-preview {
+          font-family: "Source Code Pro", monospace;
+          background: #424957;
+          color: white;
+          padding: 20px;
+          width: 100%;
+          height: 99%;
+        }
+      
+                                </style>
                               </dd>
                             </dl>
                           </div>
@@ -1754,6 +2782,123 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                     </div>
                   </div>
                 </div>
+                <style>
+                  
+            .action-sparse-row {
+              padding-top: 10px;
+              padding-bottom: 10px;
+              border-top: solid 2px #f8f8f8;
+            }
+            .action-sparse-row .action-sparse-row {
+              border-top: 0;
+            }
+
+            .action-compact-row .action-row-message {
+              margin-bottom: 1em;
+            }
+
+            .action-compact-row .action-row-details {
+              border-bottom: 2px solid #f8f8f8;
+              margin: 0.1em 0 0;
+              padding-bottom: 8px;
+            }
+
+            .action-row-details .action-row-details {
+              border: 0;
+            }
+
+            .action-compact-row .action-row-img {
+              width: 24px;
+              height: 24px;
+              border: solid 2px #f8f8f8;
+              background-color: #ffffff;
+              border-radius: 50%;
+              margin-right: 8px;
+              text-align: center;
+              line-height: 1.1;
+            }
+
+            .action-sparse-row .action-row-img {
+              margin: 10px;
+              display: inline;
+              height: 20px;
+              width: 20px;
+            }
+
+            .action-sparse-row .action-row-img svg {
+              height: 16px;
+              width: 16px;
+            }
+
+            .action-row-bottom {
+              border-bottom: solid 2px #f8f8f8;
+            }
+
+            .action-compact-row .action-row-img svg {
+              height: 12px;
+              width: 12px;
+            }
+
+            .action-sparse-row .action-row-toggler {
+              width: 10px;
+              margin: 10px;
+            }
+
+            .action-row-title {
+              font-size: 14px;
+              font-weight: 500;
+              color: #24272a;
+            }
+
+            .action-row-title a {
+              color: #666;
+            }
+
+            .action-row-title a:hover {
+              color: #24272a;
+            }
+
+            .action-row-text {
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 1.5;
+              color: #999999;
+            }
+
+            .action-row-text a {
+              color: #999999;
+            }
+
+            .action-row-text a:hover {
+              color: #24272a;
+            }
+
+            .action-row-txid {
+              font-size: 14px;
+              font-weight: 500;
+              line-height: 1.29;
+              color: #0072ce;
+            }
+
+            .action-row-timer {
+              font-size: 12px;
+              color: #999999;
+              font-weight: 100;
+            }
+
+            .action-row-timer-status {
+              font-weight: 500;
+            }
+
+            pre {
+              white-space: pre-wrap; /* Since CSS 2.1 */
+              white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+              white-space: -pre-wrap; /* Opera 4-6 */
+              white-space: -o-pre-wrap; /* Opera 7 */
+              word-wrap: break-word; /* Internet Explorer 5.5+ */
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -1778,7 +2923,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                     }
                   >
                     <textarea
-                      className="jsx-2493677144 code-preview"
+                      className="code-preview"
                       readOnly={true}
                       value="\\"9807229473212706028\\""
                     />
@@ -1797,6 +2942,19 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                     </div>
                   </div>
                 </div>
+                <style>
+                  
+        @import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap");
+        .code-preview {
+          font-family: "Source Code Pro", monospace;
+          background: #424957;
+          color: white;
+          padding: 20px;
+          width: 100%;
+          height: 99%;
+        }
+      
+                </style>
               </div>
             </div>
             <div
@@ -1827,9 +2985,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                       <div
                         className="receipt-row-title receipt-hash-title col"
                       >
-                        <b
-                          className="jsx-1757047684"
-                        >
+                        <b>
                           Receipt
                           :
                         </b>
@@ -1851,7 +3007,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                           onClick={[Function]}
                         >
                           <a
-                            className="jsx-4207953579 receipt-hash-link"
+                            className="receipt-hash-link"
                             href="/transactions/T1111111111111111111111111111111111111111111#R6666666666666666666666666666666666666666666"
                             onClick={[Function]}
                             onMouseEnter={[Function]}
@@ -1859,6 +3015,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                             R6666666666666666666666666666666666666666666
                           </a>
                         </span>
+                        <style>
+                          
+        .receipt-hash-link.disabled {
+          cursor: default;
+          color: #24272a;
+        }
+      
+                        </style>
                       </div>
                     </div>
                     <div
@@ -1904,7 +3068,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                           onClick={[Function]}
                         >
                           <a
-                            className="jsx-3150401870 account-link"
+                            className="account-link"
                             href="/accounts/system"
                             onClick={[Function]}
                             onMouseEnter={[Function]}
@@ -1912,6 +3076,13 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                             system
                           </a>
                         </span>
+                        <style>
+                          
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                        </style>
                       </div>
                     </div>
                     <div
@@ -1931,7 +3102,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                           onClick={[Function]}
                         >
                           <a
-                            className="jsx-3150401870 account-link"
+                            className="account-link"
                             href="/accounts/receiver.test"
                             onClick={[Function]}
                             onMouseEnter={[Function]}
@@ -1939,6 +3110,13 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                             receiver.test
                           </a>
                         </span>
+                        <style>
+                          
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                        </style>
                       </div>
                     </div>
                     <div
@@ -1993,7 +3171,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                             className="col-auto"
                           >
                             <div
-                              className="jsx-1246332424 action-row-img"
+                              className="action-row-img"
                             >
                               <svg
                                 viewBox="0 0 18 18"
@@ -2037,7 +3215,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                                       onClick={[Function]}
                                     >
                                       <a
-                                        className="jsx-3150401870 account-link"
+                                        className="account-link"
                                         href="/accounts/receiver.test"
                                         onClick={[Function]}
                                         onMouseEnter={[Function]}
@@ -2045,12 +3223,136 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                                         receiver.test
                                       </a>
                                     </span>
+                                    <style>
+                                      
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                                    </style>
                                   </div>
                                 </div>
                               </div>
                             </div>
                           </div>
                         </div>
+                        <style>
+                          
+            .action-sparse-row {
+              padding-top: 10px;
+              padding-bottom: 10px;
+              border-top: solid 2px #f8f8f8;
+            }
+            .action-sparse-row .action-sparse-row {
+              border-top: 0;
+            }
+
+            .action-compact-row .action-row-message {
+              margin-bottom: 1em;
+            }
+
+            .action-compact-row .action-row-details {
+              border-bottom: 2px solid #f8f8f8;
+              margin: 0.1em 0 0;
+              padding-bottom: 8px;
+            }
+
+            .action-row-details .action-row-details {
+              border: 0;
+            }
+
+            .action-compact-row .action-row-img {
+              width: 24px;
+              height: 24px;
+              border: solid 2px #f8f8f8;
+              background-color: #ffffff;
+              border-radius: 50%;
+              margin-right: 8px;
+              text-align: center;
+              line-height: 1.1;
+            }
+
+            .action-sparse-row .action-row-img {
+              margin: 10px;
+              display: inline;
+              height: 20px;
+              width: 20px;
+            }
+
+            .action-sparse-row .action-row-img svg {
+              height: 16px;
+              width: 16px;
+            }
+
+            .action-row-bottom {
+              border-bottom: solid 2px #f8f8f8;
+            }
+
+            .action-compact-row .action-row-img svg {
+              height: 12px;
+              width: 12px;
+            }
+
+            .action-sparse-row .action-row-toggler {
+              width: 10px;
+              margin: 10px;
+            }
+
+            .action-row-title {
+              font-size: 14px;
+              font-weight: 500;
+              color: #24272a;
+            }
+
+            .action-row-title a {
+              color: #666;
+            }
+
+            .action-row-title a:hover {
+              color: #24272a;
+            }
+
+            .action-row-text {
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 1.5;
+              color: #999999;
+            }
+
+            .action-row-text a {
+              color: #999999;
+            }
+
+            .action-row-text a:hover {
+              color: #24272a;
+            }
+
+            .action-row-txid {
+              font-size: 14px;
+              font-weight: 500;
+              line-height: 1.29;
+              color: #0072ce;
+            }
+
+            .action-row-timer {
+              font-size: 12px;
+              color: #999999;
+              font-weight: 100;
+            }
+
+            .action-row-timer-status {
+              font-weight: 500;
+            }
+
+            pre {
+              white-space: pre-wrap; /* Since CSS 2.1 */
+              white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+              white-space: -pre-wrap; /* Opera 4-6 */
+              white-space: -o-pre-wrap; /* Opera 7 */
+              word-wrap: break-word; /* Internet Explorer 5.5+ */
+            }
+          
+                        </style>
                       </div>
                     </div>
                     <div
@@ -2072,10 +3374,120 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                       </div>
                     </div>
                   </div>
+                  <style>
+                    
+          .receipt-row {
+            padding-top: 10px;
+            padding-bottom: 30px;
+          }
+
+          .receipt-row-section {
+            padding-top: 10px;
+            padding-left: 1.5rem;
+            border-left: 2px solid #e5e5e5;
+          }
+
+          .executed-receipt-row .receipt-row {
+            padding-left: 1.5rem;
+            padding-bottom: 0;
+            border-left: 2px solid #e5e5e5;
+          }
+
+          .receipt-hash-title {
+            padding-bottom: 10px;
+          }
+
+          .receipt-row-title {
+            font-size: 14px;
+            line-height: 1.29;
+            color: #24272a;
+          }
+
+          .receipt-row-text {
+            font-size: 12px;
+            line-height: 1.5;
+            color: #999999;
+          }
+
+          .receipt-row-receipt-hash {
+            font-size: 14px;
+            font-weight: 500;
+            line-height: 1.29;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+          }
+
+          .receipt-row-receipt-hash.truncate-link {
+            color: #007bff;
+          }
+
+          .receipt-row-status {
+            font-size: 12px;
+            color: #999999;
+            font-weight: 500;
+          }
+        
+                  </style>
                 </div>
               </div>
             </div>
           </div>
+          <style>
+            
+          .receipt-row {
+            padding-top: 10px;
+            padding-bottom: 30px;
+          }
+
+          .receipt-row-section {
+            padding-top: 10px;
+            padding-left: 1.5rem;
+            border-left: 2px solid #e5e5e5;
+          }
+
+          .executed-receipt-row .receipt-row {
+            padding-left: 1.5rem;
+            padding-bottom: 0;
+            border-left: 2px solid #e5e5e5;
+          }
+
+          .receipt-hash-title {
+            padding-bottom: 10px;
+          }
+
+          .receipt-row-title {
+            font-size: 14px;
+            line-height: 1.29;
+            color: #24272a;
+          }
+
+          .receipt-row-text {
+            font-size: 12px;
+            line-height: 1.5;
+            color: #999999;
+          }
+
+          .receipt-row-receipt-hash {
+            font-size: 14px;
+            font-weight: 500;
+            line-height: 1.29;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+          }
+
+          .receipt-row-receipt-hash.truncate-link {
+            color: #007bff;
+          }
+
+          .receipt-row-status {
+            font-size: 12px;
+            color: #999999;
+            font-weight: 500;
+          }
+        
+          </style>
         </div>
       </div>
     </div>
@@ -2098,9 +3510,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
               <div
                 className="receipt-row-title receipt-hash-title col"
               >
-                <b
-                  className="jsx-1757047684"
-                >
+                <b>
                   Receipt
                   :
                 </b>
@@ -2122,7 +3532,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                   onClick={[Function]}
                 >
                   <a
-                    className="jsx-4207953579 receipt-hash-link"
+                    className="receipt-hash-link"
                     href="/transactions/T1111111111111111111111111111111111111111111#R4444444444444444444444444444444444444444444"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
@@ -2130,6 +3540,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                     R4444444444444444444444444444444444444444444
                   </a>
                 </span>
+                <style>
+                  
+        .receipt-hash-link.disabled {
+          cursor: default;
+          color: #24272a;
+        }
+      
+                </style>
               </div>
             </div>
             <div
@@ -2175,7 +3593,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                   onClick={[Function]}
                 >
                   <a
-                    className="jsx-3150401870 account-link"
+                    className="account-link"
                     href="/accounts/system"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
@@ -2183,6 +3601,13 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                     system
                   </a>
                 </span>
+                <style>
+                  
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                </style>
               </div>
             </div>
             <div
@@ -2202,7 +3627,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                   onClick={[Function]}
                 >
                   <a
-                    className="jsx-3150401870 account-link"
+                    className="account-link"
                     href="/accounts/receiver.test"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
@@ -2210,6 +3635,13 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                     receiver.test
                   </a>
                 </span>
+                <style>
+                  
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                </style>
               </div>
             </div>
             <div
@@ -2264,7 +3696,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                     className="col-auto"
                   >
                     <div
-                      className="jsx-1246332424 action-row-img"
+                      className="action-row-img"
                     >
                       <svg
                         viewBox="0 0 18 18"
@@ -2308,7 +3740,7 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                               onClick={[Function]}
                             >
                               <a
-                                className="jsx-3150401870 account-link"
+                                className="account-link"
                                 href="/accounts/receiver.test"
                                 onClick={[Function]}
                                 onMouseEnter={[Function]}
@@ -2316,12 +3748,136 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                                 receiver.test
                               </a>
                             </span>
+                            <style>
+                              
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                            </style>
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
                 </div>
+                <style>
+                  
+            .action-sparse-row {
+              padding-top: 10px;
+              padding-bottom: 10px;
+              border-top: solid 2px #f8f8f8;
+            }
+            .action-sparse-row .action-sparse-row {
+              border-top: 0;
+            }
+
+            .action-compact-row .action-row-message {
+              margin-bottom: 1em;
+            }
+
+            .action-compact-row .action-row-details {
+              border-bottom: 2px solid #f8f8f8;
+              margin: 0.1em 0 0;
+              padding-bottom: 8px;
+            }
+
+            .action-row-details .action-row-details {
+              border: 0;
+            }
+
+            .action-compact-row .action-row-img {
+              width: 24px;
+              height: 24px;
+              border: solid 2px #f8f8f8;
+              background-color: #ffffff;
+              border-radius: 50%;
+              margin-right: 8px;
+              text-align: center;
+              line-height: 1.1;
+            }
+
+            .action-sparse-row .action-row-img {
+              margin: 10px;
+              display: inline;
+              height: 20px;
+              width: 20px;
+            }
+
+            .action-sparse-row .action-row-img svg {
+              height: 16px;
+              width: 16px;
+            }
+
+            .action-row-bottom {
+              border-bottom: solid 2px #f8f8f8;
+            }
+
+            .action-compact-row .action-row-img svg {
+              height: 12px;
+              width: 12px;
+            }
+
+            .action-sparse-row .action-row-toggler {
+              width: 10px;
+              margin: 10px;
+            }
+
+            .action-row-title {
+              font-size: 14px;
+              font-weight: 500;
+              color: #24272a;
+            }
+
+            .action-row-title a {
+              color: #666;
+            }
+
+            .action-row-title a:hover {
+              color: #24272a;
+            }
+
+            .action-row-text {
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 1.5;
+              color: #999999;
+            }
+
+            .action-row-text a {
+              color: #999999;
+            }
+
+            .action-row-text a:hover {
+              color: #24272a;
+            }
+
+            .action-row-txid {
+              font-size: 14px;
+              font-weight: 500;
+              line-height: 1.29;
+              color: #0072ce;
+            }
+
+            .action-row-timer {
+              font-size: 12px;
+              color: #999999;
+              font-weight: 100;
+            }
+
+            .action-row-timer-status {
+              font-weight: 500;
+            }
+
+            pre {
+              white-space: pre-wrap; /* Since CSS 2.1 */
+              white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+              white-space: -pre-wrap; /* Opera 4-6 */
+              white-space: -o-pre-wrap; /* Opera 7 */
+              word-wrap: break-word; /* Internet Explorer 5.5+ */
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -2343,10 +3899,120 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
               </div>
             </div>
           </div>
+          <style>
+            
+          .receipt-row {
+            padding-top: 10px;
+            padding-bottom: 30px;
+          }
+
+          .receipt-row-section {
+            padding-top: 10px;
+            padding-left: 1.5rem;
+            border-left: 2px solid #e5e5e5;
+          }
+
+          .executed-receipt-row .receipt-row {
+            padding-left: 1.5rem;
+            padding-bottom: 0;
+            border-left: 2px solid #e5e5e5;
+          }
+
+          .receipt-hash-title {
+            padding-bottom: 10px;
+          }
+
+          .receipt-row-title {
+            font-size: 14px;
+            line-height: 1.29;
+            color: #24272a;
+          }
+
+          .receipt-row-text {
+            font-size: 12px;
+            line-height: 1.5;
+            color: #999999;
+          }
+
+          .receipt-row-receipt-hash {
+            font-size: 14px;
+            font-weight: 500;
+            line-height: 1.29;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+          }
+
+          .receipt-row-receipt-hash.truncate-link {
+            color: #007bff;
+          }
+
+          .receipt-row-status {
+            font-size: 12px;
+            color: #999999;
+            font-weight: 500;
+          }
+        
+          </style>
         </div>
       </div>
     </div>
   </div>
+  <style>
+    
+          .receipt-row {
+            padding-top: 10px;
+            padding-bottom: 30px;
+          }
+
+          .receipt-row-section {
+            padding-top: 10px;
+            padding-left: 1.5rem;
+            border-left: 2px solid #e5e5e5;
+          }
+
+          .executed-receipt-row .receipt-row {
+            padding-left: 1.5rem;
+            padding-bottom: 0;
+            border-left: 2px solid #e5e5e5;
+          }
+
+          .receipt-hash-title {
+            padding-bottom: 10px;
+          }
+
+          .receipt-row-title {
+            font-size: 14px;
+            line-height: 1.29;
+            color: #24272a;
+          }
+
+          .receipt-row-text {
+            font-size: 12px;
+            line-height: 1.5;
+            color: #999999;
+          }
+
+          .receipt-row-receipt-hash {
+            font-size: 14px;
+            font-weight: 500;
+            line-height: 1.29;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+          }
+
+          .receipt-row-receipt-hash.truncate-link {
+            color: #007bff;
+          }
+
+          .receipt-row-status {
+            font-size: 12px;
+            color: #999999;
+            font-weight: 500;
+          }
+        
+  </style>
 </div>
 `;
 
@@ -2364,9 +4030,7 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
       <div
         className="receipt-row-title receipt-hash-title col"
       >
-        <b
-          className="jsx-1757047684"
-        >
+        <b>
           Receipt
           :
         </b>
@@ -2388,7 +4052,7 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
           onClick={[Function]}
         >
           <a
-            className="jsx-4207953579 receipt-hash-link"
+            className="receipt-hash-link"
             href="/transactions/T1111111111111111111111111111111111111111111#R1111111111111111111111111111111111111111111"
             onClick={[Function]}
             onMouseEnter={[Function]}
@@ -2396,6 +4060,14 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
             R1111111111111111111111111111111111111111111
           </a>
         </span>
+        <style>
+          
+        .receipt-hash-link.disabled {
+          cursor: default;
+          color: #24272a;
+        }
+      
+        </style>
       </div>
     </div>
     <div
@@ -2441,7 +4113,7 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
           onClick={[Function]}
         >
           <a
-            className="jsx-3150401870 account-link"
+            className="account-link"
             href="/accounts/signer.test"
             onClick={[Function]}
             onMouseEnter={[Function]}
@@ -2449,6 +4121,13 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
             signer.test
           </a>
         </span>
+        <style>
+          
+        .account-link {
+          white-space: nowrap;
+        }
+      
+        </style>
       </div>
     </div>
     <div
@@ -2468,7 +4147,7 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
           onClick={[Function]}
         >
           <a
-            className="jsx-3150401870 account-link"
+            className="account-link"
             href="/accounts/receiver.test"
             onClick={[Function]}
             onMouseEnter={[Function]}
@@ -2476,6 +4155,13 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
             receiver.test
           </a>
         </span>
+        <style>
+          
+        .account-link {
+          white-space: nowrap;
+        }
+      
+        </style>
       </div>
     </div>
     <div
@@ -2530,7 +4216,7 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
             className="col-auto"
           >
             <div
-              className="jsx-1246332424 action-row-img"
+              className="action-row-img"
             >
               <svg
                 viewBox="0 0 18 18"
@@ -2563,7 +4249,7 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
                       onClick={[Function]}
                     >
                       <a
-                        className="jsx-3150401870 account-link"
+                        className="account-link"
                         href="/accounts/receiver.test"
                         onClick={[Function]}
                         onMouseEnter={[Function]}
@@ -2571,6 +4257,13 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
                         receiver.test
                       </a>
                     </span>
+                    <style>
+                      
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                    </style>
                     <dl>
                       <dt>
                         Arguments:
@@ -2587,7 +4280,7 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
                             }
                           >
                             <textarea
-                              className="jsx-2493677144 code-preview"
+                              className="code-preview"
                               readOnly={true}
                               value="{
   \\"request\\": {
@@ -2612,6 +4305,19 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
                             </div>
                           </div>
                         </div>
+                        <style>
+                          
+        @import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap");
+        .code-preview {
+          font-family: "Source Code Pro", monospace;
+          background: #424957;
+          color: white;
+          padding: 20px;
+          width: 100%;
+          height: 99%;
+        }
+      
+                        </style>
                       </dd>
                     </dl>
                   </div>
@@ -2620,6 +4326,123 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+            .action-sparse-row {
+              padding-top: 10px;
+              padding-bottom: 10px;
+              border-top: solid 2px #f8f8f8;
+            }
+            .action-sparse-row .action-sparse-row {
+              border-top: 0;
+            }
+
+            .action-compact-row .action-row-message {
+              margin-bottom: 1em;
+            }
+
+            .action-compact-row .action-row-details {
+              border-bottom: 2px solid #f8f8f8;
+              margin: 0.1em 0 0;
+              padding-bottom: 8px;
+            }
+
+            .action-row-details .action-row-details {
+              border: 0;
+            }
+
+            .action-compact-row .action-row-img {
+              width: 24px;
+              height: 24px;
+              border: solid 2px #f8f8f8;
+              background-color: #ffffff;
+              border-radius: 50%;
+              margin-right: 8px;
+              text-align: center;
+              line-height: 1.1;
+            }
+
+            .action-sparse-row .action-row-img {
+              margin: 10px;
+              display: inline;
+              height: 20px;
+              width: 20px;
+            }
+
+            .action-sparse-row .action-row-img svg {
+              height: 16px;
+              width: 16px;
+            }
+
+            .action-row-bottom {
+              border-bottom: solid 2px #f8f8f8;
+            }
+
+            .action-compact-row .action-row-img svg {
+              height: 12px;
+              width: 12px;
+            }
+
+            .action-sparse-row .action-row-toggler {
+              width: 10px;
+              margin: 10px;
+            }
+
+            .action-row-title {
+              font-size: 14px;
+              font-weight: 500;
+              color: #24272a;
+            }
+
+            .action-row-title a {
+              color: #666;
+            }
+
+            .action-row-title a:hover {
+              color: #24272a;
+            }
+
+            .action-row-text {
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 1.5;
+              color: #999999;
+            }
+
+            .action-row-text a {
+              color: #999999;
+            }
+
+            .action-row-text a:hover {
+              color: #24272a;
+            }
+
+            .action-row-txid {
+              font-size: 14px;
+              font-weight: 500;
+              line-height: 1.29;
+              color: #0072ce;
+            }
+
+            .action-row-timer {
+              font-size: 12px;
+              color: #999999;
+              font-weight: 100;
+            }
+
+            .action-row-timer-status {
+              font-weight: 500;
+            }
+
+            pre {
+              white-space: pre-wrap; /* Since CSS 2.1 */
+              white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+              white-space: -pre-wrap; /* Opera 4-6 */
+              white-space: -o-pre-wrap; /* Opera 7 */
+              word-wrap: break-word; /* Internet Explorer 5.5+ */
+            }
+          
+        </style>
       </div>
     </div>
     <div
@@ -2644,7 +4467,7 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
             }
           >
             <textarea
-              className="jsx-2493677144 code-preview"
+              className="code-preview"
               readOnly={true}
               value="{
   \\"left\\": 29647268,
@@ -2666,6 +4489,19 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+        @import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap");
+        .code-preview {
+          font-family: "Source Code Pro", monospace;
+          background: #424957;
+          color: white;
+          padding: 20px;
+          width: 100%;
+          height: 99%;
+        }
+      
+        </style>
       </div>
     </div>
     <div
@@ -2696,9 +4532,7 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
               <div
                 className="receipt-row-title receipt-hash-title col"
               >
-                <b
-                  className="jsx-1757047684"
-                >
+                <b>
                   Receipt
                   :
                 </b>
@@ -2720,7 +4554,7 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
                   onClick={[Function]}
                 >
                   <a
-                    className="jsx-4207953579 receipt-hash-link"
+                    className="receipt-hash-link"
                     href="/transactions/T1111111111111111111111111111111111111111111#R2222222222222222222222222222222222222222222"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
@@ -2728,6 +4562,14 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
                     R2222222222222222222222222222222222222222222
                   </a>
                 </span>
+                <style>
+                  
+        .receipt-hash-link.disabled {
+          cursor: default;
+          color: #24272a;
+        }
+      
+                </style>
               </div>
             </div>
             <div
@@ -2773,7 +4615,7 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
                   onClick={[Function]}
                 >
                   <a
-                    className="jsx-3150401870 account-link"
+                    className="account-link"
                     href="/accounts/system"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
@@ -2781,6 +4623,13 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
                     system
                   </a>
                 </span>
+                <style>
+                  
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                </style>
               </div>
             </div>
             <div
@@ -2800,7 +4649,7 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
                   onClick={[Function]}
                 >
                   <a
-                    className="jsx-3150401870 account-link"
+                    className="account-link"
                     href="/accounts/receiver.test"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
@@ -2808,6 +4657,13 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
                     receiver.test
                   </a>
                 </span>
+                <style>
+                  
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                </style>
               </div>
             </div>
             <div
@@ -2862,7 +4718,7 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
                     className="col-auto"
                   >
                     <div
-                      className="jsx-1246332424 action-row-img"
+                      className="action-row-img"
                     >
                       <svg
                         viewBox="0 0 18 18"
@@ -2906,7 +4762,7 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
                               onClick={[Function]}
                             >
                               <a
-                                className="jsx-3150401870 account-link"
+                                className="account-link"
                                 href="/accounts/receiver.test"
                                 onClick={[Function]}
                                 onMouseEnter={[Function]}
@@ -2914,12 +4770,136 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
                                 receiver.test
                               </a>
                             </span>
+                            <style>
+                              
+        .account-link {
+          white-space: nowrap;
+        }
+      
+                            </style>
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
                 </div>
+                <style>
+                  
+            .action-sparse-row {
+              padding-top: 10px;
+              padding-bottom: 10px;
+              border-top: solid 2px #f8f8f8;
+            }
+            .action-sparse-row .action-sparse-row {
+              border-top: 0;
+            }
+
+            .action-compact-row .action-row-message {
+              margin-bottom: 1em;
+            }
+
+            .action-compact-row .action-row-details {
+              border-bottom: 2px solid #f8f8f8;
+              margin: 0.1em 0 0;
+              padding-bottom: 8px;
+            }
+
+            .action-row-details .action-row-details {
+              border: 0;
+            }
+
+            .action-compact-row .action-row-img {
+              width: 24px;
+              height: 24px;
+              border: solid 2px #f8f8f8;
+              background-color: #ffffff;
+              border-radius: 50%;
+              margin-right: 8px;
+              text-align: center;
+              line-height: 1.1;
+            }
+
+            .action-sparse-row .action-row-img {
+              margin: 10px;
+              display: inline;
+              height: 20px;
+              width: 20px;
+            }
+
+            .action-sparse-row .action-row-img svg {
+              height: 16px;
+              width: 16px;
+            }
+
+            .action-row-bottom {
+              border-bottom: solid 2px #f8f8f8;
+            }
+
+            .action-compact-row .action-row-img svg {
+              height: 12px;
+              width: 12px;
+            }
+
+            .action-sparse-row .action-row-toggler {
+              width: 10px;
+              margin: 10px;
+            }
+
+            .action-row-title {
+              font-size: 14px;
+              font-weight: 500;
+              color: #24272a;
+            }
+
+            .action-row-title a {
+              color: #666;
+            }
+
+            .action-row-title a:hover {
+              color: #24272a;
+            }
+
+            .action-row-text {
+              font-size: 12px;
+              font-weight: 500;
+              line-height: 1.5;
+              color: #999999;
+            }
+
+            .action-row-text a {
+              color: #999999;
+            }
+
+            .action-row-text a:hover {
+              color: #24272a;
+            }
+
+            .action-row-txid {
+              font-size: 14px;
+              font-weight: 500;
+              line-height: 1.29;
+              color: #0072ce;
+            }
+
+            .action-row-timer {
+              font-size: 12px;
+              color: #999999;
+              font-weight: 100;
+            }
+
+            .action-row-timer-status {
+              font-weight: 500;
+            }
+
+            pre {
+              white-space: pre-wrap; /* Since CSS 2.1 */
+              white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+              white-space: -pre-wrap; /* Opera 4-6 */
+              white-space: -o-pre-wrap; /* Opera 7 */
+              word-wrap: break-word; /* Internet Explorer 5.5+ */
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -2941,9 +4921,119 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
               </div>
             </div>
           </div>
+          <style>
+            
+          .receipt-row {
+            padding-top: 10px;
+            padding-bottom: 30px;
+          }
+
+          .receipt-row-section {
+            padding-top: 10px;
+            padding-left: 1.5rem;
+            border-left: 2px solid #e5e5e5;
+          }
+
+          .executed-receipt-row .receipt-row {
+            padding-left: 1.5rem;
+            padding-bottom: 0;
+            border-left: 2px solid #e5e5e5;
+          }
+
+          .receipt-hash-title {
+            padding-bottom: 10px;
+          }
+
+          .receipt-row-title {
+            font-size: 14px;
+            line-height: 1.29;
+            color: #24272a;
+          }
+
+          .receipt-row-text {
+            font-size: 12px;
+            line-height: 1.5;
+            color: #999999;
+          }
+
+          .receipt-row-receipt-hash {
+            font-size: 14px;
+            font-weight: 500;
+            line-height: 1.29;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+          }
+
+          .receipt-row-receipt-hash.truncate-link {
+            color: #007bff;
+          }
+
+          .receipt-row-status {
+            font-size: 12px;
+            color: #999999;
+            font-weight: 500;
+          }
+        
+          </style>
         </div>
       </div>
     </div>
   </div>
+  <style>
+    
+          .receipt-row {
+            padding-top: 10px;
+            padding-bottom: 30px;
+          }
+
+          .receipt-row-section {
+            padding-top: 10px;
+            padding-left: 1.5rem;
+            border-left: 2px solid #e5e5e5;
+          }
+
+          .executed-receipt-row .receipt-row {
+            padding-left: 1.5rem;
+            padding-bottom: 0;
+            border-left: 2px solid #e5e5e5;
+          }
+
+          .receipt-hash-title {
+            padding-bottom: 10px;
+          }
+
+          .receipt-row-title {
+            font-size: 14px;
+            line-height: 1.29;
+            color: #24272a;
+          }
+
+          .receipt-row-text {
+            font-size: 12px;
+            line-height: 1.5;
+            color: #999999;
+          }
+
+          .receipt-row-receipt-hash {
+            font-size: 14px;
+            font-weight: 500;
+            line-height: 1.29;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+          }
+
+          .receipt-row-receipt-hash.truncate-link {
+            color: #007bff;
+          }
+
+          .receipt-row-status {
+            font-size: 12px;
+            color: #999999;
+            font-weight: 500;
+          }
+        
+  </style>
 </div>
 `;

--- a/frontend/src/components/transactions/__tests__/__snapshots__/TransactionDetails.test.tsx.snap
+++ b/frontend/src/components/transactions/__tests__/__snapshots__/TransactionDetails.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<TransactionDetails /> renders no deposit 1`] = `
 <div
-  className="jsx-1302829068 transaction-info-container"
+  className="transaction-info-container"
 >
   <div
     className="header-row row no-gutters"
@@ -23,19 +23,35 @@ exports[`<TransactionDetails /> renders no deposit 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-m-user.svg"
               />
               Signed by
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -45,7 +61,7 @@ exports[`<TransactionDetails /> renders no deposit 1`] = `
                 onClick={[Function]}
               >
                 <a
-                  className="jsx-3150401870 account-link"
+                  className="account-link"
                   href="/accounts/signer.test"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
@@ -53,9 +69,63 @@ exports[`<TransactionDetails /> renders no deposit 1`] = `
                   signer.test
                 </a>
               </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -74,19 +144,35 @@ exports[`<TransactionDetails /> renders no deposit 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-m-user.svg"
               />
               Receiver
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -96,7 +182,7 @@ exports[`<TransactionDetails /> renders no deposit 1`] = `
                 onClick={[Function]}
               >
                 <a
-                  className="jsx-3150401870 account-link"
+                  className="account-link"
                   href="/accounts/receiver.test"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
@@ -104,9 +190,63 @@ exports[`<TransactionDetails /> renders no deposit 1`] = `
                   receiver.test
                 </a>
               </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -125,26 +265,41 @@ exports[`<TransactionDetails /> renders no deposit 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-t-status.svg"
               />
               Status
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
               className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
             >
               <div
-                className="jsx-1302829068"
                 style={
                   Object {
                     "fontSize": "21px",
@@ -157,6 +312,53 @@ exports[`<TransactionDetails /> renders no deposit 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
   </div>
@@ -179,19 +381,35 @@ exports[`<TransactionDetails /> renders no deposit 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-m-size.svg"
               />
               Transaction Fee
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -210,6 +428,53 @@ exports[`<TransactionDetails /> renders no deposit 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -228,19 +493,35 @@ exports[`<TransactionDetails /> renders no deposit 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-m-filter.svg"
               />
               Deposit Value
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -259,6 +540,53 @@ exports[`<TransactionDetails /> renders no deposit 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -277,19 +605,35 @@ exports[`<TransactionDetails /> renders no deposit 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-m-size.svg"
               />
               Gas Used
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -299,6 +643,53 @@ exports[`<TransactionDetails /> renders no deposit 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -317,19 +708,35 @@ exports[`<TransactionDetails /> renders no deposit 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-m-size.svg"
               />
               Attached Gas
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -339,6 +746,53 @@ exports[`<TransactionDetails /> renders no deposit 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
   </div>
@@ -362,14 +816,30 @@ exports[`<TransactionDetails /> renders no deposit 1`] = `
             >
               Created
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -379,6 +849,53 @@ exports[`<TransactionDetails /> renders no deposit 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -398,14 +915,30 @@ exports[`<TransactionDetails /> renders no deposit 1`] = `
             >
               Hash
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -415,6 +948,53 @@ exports[`<TransactionDetails /> renders no deposit 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
   </div>
@@ -438,14 +1018,30 @@ exports[`<TransactionDetails /> renders no deposit 1`] = `
             >
               Block Hash
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -466,15 +1062,92 @@ exports[`<TransactionDetails /> renders no deposit 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
   </div>
+  <style>
+    
+                  .transaction-info-container {
+                    border: solid 4px #e6e6e6;
+                    border-radius: 4px;
+                  }
+
+                  .transaction-info-container &gt; .row {
+                    border-bottom: 2px solid #e6e6e6;
+                  }
+
+                  .transaction-info-container &gt; .row:last-of-type {
+                    border-bottom: 0;
+                  }
+
+                  .transaction-info-container .header-row .card-cell-text {
+                    font-size: 24px;
+                  }
+
+                  .transaction-card-block-hash {
+                    background-color: #f8f8f8;
+                  }
+
+                  @media (max-width: 767.98px) {
+                    .transaction-info-container .border-sm-0 {
+                      border: 0;
+                    }
+                  }
+                
+  </style>
 </div>
 `;
 
 exports[`<TransactionDetails /> renders with one small deposit 1`] = `
 <div
-  className="jsx-1302829068 transaction-info-container"
+  className="transaction-info-container"
 >
   <div
     className="header-row row no-gutters"
@@ -495,19 +1168,35 @@ exports[`<TransactionDetails /> renders with one small deposit 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-m-user.svg"
               />
               Signed by
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -517,7 +1206,7 @@ exports[`<TransactionDetails /> renders with one small deposit 1`] = `
                 onClick={[Function]}
               >
                 <a
-                  className="jsx-3150401870 account-link"
+                  className="account-link"
                   href="/accounts/signer2.test"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
@@ -525,9 +1214,63 @@ exports[`<TransactionDetails /> renders with one small deposit 1`] = `
                   signer2.test
                 </a>
               </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -546,19 +1289,35 @@ exports[`<TransactionDetails /> renders with one small deposit 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-m-user.svg"
               />
               Receiver
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -568,7 +1327,7 @@ exports[`<TransactionDetails /> renders with one small deposit 1`] = `
                 onClick={[Function]}
               >
                 <a
-                  className="jsx-3150401870 account-link"
+                  className="account-link"
                   href="/accounts/receiver2.test"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
@@ -576,9 +1335,63 @@ exports[`<TransactionDetails /> renders with one small deposit 1`] = `
                   receiver2.test
                 </a>
               </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -597,26 +1410,41 @@ exports[`<TransactionDetails /> renders with one small deposit 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-t-status.svg"
               />
               Status
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
               className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
             >
               <div
-                className="jsx-1302829068"
                 style={
                   Object {
                     "fontSize": "21px",
@@ -629,6 +1457,53 @@ exports[`<TransactionDetails /> renders with one small deposit 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
   </div>
@@ -651,19 +1526,35 @@ exports[`<TransactionDetails /> renders with one small deposit 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-m-size.svg"
               />
               Transaction Fee
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -682,6 +1573,53 @@ exports[`<TransactionDetails /> renders with one small deposit 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -700,19 +1638,35 @@ exports[`<TransactionDetails /> renders with one small deposit 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-m-filter.svg"
               />
               Deposit Value
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -731,6 +1685,53 @@ exports[`<TransactionDetails /> renders with one small deposit 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -749,19 +1750,35 @@ exports[`<TransactionDetails /> renders with one small deposit 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-m-size.svg"
               />
               Gas Used
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -771,6 +1788,53 @@ exports[`<TransactionDetails /> renders with one small deposit 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -789,19 +1853,35 @@ exports[`<TransactionDetails /> renders with one small deposit 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-m-size.svg"
               />
               Attached Gas
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -811,6 +1891,53 @@ exports[`<TransactionDetails /> renders with one small deposit 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
   </div>
@@ -834,14 +1961,30 @@ exports[`<TransactionDetails /> renders with one small deposit 1`] = `
             >
               Created
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -851,6 +1994,53 @@ exports[`<TransactionDetails /> renders with one small deposit 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -870,14 +2060,30 @@ exports[`<TransactionDetails /> renders with one small deposit 1`] = `
             >
               Hash
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -887,6 +2093,53 @@ exports[`<TransactionDetails /> renders with one small deposit 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
   </div>
@@ -910,14 +2163,30 @@ exports[`<TransactionDetails /> renders with one small deposit 1`] = `
             >
               Block Hash
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -938,15 +2207,92 @@ exports[`<TransactionDetails /> renders with one small deposit 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
   </div>
+  <style>
+    
+                  .transaction-info-container {
+                    border: solid 4px #e6e6e6;
+                    border-radius: 4px;
+                  }
+
+                  .transaction-info-container &gt; .row {
+                    border-bottom: 2px solid #e6e6e6;
+                  }
+
+                  .transaction-info-container &gt; .row:last-of-type {
+                    border-bottom: 0;
+                  }
+
+                  .transaction-info-container .header-row .card-cell-text {
+                    font-size: 24px;
+                  }
+
+                  .transaction-card-block-hash {
+                    background-color: #f8f8f8;
+                  }
+
+                  @media (max-width: 767.98px) {
+                    .transaction-info-container .border-sm-0 {
+                      border: 0;
+                    }
+                  }
+                
+  </style>
 </div>
 `;
 
 exports[`<TransactionDetails /> renders with two big deposit 1`] = `
 <div
-  className="jsx-1302829068 transaction-info-container"
+  className="transaction-info-container"
 >
   <div
     className="header-row row no-gutters"
@@ -967,19 +2313,35 @@ exports[`<TransactionDetails /> renders with two big deposit 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-m-user.svg"
               />
               Signed by
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -989,7 +2351,7 @@ exports[`<TransactionDetails /> renders with two big deposit 1`] = `
                 onClick={[Function]}
               >
                 <a
-                  className="jsx-3150401870 account-link"
+                  className="account-link"
                   href="/accounts/signer2.test"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
@@ -997,9 +2359,63 @@ exports[`<TransactionDetails /> renders with two big deposit 1`] = `
                   signer2.test
                 </a>
               </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -1018,19 +2434,35 @@ exports[`<TransactionDetails /> renders with two big deposit 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-m-user.svg"
               />
               Receiver
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -1040,7 +2472,7 @@ exports[`<TransactionDetails /> renders with two big deposit 1`] = `
                 onClick={[Function]}
               >
                 <a
-                  className="jsx-3150401870 account-link"
+                  className="account-link"
                   href="/accounts/receiver2.test"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
@@ -1048,9 +2480,63 @@ exports[`<TransactionDetails /> renders with two big deposit 1`] = `
                   receiver2.test
                 </a>
               </span>
+              <style>
+                
+        .account-link {
+          white-space: nowrap;
+        }
+      
+              </style>
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -1069,26 +2555,41 @@ exports[`<TransactionDetails /> renders with two big deposit 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-t-status.svg"
               />
               Status
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
               className="ml-auto card-cell-text align-self-center col-md-12 col-auto"
             >
               <div
-                className="jsx-1302829068"
                 style={
                   Object {
                     "fontSize": "21px",
@@ -1101,6 +2602,53 @@ exports[`<TransactionDetails /> renders with two big deposit 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
   </div>
@@ -1123,19 +2671,35 @@ exports[`<TransactionDetails /> renders with two big deposit 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-m-size.svg"
               />
               Transaction Fee
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -1154,6 +2718,53 @@ exports[`<TransactionDetails /> renders with two big deposit 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -1172,19 +2783,35 @@ exports[`<TransactionDetails /> renders with two big deposit 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-m-filter.svg"
               />
               Deposit Value
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -1203,6 +2830,53 @@ exports[`<TransactionDetails /> renders with two big deposit 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -1221,19 +2895,35 @@ exports[`<TransactionDetails /> renders with two big deposit 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-m-size.svg"
               />
               Gas Used
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -1243,6 +2933,53 @@ exports[`<TransactionDetails /> renders with two big deposit 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -1261,19 +2998,35 @@ exports[`<TransactionDetails /> renders with two big deposit 1`] = `
               className="card-cell-title align-self-center col-md-12 col-auto"
             >
               <img
-                className="jsx-1735495307 card-cell-title-img"
+                className="card-cell-title-img"
                 src="/static/images/icon-m-size.svg"
               />
               Attached Gas
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -1283,6 +3036,53 @@ exports[`<TransactionDetails /> renders with two big deposit 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
   </div>
@@ -1306,14 +3106,30 @@ exports[`<TransactionDetails /> renders with two big deposit 1`] = `
             >
               Created
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -1323,6 +3139,53 @@ exports[`<TransactionDetails /> renders with two big deposit 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
     <div
@@ -1342,14 +3205,30 @@ exports[`<TransactionDetails /> renders with two big deposit 1`] = `
             >
               Hash
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -1359,6 +3238,53 @@ exports[`<TransactionDetails /> renders with two big deposit 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
   </div>
@@ -1382,14 +3308,30 @@ exports[`<TransactionDetails /> renders with two big deposit 1`] = `
             >
               Block Hash
               <div
-                className="jsx-782042476 term-helper"
+                className="term-helper"
                 onClick={[Function]}
               >
                 <img
-                  className="jsx-782042476 info"
+                  className="info"
                   onClick={[Function]}
                   src="/static/images/icon-info.svg"
                 />
+                <style>
+                  
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+                </style>
               </div>
             </div>
             <div
@@ -1410,8 +3352,85 @@ exports[`<TransactionDetails /> renders with two big deposit 1`] = `
             </div>
           </div>
         </div>
+        <style>
+          
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+        </style>
       </div>
     </div>
   </div>
+  <style>
+    
+                  .transaction-info-container {
+                    border: solid 4px #e6e6e6;
+                    border-radius: 4px;
+                  }
+
+                  .transaction-info-container &gt; .row {
+                    border-bottom: 2px solid #e6e6e6;
+                  }
+
+                  .transaction-info-container &gt; .row:last-of-type {
+                    border-bottom: 0;
+                  }
+
+                  .transaction-info-container .header-row .card-cell-text {
+                    font-size: 24px;
+                  }
+
+                  .transaction-card-block-hash {
+                    background-color: #f8f8f8;
+                  }
+
+                  @media (max-width: 767.98px) {
+                    .transaction-info-container .border-sm-0 {
+                      border: 0;
+                    }
+                  }
+                
+  </style>
 </div>
 `;

--- a/frontend/src/components/utils/__tests__/__snapshots__/AccountLink.test.tsx.snap
+++ b/frontend/src/components/utils/__tests__/__snapshots__/AccountLink.test.tsx.snap
@@ -1,31 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<AccountLink /> renders long account id 1`] = `
-<span
-  onClick={[Function]}
->
-  <a
-    className="jsx-3150401870 account-link"
-    href="/accounts/b7df2090560a225dc4934aed43db03a6c674c2d4.lockup.near"
+Array [
+  <span
     onClick={[Function]}
-    onMouseEnter={[Function]}
   >
-    b7df2…ockup.near
-  </a>
-</span>
+    <a
+      className="account-link"
+      href="/accounts/b7df2090560a225dc4934aed43db03a6c674c2d4.lockup.near"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+    >
+      b7df2…ockup.near
+    </a>
+  </span>,
+  <style>
+    
+        .account-link {
+          white-space: nowrap;
+        }
+      
+  </style>,
+]
 `;
 
 exports[`<AccountLink /> renders short account id 1`] = `
-<span
-  onClick={[Function]}
->
-  <a
-    className="jsx-3150401870 account-link"
-    href="/accounts/jerry.zest.near"
+Array [
+  <span
     onClick={[Function]}
-    onMouseEnter={[Function]}
   >
-    jerry.zest.near
-  </a>
-</span>
+    <a
+      className="account-link"
+      href="/accounts/jerry.zest.near"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+    >
+      jerry.zest.near
+    </a>
+  </span>,
+  <style>
+    
+        .account-link {
+          white-space: nowrap;
+        }
+      
+  </style>,
+]
 `;

--- a/frontend/src/components/utils/__tests__/__snapshots__/CardCell.test.tsx.snap
+++ b/frontend/src/components/utils/__tests__/__snapshots__/CardCell.test.tsx.snap
@@ -22,5 +22,52 @@ exports[`<CardCell /> renders 1`] = `
       </div>
     </div>
   </div>
+  <style>
+    
+      .card-cell {
+        border-style: solid;
+        border-color: #e6e6e6;
+        border-width: 0 0 0 2px;
+        border-radius: 0;
+        height: 100%;
+      }
+      .card-cell-title {
+        text-transform: uppercase;
+        letter-spacing: 1.8px;
+        color: #999999;
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .card-cell-title-img {
+        width: 12px !important;
+        margin-right: 8px;
+        margin-top: -3px;
+      }
+      .card-cell-text {
+        font-size: 18px;
+        font-weight: 500;
+        color: #24272a;
+      }
+      .card-cell a {
+        font-weight: 500;
+        color: #6ad1e3;
+        text-decoration: none !important;
+      }
+      .card-cell a:hover {
+        color: #6ad1e3;
+      }
+      .card-cell .term-helper .info {
+        display: none;
+      }
+      .card-cell:hover .term-helper .info {
+        display: block;
+      }
+      @media (max-width: 800px) {
+        .card-cell:hover .term-helper .info {
+          display: block;
+        }
+      }
+    
+  </style>
 </div>
 `;

--- a/frontend/src/components/utils/__tests__/__snapshots__/ReceiptLink.test.tsx.snap
+++ b/frontend/src/components/utils/__tests__/__snapshots__/ReceiptLink.test.tsx.snap
@@ -1,25 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ReceiptLink /> renders successfully in existing transaction 1`] = `
-<span
-  onClick={[Function]}
->
-  <a
-    className="jsx-4207953579 receipt-hash-link"
-    href="/transactions/66WYKL9FcK1Av1WffDYwftm6t4iwUkJrnfZPjvZgsEB7#FNNA1kX7mBPZ5LD7t8RFAVNybvybVr8h5o3n5Xw86hUW"
+Array [
+  <span
     onClick={[Function]}
-    onMouseEnter={[Function]}
   >
-    FNNA1kX...
-  </a>
-</span>
+    <a
+      className="receipt-hash-link"
+      href="/transactions/66WYKL9FcK1Av1WffDYwftm6t4iwUkJrnfZPjvZgsEB7#FNNA1kX7mBPZ5LD7t8RFAVNybvybVr8h5o3n5Xw86hUW"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+    >
+      FNNA1kX...
+    </a>
+  </span>,
+  <style>
+    
+        .receipt-hash-link.disabled {
+          cursor: default;
+          color: #24272a;
+        }
+      
+  </style>,
+]
 `;
 
 exports[`<ReceiptLink /> renders successfully in non existing transaction 1`] = `
-<span
-  className="jsx-4207953579 receipt-hash-link disabled"
-  title="9zSjvFzm6BeNsco3fdNWqKNaYFkrj94AWWfGvgssQJuG"
->
-  9zSjvFz...
-</span>
+Array [
+  <span
+    className="receipt-hash-link disabled"
+    title="9zSjvFzm6BeNsco3fdNWqKNaYFkrj94AWWfGvgssQJuG"
+  >
+    9zSjvFz...
+  </span>,
+  <style>
+    
+        .receipt-hash-link.disabled {
+          cursor: default;
+          color: #24272a;
+        }
+      
+  </style>,
+]
 `;

--- a/frontend/src/components/utils/__tests__/__snapshots__/Term.test.tsx.snap
+++ b/frontend/src/components/utils/__tests__/__snapshots__/Term.test.tsx.snap
@@ -4,14 +4,30 @@ exports[`<CardCell /> renders 1`] = `
 Array [
   "Nodes Online",
   <div
-    className="jsx-782042476 term-helper"
+    className="term-helper"
     onClick={[Function]}
   >
     <img
-      className="jsx-782042476 info"
+      className="info"
       onClick={[Function]}
       src="/static/images/icon-info.svg"
     />
+    <style>
+      
+            .term-helper {
+              display: inline-block;
+              width: 14px;
+              height: 14px;
+            }
+
+            .term-helper .info {
+              vertical-align: text-bottom;
+              margin-left: 5px;
+              width: 16px;
+              cursor: pointer;
+            }
+          
+    </style>
   </div>,
 ]
 `;


### PR DESCRIPTION
Before we move to [rust compiler in jest](https://nextjs.org/docs/testing#setting-up-jest-with-the-rust-compiler), we need to turn on proper `style` tag snapshotting, which is not actually relevant at the moment (we snap class name hash instead of actual CSS content).
The option in `.babelrc` will be removed as soon as we'll enable next-generated `jest` config.