### PR TITLE
Fix: Next.js params in special case

### DIFF
--- a/frontend/src/pages/accounts/[id].tsx
+++ b/frontend/src/pages/accounts/[id].tsx
@@ -82,7 +82,7 @@ export const getServerSideProps: GetServerSideProps<
   Props,
   { id: string }
 > = async ({ req, params }) => {
-  const accountId = params!.id;
+  const accountId = params?.id ?? "";
   if (/[A-Z]/.test(accountId)) {
     return {
       redirect: {

--- a/frontend/src/pages/blocks/[hash].tsx
+++ b/frontend/src/pages/blocks/[hash].tsx
@@ -73,7 +73,7 @@ export const getServerSideProps: GetServerSideProps<
   Props,
   { hash: string }
 > = async ({ req, params }) => {
-  const hash = params!.hash;
+  const hash = params?.hash ?? "";
   try {
     const nearNetwork = getNearNetwork(req);
     const block = await getBlock(wampApi.getCall(nearNetwork), hash);

--- a/frontend/src/pages/transactions/[hash].tsx
+++ b/frontend/src/pages/transactions/[hash].tsx
@@ -131,7 +131,7 @@ export const getServerSideProps: GetServerSideProps<
   Props,
   { hash: string }
 > = async ({ req, params }) => {
-  const hash = params!.hash;
+  const hash = params?.hash ?? "";
   try {
     const nearNetwork = getNearNetwork(req);
     const wampCall = wampApi.getCall(nearNetwork);


### PR DESCRIPTION
In production there is a mistake that gets us to 500 response.
It is caused if someone goes to `accounts/[id]` page, literally. In this case `[id]` doesn't match pattern but is literally `[id]` which make `params` props of `getServerSideProps` undefined.