### PR TITLE
refactor(frontend): Switch to getServerSideProps

### DIFF
--- a/frontend/cypress/integration/account-details-navigation.spec.ts
+++ b/frontend/cypress/integration/account-details-navigation.spec.ts
@@ -17,7 +17,7 @@ context("Account Details navigation", () => {
       });
   });
 
-  it("Direct navigation to /accounts/:accountId page with account ID in upper/mixed case should return HTTP 301 (Permanent Redirect)", () => {
+  it("Direct navigation to /accounts/:accountId page with account ID in upper/mixed case should return HTTP 308 (Permanent Redirect)", () => {
     cy.fixture("mixedcase-account-ids.json")
       .as("mixedcaseAccountIds")
       .then((mixedcaseAccountId) => {
@@ -31,7 +31,7 @@ context("Account Details navigation", () => {
               if (mixedcaseAccountId === mixedcaseAccountId.toLowerCase()) {
                 expect(resp.status).to.eq(200);
               } else {
-                expect(resp.status).to.eq(301);
+                expect(resp.status).to.eq(308);
                 expect(resp.redirectedToUrl).to.include(
                   `/accounts/${mixedcaseAccountId.toLowerCase()}`
                 );

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -157,17 +157,6 @@ const App: AppType = ({
 };
 
 App.getInitialProps = async (appContext) => {
-  // WARNING: Do not remove this getInitialProps implementation as it
-  // will enable Automatic Prerendering, which does not work fine with
-  // `publicRuntimeConfig`:
-  //
-  // > Note: A page that relies on publicRuntimeConfig must use
-  // > `getInitialProps` to opt-out of automatic prerendering. You can
-  // > also de-optimize your entire application by creating a Custom
-  // > `<App>` with `getInitialProps`.
-  //
-  // https://github.com/zeit/next.js#runtime-configuration
-
   let currentNearNetwork: NearNetwork;
   let cookies, acceptedLanguages;
   if (typeof window === "undefined") {

--- a/frontend/src/pages/blocks/[hash].tsx
+++ b/frontend/src/pages/blocks/[hash].tsx
@@ -16,7 +16,7 @@ import Transactions from "../../components/transactions/Transactions";
 import Content from "../../components/utils/Content";
 
 import { Translate } from "react-localize-redux";
-import { NextPage } from "next";
+import { GetServerSideProps, NextPage } from "next";
 
 type SuccessfulProps = Omit<
   BlockInfo,
@@ -105,19 +105,26 @@ const BlockDetail: NextPage<Props> = (props) => {
   );
 };
 
-BlockDetail.getInitialProps = async ({ req, query: { hash: rawHash } }) => {
-  const hash = rawHash as string;
+export const getServerSideProps: GetServerSideProps<
+  Props,
+  { hash: string }
+> = async ({ req, params }) => {
+  const hash = params!.hash;
   try {
     const block = await new BlocksApi(req).getBlockInfo(hash);
     return {
-      ...block,
-      // the return value should be a serializable object per Next.js documentation, so we map BN to strings
-      totalSupply: block.totalSupply.toString(),
-      gasPrice: block.gasPrice.toString(),
-      gasUsed: block.gasUsed.toString(),
+      props: {
+        ...block,
+        // the return value should be a serializable object per Next.js documentation, so we map BN to strings
+        totalSupply: block.totalSupply.toString(),
+        gasPrice: block.gasPrice.toString(),
+        gasUsed: block.gasUsed.toString(),
+      },
     };
   } catch (err) {
-    return { hash, err };
+    return {
+      props: { hash, err },
+    };
   }
 };
 

--- a/frontend/src/pages/transactions/[hash].tsx
+++ b/frontend/src/pages/transactions/[hash].tsx
@@ -17,16 +17,13 @@ import TransactionOutcome from "../../components/transactions/TransactionOutcome
 import Content from "../../components/utils/Content";
 
 import { Translate } from "react-localize-redux";
-import { NextPage } from "next";
+import { GetServerSideProps, NextPage } from "next";
 
-type SuccessfulProps = Transaction | null;
-
-type FailedProps = {
+type Props = {
   hash: string;
-  err: unknown;
+  transaction?: Transaction;
+  err?: unknown;
 };
-
-type Props = SuccessfulProps | FailedProps;
 
 const TransactionDetailsPage: NextPage<Props> = (props) => {
   useEffect(() => {
@@ -37,7 +34,7 @@ const TransactionDetailsPage: NextPage<Props> = (props) => {
 
   // Prepare the transaction object with all the right types and field names on render() since
   // `getInitialProps` can only return basic types to be serializable after Server-side Rendering
-  const transaction = "err" in props ? undefined : props;
+  const transaction = props.transaction;
 
   return (
     <>
@@ -106,15 +103,24 @@ const TransactionDetailsPage: NextPage<Props> = (props) => {
   );
 };
 
-TransactionDetailsPage.getInitialProps = async ({
-  req,
-  query: { hash: rawHash },
-}) => {
-  const hash = rawHash as string;
+export const getServerSideProps: GetServerSideProps<
+  Props,
+  { hash: string }
+> = async ({ req, params }) => {
+  const hash = params!.hash;
   try {
-    return await new TransactionsApi(req).getTransactionInfo(hash);
+    return {
+      props: {
+        hash,
+        transaction:
+          (await new TransactionsApi(req).getTransactionInfo(hash)) ||
+          undefined,
+      },
+    };
   } catch (err) {
-    return { hash, err };
+    return {
+      props: { hash, err },
+    };
   }
 };
 


### PR DESCRIPTION
[getInitialProps](https://nextjs.org/docs/api-reference/data-fetching/getInitialProps) are considered kinda deprecated, in favor for `getServerSideProps` and `getStaticProps`.
