### PR TITLE
Fix: ESM module import

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -54,6 +54,11 @@ const config: ExplorerConfig & NextConfig = {
     });
     return config;
   },
+  experimental: {
+    // Turning feature on breaks production code (with ESM module imported, e.g. stitches)
+    // https://github.com/vercel/next.js/issues/32360
+    esmExternals: false,
+  },
 };
 
 export = config;


### PR DESCRIPTION
After `stitches` introduce we got first ESM module in out ecosystem, which broke `nextjs` build (but for some reason not on the first attempt).
The bug is that a ESM module uses `import` instead of `require` thus marked async and creates a circular dependency in imports. Problem is [known](https://github.com/vercel/next.js/issues/32360) though not addressed yet, but we got a solution - just turn off `esmExternals` experimental feature.

This problem reproduced on multiple commits locally starting from one with stitches (before verifying I cleaned up `node_modules`, `.next`, made clean install of packages and clean build.
Also, PR stages started to reproduce the problem.
For some reason (yet to discover) production is totally fine.