### PR TITLE
feat(backend): Introduce executed receipts in block method

### DIFF
--- a/backend/src/db-utils.js
+++ b/backend/src/db-utils.js
@@ -1083,6 +1083,32 @@ const queryReceiptsList = async (blockHash) => {
     { dataSource: DS_INDEXER_BACKEND }
   );
 };
+// query receipts executed in particular block
+const queryExecutedReceiptsList = async (blockHash) => {
+  return await queryRows(
+    [
+      `SELECT
+        receipts.receipt_id,
+        receipts.originated_from_transaction_hash,
+        receipts.predecessor_account_id AS predecessor_id,
+        receipts.receiver_account_id AS receiver_id,
+        execution_outcomes.status,
+        execution_outcomes.gas_burnt,
+        execution_outcomes.tokens_burnt,
+        execution_outcomes.executed_in_block_timestamp,
+        action_receipt_actions.action_kind AS kind,
+        action_receipt_actions.args
+       FROM action_receipt_actions
+       LEFT JOIN receipts ON receipts.receipt_id = action_receipt_actions.receipt_id
+       LEFT JOIN execution_outcomes ON execution_outcomes.receipt_id = action_receipt_actions.receipt_id
+       WHERE execution_outcomes.executed_in_block_hash = :block_hash
+       AND receipts.receipt_kind = 'ACTION'
+       ORDER BY receipts.included_in_chunk_hash, receipts.index_in_chunk, action_receipt_actions.index_in_action_receipt`,
+      { block_hash: blockHash },
+    ],
+    { dataSource: DS_INDEXER_BACKEND }
+  );
+};
 
 const queryContractInfo = async (accountId) => {
   return await querySingleRow(


### PR DESCRIPTION
This PR just introduces method to execute 'executed receipts in block' to work on it in next PR