### PR TITLE
Fix (frontend): outdated dashboard link

### DIFF
--- a/frontend/src/components/dashboard/DashboardNode.tsx
+++ b/frontend/src/components/dashboard/DashboardNode.tsx
@@ -28,7 +28,7 @@ const DashboardNode = () => {
                 )}
                 text={t("component.dashboard.DashboardNode.nodes_online.text")}
                 href={
-                  "https://docs.near.org/docs/validator/staking#run-the-node"
+                  "https://docs.near.org/docs/develop/node/intro/what-is-a-node"
                 }
               />
             }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/81771303/153728797-77e3784a-6262-4a99-a253-f09621d1bbdc.png)

Dashboard [link to docs](https://docs.near.org/docs/validator/staking#run-the-node) seems to be outdated, so changed it to follow [here](https://docs.near.org/docs/develop/node/intro/what-is-a-node)

