### PR TITLE
refactor(frontend): Fix forced loading of blocks

### DIFF
--- a/frontend/src/components/utils/ListHandler.tsx
+++ b/frontend/src/components/utils/ListHandler.tsx
@@ -70,17 +70,13 @@ const Wrapper = <T, I>(config: StaticConfig<T, I>): FC<Props<T, I>> => {
             {!props.detailPage ? (
               <DatabaseConsumer>
                 {(context) => (
-                  <>
-                    {context.latestBlockHeight ? (
-                      <div onClick={fetch}>
-                        {config.category === "Block" ? (
-                          <Update>{`${translate(
-                            "utils.ListHandler.last_block"
-                          ).toString()}#${context.latestBlockHeight}.`}</Update>
-                        ) : null}
-                      </div>
+                  <div onClick={fetch}>
+                    {config.category === "Block" ? (
+                      <Update>{`${translate(
+                        "utils.ListHandler.last_block"
+                      ).toString()}#${context.latestBlockHeight}.`}</Update>
                     ) : null}
-                  </>
+                  </div>
                 )}
               </DatabaseConsumer>
             ) : null}

--- a/frontend/src/components/utils/ListHandler.tsx
+++ b/frontend/src/components/utils/ListHandler.tsx
@@ -28,25 +28,19 @@ const Wrapper = <T, I>(config: StaticConfig<T, I>): FC<Props<T, I>> => {
     const [hasMore, setHasMore] = useState(true);
     const [loading, setLoading] = useState(false);
 
-    const fetch = useCallback(
-      (count) => {
-        setLoading(true);
-        setShouldShow(false);
-        setItems([]);
-        props
-          .fetchDataFn(count)
-          .then((items) => {
-            setItems(items);
-            setHasMore(items.length >= props.count);
-          })
-          .catch((err: Error) => console.error(err))
-          .then(() => {
-            setLoading(false);
-            setShouldShow(true);
-          });
-      },
-      [setLoading, props.count]
-    );
+    const fetch = useCallback(() => {
+      props
+        .fetchDataFn(props.count)
+        .then((items) => {
+          setItems(items);
+          setHasMore(items.length >= props.count);
+        })
+        .catch((err: Error) => console.error(err))
+        .then(() => {
+          setLoading(false);
+          setShouldShow(true);
+        });
+    }, [setLoading, props.count]);
 
     const fetchMore = useCallback(() => {
       setLoading(true);
@@ -62,7 +56,7 @@ const Wrapper = <T, I>(config: StaticConfig<T, I>): FC<Props<T, I>> => {
 
     useEffect(() => {
       if (props.count > 0) {
-        fetch(props.count);
+        fetch();
       }
     }, [props.count]);
 

--- a/frontend/src/libraries/explorer-wamp/blocks.ts
+++ b/frontend/src/libraries/explorer-wamp/blocks.ts
@@ -34,14 +34,10 @@ export default class BlocksApi extends ExplorerApi {
     if (!block) {
       throw new Error(`BlocksApi.getBlockInfo: block '${blockId}' not found`);
     }
-
-    const gasUsed = await this.getGasUsedInBlock(block.hash).catch(
-      () => new BN(0)
-    );
-    const receiptsCount = await this.call<number>("receipts-count-in-block", [
-      block.hash,
+    const [gasUsed, receiptsCount] = await Promise.all([
+      this.getGasUsedInBlock(block.hash).catch(() => new BN(0)),
+      this.call<number>("receipts-count-in-block", [block.hash]),
     ]);
-
     return {
       hash: block.hash,
       prevHash: block.prevHash,

--- a/frontend/src/libraries/explorer-wamp/blocks.ts
+++ b/frontend/src/libraries/explorer-wamp/blocks.ts
@@ -34,10 +34,14 @@ export default class BlocksApi extends ExplorerApi {
     if (!block) {
       throw new Error(`BlocksApi.getBlockInfo: block '${blockId}' not found`);
     }
-    const [gasUsed, receiptsCount] = await Promise.all([
-      this.getGasUsedInBlock(block.hash),
-      this.call<number>("receipts-count-in-block", [block.hash]),
+
+    const gasUsed = await this.getGasUsedInBlock(block.hash).catch(
+      () => new BN(0)
+    );
+    const receiptsCount = await this.call<number>("receipts-count-in-block", [
+      block.hash,
     ]);
+
     return {
       hash: block.hash,
       prevHash: block.prevHash,


### PR DESCRIPTION
We had some strange behavior with forced loading blocks on Blocks page. When you click on "Refresh..." you'll see this:
<img width="1117" alt="Снимок экрана 2022-01-18 в 12 14 16" src="https://user-images.githubusercontent.com/34593263/149917647-33a23610-0487-49ad-8967-c12c19d74542.png">
<img width="1117" alt="Снимок экрана 2022-01-18 в 12 14 20" src="https://user-images.githubusercontent.com/34593263/149917655-459d1cfe-d0ff-4989-90d3-b1a7957ea4c4.png">
<img width="1117" alt="Снимок экрана 2022-01-18 в 12 14 26" src="https://user-images.githubusercontent.com/34593263/149917657-5ee498be-3060-4388-9cef-252d290fcd5a.png">

Also we had some issue with block (hash: `CYug4KVfwXqt2cNhzzPDoN4Tz4EWEsrvj1hnna8tKrUk`). This block exist but we doun't display any information about it because `getGasUsedInBlock` request return null.
