### PR TITLE
Refactor (frontend): no absolute imports

### DIFF
--- a/frontend/src/hooks/use-near-network.ts
+++ b/frontend/src/hooks/use-near-network.ts
@@ -1,6 +1,6 @@
 import { NearNetwork } from "next.config";
 import { useContext } from "react";
-import { NetworkContext } from "src/context/NetworkProvider";
+import { NetworkContext } from "../context/NetworkProvider";
 
 export const useNearNetwork = (): {
   currentNetwork: NearNetwork;

--- a/frontend/src/pages/accounts/[id].tsx
+++ b/frontend/src/pages/accounts/[id].tsx
@@ -15,7 +15,7 @@ import TransactionIcon from "../../../public/static/images/icon-t-transactions.s
 
 import { Translate } from "react-localize-redux";
 import { NextPage } from "next";
-import { useNearNetwork } from "src/hooks/use-near-network";
+import { useNearNetwork } from "../../hooks/use-near-network";
 
 interface Props {
   account:

--- a/frontend/src/pages/stats/index.tsx
+++ b/frontend/src/pages/stats/index.tsx
@@ -16,7 +16,7 @@ import ActiveContractsList from "../../components/stats/ActiveContractsList";
 import StakingBar from "../../components/stats/StakingBar";
 import ProtocolConfigInfo from "../../components/stats/ProtocolConfigInfo";
 import CirculatingSupplyStats from "../../components/stats/CirculatingSupplyStats";
-import { useNearNetwork } from "src/hooks/use-near-network";
+import { useNearNetwork } from "../../hooks/use-near-network";
 
 import { Translate } from "react-localize-redux";
 import { NextPage } from "next";


### PR DESCRIPTION
It seems like absolute imports break `jest`, let's take them out as soon as it's possible :)