### PR TITLE
fix(frontend): Fix `undefined` in ListHandler on Blocks page

### DIFF
--- a/frontend/src/components/utils/ListHandler.tsx
+++ b/frontend/src/components/utils/ListHandler.tsx
@@ -76,13 +76,17 @@ const Wrapper = <T, I>(config: StaticConfig<T, I>): FC<Props<T, I>> => {
             {!props.detailPage ? (
               <DatabaseConsumer>
                 {(context) => (
-                  <div onClick={fetch}>
-                    {config.category === "Block" ? (
-                      <Update>{`${translate(
-                        "utils.ListHandler.last_block"
-                      ).toString()}#${context.latestBlockHeight}.`}</Update>
+                  <>
+                    {context.latestBlockHeight ? (
+                      <div onClick={fetch}>
+                        {config.category === "Block" ? (
+                          <Update>{`${translate(
+                            "utils.ListHandler.last_block"
+                          ).toString()}#${context.latestBlockHeight}.`}</Update>
+                        ) : null}
+                      </div>
                     ) : null}
-                  </div>
+                  </>
                 )}
               </DatabaseConsumer>
             ) : null}


### PR DESCRIPTION
Sometimes on Blocks page we could see `#undefined` instead of number of latest block
<img width="1117" alt="Снимок экрана 2022-01-18 в 13 10 45" src="https://user-images.githubusercontent.com/34593263/149927041-f0f6ff3d-a4fc-465d-921f-803ce88b2be2.png">

