### PR TITLE
Always use React.memo

### DIFF
--- a/frontend/additional.d.ts
+++ b/frontend/additional.d.ts
@@ -1,9 +1,4 @@
 // See https://nextjs.org/docs/basic-features/typescript for more information.
 
-declare module "*.svg" {
-  const content: React.FC;
-  export default content;
-}
-
 declare module "react-text-collapse";
 declare module "json-2-prom";

--- a/frontend/src/components/accounts/AccountDetails.tsx
+++ b/frontend/src/components/accounts/AccountDetails.tsx
@@ -45,7 +45,7 @@ export interface Props {
   };
 }
 
-const AccountDetails: React.FC<Props> = ({ account }) => {
+const AccountDetails: React.FC<Props> = React.memo(({ account }) => {
   const { t } = useTranslation();
   const { currentNetwork } = useNetworkContext();
   const transactionCount = useWampSimpleQuery("account-transactions-count", [
@@ -328,6 +328,6 @@ const AccountDetails: React.FC<Props> = ({ account }) => {
       )}
     </AccountInfoContainer>
   );
-};
+});
 
 export default AccountDetails;

--- a/frontend/src/components/accounts/AccountRow.tsx
+++ b/frontend/src/components/accounts/AccountRow.tsx
@@ -60,7 +60,7 @@ export interface State {
   createdAtBlockTimestamp?: number;
 }
 
-const AccountRow: React.FC<Props> = ({ accountId }) => {
+const AccountRow: React.FC<Props> = React.memo(({ accountId }) => {
   const { t } = useTranslation();
   const accountInfo = useWampQuery<Account>(
     React.useCallback((wampCall) => getAccount(wampCall, accountId), [
@@ -110,6 +110,6 @@ const AccountRow: React.FC<Props> = ({ accountId }) => {
       </LinkWrapper>
     </Link>
   );
-};
+});
 
 export default AccountRow;

--- a/frontend/src/components/accounts/Accounts.tsx
+++ b/frontend/src/components/accounts/Accounts.tsx
@@ -17,9 +17,9 @@ const fetchDataFn = (
   paginationIndexer?: AccountPagination
 ) => wampCall("accounts-list", [count, paginationIndexer]);
 
-const AccountsWrapper: React.FC = () => (
+const AccountsWrapper: React.FC = React.memo(() => (
   <AccountsList count={ACCOUNTS_PER_PAGE} fetchDataFn={fetchDataFn} />
-);
+));
 
 export default AccountsWrapper;
 
@@ -27,7 +27,7 @@ interface InnerProps {
   items: PaginatedAccountBasicInfo[];
 }
 
-const Accounts: React.FC<InnerProps> = ({ items }) => (
+const Accounts: React.FC<InnerProps> = React.memo(({ items }) => (
   <FlipMove duration={1000} staggerDurationBy={0}>
     {items.map((account) => (
       <div key={account.accountId}>
@@ -35,7 +35,7 @@ const Accounts: React.FC<InnerProps> = ({ items }) => (
       </div>
     ))}
   </FlipMove>
-);
+));
 
 const AccountsList = ListHandler({
   Component: Accounts,

--- a/frontend/src/components/blocks/BlockDetails.tsx
+++ b/frontend/src/components/blocks/BlockDetails.tsx
@@ -49,7 +49,7 @@ export interface Props {
   block: Block;
 }
 
-const BlockDetails: React.FC<Props> = ({ block }) => {
+const BlockDetails: React.FC<Props> = React.memo(({ block }) => {
   const { t } = useTranslation();
   const finalBlockTimestampNanosecond = useFinalBlockTimestampNanosecond();
   const gasUsed = React.useMemo(() => new BN(block.gasUsed), [block.gasUsed]);
@@ -192,6 +192,6 @@ const BlockDetails: React.FC<Props> = ({ block }) => {
       </BlockInfoContainer>
     </Row>
   );
-};
+});
 
 export default BlockDetails;

--- a/frontend/src/components/blocks/Blocks.tsx
+++ b/frontend/src/components/blocks/Blocks.tsx
@@ -15,9 +15,9 @@ const fetchDataFn = (
   paginationIndexer?: number
 ) => wampCall("blocks-list", [count, paginationIndexer]);
 
-const BlocksWrapper: React.FC = () => (
+const BlocksWrapper: React.FC = React.memo(() => (
   <BlocksList count={BLOCKS_PER_PAGE} fetchDataFn={fetchDataFn} />
-);
+));
 
 export default BlocksWrapper;
 
@@ -25,7 +25,7 @@ export interface InnerProps {
   items: BlockBase[];
 }
 
-const Blocks: React.FC<InnerProps> = ({ items }) => (
+const Blocks: React.FC<InnerProps> = React.memo(({ items }) => (
   <FlipMove duration={1000} staggerDurationBy={0}>
     {items.map((block) => (
       <div key={block.hash}>
@@ -33,7 +33,7 @@ const Blocks: React.FC<InnerProps> = ({ items }) => (
       </div>
     ))}
   </FlipMove>
-);
+));
 
 const BlocksList = ListHandler({
   Component: Blocks,

--- a/frontend/src/components/blocks/BlocksRow.tsx
+++ b/frontend/src/components/blocks/BlocksRow.tsx
@@ -69,7 +69,7 @@ export interface Props {
   block: BlockBase;
 }
 
-const BlocksRow: React.FC<Props> = ({ block }) => {
+const BlocksRow: React.FC<Props> = React.memo(({ block }) => {
   const { t } = useTranslation();
   const finalBlockTimestampNanosecond = useFinalBlockTimestampNanosecond();
   return (
@@ -125,6 +125,6 @@ const BlocksRow: React.FC<Props> = ({ block }) => {
       </LinkWrapper>
     </Link>
   );
-};
+});
 
 export default BlocksRow;

--- a/frontend/src/components/contracts/ContractDetails.tsx
+++ b/frontend/src/components/contracts/ContractDetails.tsx
@@ -46,7 +46,7 @@ interface Props {
   accountId: string;
 }
 
-const ContractDetails: React.FC<Props> = ({ accountId }) => {
+const ContractDetails: React.FC<Props> = React.memo(({ accountId }) => {
   const { t } = useTranslation();
   const contractInfo = useWampQuery(
     React.useCallback(
@@ -190,6 +190,6 @@ const ContractDetails: React.FC<Props> = ({ accountId }) => {
       </ContractInfoContainer>
     </>
   );
-};
+});
 
 export default ContractDetails;

--- a/frontend/src/components/dashboard/DashboardBlock.tsx
+++ b/frontend/src/components/dashboard/DashboardBlock.tsx
@@ -10,7 +10,7 @@ import { Trans, useTranslation } from "react-i18next";
 import { useChainBlockStats } from "../../hooks/subscriptions";
 import { useLatestBlockHeight } from "../../hooks/data";
 
-const DashboardBlock: React.FC = () => {
+const DashboardBlock: React.FC = React.memo(() => {
   const { t } = useTranslation();
   const latestBlockHeight = useLatestBlockHeight();
   const recentBlockProductionSpeed = useChainBlockStats()
@@ -74,6 +74,6 @@ const DashboardBlock: React.FC = () => {
       </Row>
     </DashboardCard>
   );
-};
+});
 
 export default DashboardBlock;

--- a/frontend/src/components/dashboard/DashboardNode.tsx
+++ b/frontend/src/components/dashboard/DashboardNode.tsx
@@ -16,7 +16,7 @@ const CountCell = styled(LongCardCell, {
   },
 });
 
-const DashboardNode = () => {
+const DashboardNode: React.FC = React.memo(() => {
   const { t } = useTranslation();
   const networkStats = useNetworkStats();
 
@@ -67,6 +67,6 @@ const DashboardNode = () => {
       </Row>
     </DashboardCard>
   );
-};
+});
 
 export default DashboardNode;

--- a/frontend/src/components/dashboard/DashboardTransaction.tsx
+++ b/frontend/src/components/dashboard/DashboardTransaction.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { Col, Row } from "react-bootstrap";
 import { useTranslation } from "react-i18next";
 
@@ -24,7 +25,7 @@ const TransactionCharts = styled(Row, {
   },
 });
 
-const DashboardTransaction = () => {
+const DashboardTransaction: React.FC = React.memo(() => {
   const { t } = useTranslation();
   const transactionsCountHistoryForTwoWeeks = useChainTransactionStats()
     ?.transactionsCountHistoryForTwoWeeks;
@@ -92,6 +93,6 @@ const DashboardTransaction = () => {
       ) : null}
     </DashboardCard>
   );
-};
+});
 
 export default DashboardTransaction;

--- a/frontend/src/components/dashboard/DashboardTransactionsHistoryChart.tsx
+++ b/frontend/src/components/dashboard/DashboardTransactionsHistoryChart.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import ReactEcharts from "echarts-for-react";
 import * as echarts from "echarts";
 import moment from "moment";
@@ -13,7 +14,7 @@ const chartsStyle = {
   marginBottom: 26,
 };
 
-const DashboardTransactionHistoryChart = () => {
+const DashboardTransactionHistoryChart: React.FC = React.memo(() => {
   const { t } = useTranslation();
   const transactionsCountHistoryForTwoWeeks =
     useChainTransactionStats()?.transactionsCountHistoryForTwoWeeks || [];
@@ -126,6 +127,6 @@ const DashboardTransactionHistoryChart = () => {
     return <PaginationSpinner />;
   }
   return <ReactEcharts option={getOption()} style={chartsStyle} />;
-};
+});
 
 export default DashboardTransactionHistoryChart;

--- a/frontend/src/components/nodes/CumulativeStakeChart.tsx
+++ b/frontend/src/components/nodes/CumulativeStakeChart.tsx
@@ -44,22 +44,24 @@ interface Props {
   current: number;
 }
 
-const CumulativeStakeChart: React.FC<Props> = ({ total, current }) => {
-  const { t } = useTranslation();
-  return (
-    <Wrapper>
-      <Value type="total" style={{ width: total ? `${total}%` : "0%" }} />
-      <Value
-        type="current"
-        style={{
-          width: current ? `${current - total}%` : "0%",
-        }}
-      />
-      <CumulativeStakeLabel>
-        {current ? `${current}%` : t("common.state.not_available")}
-      </CumulativeStakeLabel>
-    </Wrapper>
-  );
-};
+const CumulativeStakeChart: React.FC<Props> = React.memo(
+  ({ total, current }) => {
+    const { t } = useTranslation();
+    return (
+      <Wrapper>
+        <Value type="total" style={{ width: total ? `${total}%` : "0%" }} />
+        <Value
+          type="current"
+          style={{
+            width: current ? `${current - total}%` : "0%",
+          }}
+        />
+        <CumulativeStakeLabel>
+          {current ? `${current}%` : t("common.state.not_available")}
+        </CumulativeStakeLabel>
+      </Wrapper>
+    );
+  }
+);
 
 export default CumulativeStakeChart;

--- a/frontend/src/components/nodes/NearBadge.tsx
+++ b/frontend/src/components/nodes/NearBadge.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { Badge } from "react-bootstrap";
 import { styled } from "../../libraries/styles";
 
@@ -10,8 +11,8 @@ const NearBadgeWrapper = styled(Badge, {
   background: "transparent",
 });
 
-const NearBadge = () => (
+const NearBadge: React.FC = React.memo(() => (
   <NearBadgeWrapper variant="light">NEAR</NearBadgeWrapper>
-);
+));
 
 export default NearBadge;

--- a/frontend/src/components/nodes/NodeNav.tsx
+++ b/frontend/src/components/nodes/NodeNav.tsx
@@ -53,7 +53,7 @@ interface Props {
   role: string;
 }
 
-const NodeNav: React.FC<Props> = ({ role }) => {
+const NodeNav: React.FC<Props> = React.memo(({ role }) => {
   const { t } = useTranslation();
   const networkStats = useNetworkStats();
 
@@ -75,6 +75,6 @@ const NodeNav: React.FC<Props> = ({ role }) => {
       </NodeSelector>
     </Row>
   );
-};
+});
 
 export default NodeNav;

--- a/frontend/src/components/nodes/NodeRow.tsx
+++ b/frontend/src/components/nodes/NodeRow.tsx
@@ -84,7 +84,7 @@ export const statusIdentifier = new Map([
   ["NoSync", ""],
 ]);
 
-const NodeRow: React.FC<Props> = ({ node, index }) => {
+const NodeRow: React.FC<Props> = React.memo(({ node, index }) => {
   const { t } = useTranslation();
   const [isRowActive, setRowActive] = React.useState(false);
   const switchRowActive = React.useCallback(() => setRowActive((x) => !x), [
@@ -254,6 +254,6 @@ const NodeRow: React.FC<Props> = ({ node, index }) => {
       </TableCollapseRow>
     </>
   );
-};
+});
 
 export default NodeRow;

--- a/frontend/src/components/nodes/Nodes.tsx
+++ b/frontend/src/components/nodes/Nodes.tsx
@@ -10,7 +10,7 @@ import { useNodes } from "../../hooks/subscriptions";
 
 const ITEMS_PER_PAGE = 10;
 
-const Nodes: React.FC = () => {
+const Nodes: React.FC = React.memo(() => {
   const { t } = useTranslation();
   const [activePage, setActivePage] = React.useState(0);
   const [startPage, setStartPage] = React.useState(1);
@@ -58,6 +58,6 @@ const Nodes: React.FC = () => {
       </tbody>
     </Table>
   );
-};
+});
 
 export default Nodes;

--- a/frontend/src/components/nodes/NodesCard.tsx
+++ b/frontend/src/components/nodes/NodesCard.tsx
@@ -58,13 +58,12 @@ const NodeBalanceSuffix = styled("span", {
   },
 });
 
-const NodeBalance = ({
-  amount,
-  type,
-}: {
+type BalanceProps = {
   amount: BN;
   type: "totalSupply" | "totalStakeAmount" | "seatPriceAmount";
-}) => {
+};
+
+const NodeBalance: React.FC<BalanceProps> = React.memo(({ amount, type }) => {
   if (!amount) return null;
   let value;
   let suffix;
@@ -100,7 +99,7 @@ const NodeBalance = ({
       </NodeBalanceText>
     </OverlayTrigger>
   );
-};
+});
 
 interface Props {
   currentValidatorsCount?: number;
@@ -109,52 +108,49 @@ interface Props {
   seatPrice?: string;
 }
 
-const NodesCard: React.FC<Props> = ({
-  currentValidatorsCount,
-  totalSupply,
-  totalStake,
-  seatPrice,
-}) => {
-  const { t } = useTranslation();
-  return (
-    <NodesCardWrapper>
-      <Cell
-        title={t("component.nodes.NodesCard.nodes_validating")}
-        cellOptions={{ xs: "12", sm: "6", md: "6", xl: "2" }}
-      >
-        {currentValidatorsCount !== undefined && (
-          <Validating>{currentValidatorsCount}</Validating>
-        )}
-      </Cell>
+const NodesCard: React.FC<Props> = React.memo(
+  ({ currentValidatorsCount, totalSupply, totalStake, seatPrice }) => {
+    const { t } = useTranslation();
+    return (
+      <NodesCardWrapper>
+        <Cell
+          title={t("component.nodes.NodesCard.nodes_validating")}
+          cellOptions={{ xs: "12", sm: "6", md: "6", xl: "2" }}
+        >
+          {currentValidatorsCount !== undefined && (
+            <Validating>{currentValidatorsCount}</Validating>
+          )}
+        </Cell>
 
-      <Cell
-        title={t("component.nodes.NodesCard.total_supply")}
-        cellOptions={{ xs: "12", sm: "6", md: "6", xl: "3" }}
-      >
-        {totalSupply && (
-          <NodeBalance amount={new BN(totalSupply)} type="totalSupply" />
-        )}
-      </Cell>
+        <Cell
+          title={t("component.nodes.NodesCard.total_supply")}
+          cellOptions={{ xs: "12", sm: "6", md: "6", xl: "3" }}
+        >
+          {totalSupply && (
+            <NodeBalance amount={new BN(totalSupply)} type="totalSupply" />
+          )}
+        </Cell>
 
-      <Cell
-        title={t("component.nodes.NodesCard.total_stake")}
-        cellOptions={{ xs: "12", md: "6", xl: "3" }}
-      >
-        {totalStake && (
-          <NodeBalance amount={new BN(totalStake)} type="totalStakeAmount" />
-        )}
-      </Cell>
+        <Cell
+          title={t("component.nodes.NodesCard.total_stake")}
+          cellOptions={{ xs: "12", md: "6", xl: "3" }}
+        >
+          {totalStake && (
+            <NodeBalance amount={new BN(totalStake)} type="totalStakeAmount" />
+          )}
+        </Cell>
 
-      <Cell
-        title={t("component.nodes.NodesCard.seat_price")}
-        cellOptions={{ xs: "12", md: "6", xl: "4" }}
-      >
-        {seatPrice && (
-          <NodeBalance amount={new BN(seatPrice)} type="seatPriceAmount" />
-        )}
-      </Cell>
-    </NodesCardWrapper>
-  );
-};
+        <Cell
+          title={t("component.nodes.NodesCard.seat_price")}
+          cellOptions={{ xs: "12", md: "6", xl: "4" }}
+        >
+          {seatPrice && (
+            <NodeBalance amount={new BN(seatPrice)} type="seatPriceAmount" />
+          )}
+        </Cell>
+      </NodesCardWrapper>
+    );
+  }
+);
 
 export default NodesCard;

--- a/frontend/src/components/nodes/NodesContentHeader.tsx
+++ b/frontend/src/components/nodes/NodesContentHeader.tsx
@@ -21,7 +21,7 @@ interface Props {
   navRole: string;
 }
 
-const NodesContentHeader: React.FC<Props> = ({ navRole }) => {
+const NodesContentHeader: React.FC<Props> = React.memo(({ navRole }) => {
   const { t } = useTranslation();
   return (
     <Row noGutters>
@@ -38,6 +38,6 @@ const NodesContentHeader: React.FC<Props> = ({ navRole }) => {
       </Col>
     </Row>
   );
-};
+});
 
 export default NodesContentHeader;

--- a/frontend/src/components/nodes/NodesEpoch.tsx
+++ b/frontend/src/components/nodes/NodesEpoch.tsx
@@ -49,83 +49,85 @@ interface Props {
   latestBlockTimestamp: number;
 }
 
-const NodesEpoch: React.FC<Props> = ({
-  epochStartHeight,
-  latestBlockHeight,
-  epochLength,
-  epochStartTimestamp,
-  latestBlockTimestamp,
-}) => {
-  const { t } = useTranslation();
-  const epochProgress =
-    ((latestBlockHeight - epochStartHeight) / epochLength) * 100;
-  const timeRemaining =
-    ((latestBlockTimestamp - epochStartTimestamp) / epochProgress) *
-    (100 - epochProgress);
+const NodesEpoch: React.FC<Props> = React.memo(
+  ({
+    epochStartHeight,
+    latestBlockHeight,
+    epochLength,
+    epochStartTimestamp,
+    latestBlockTimestamp,
+  }) => {
+    const { t } = useTranslation();
+    const epochProgress =
+      ((latestBlockHeight - epochStartHeight) / epochLength) * 100;
+    const timeRemaining =
+      ((latestBlockTimestamp - epochStartTimestamp) / epochProgress) *
+      (100 - epochProgress);
 
-  return (
-    <NodesEpochRow>
-      <NodesEpochContent xs="12">
-        <Row noGutters>
-          <Col xs="7">
-            <Row className="d-none d-md-flex">
-              <Col>
-                {t("component.nodes.NodesEpoch.current_epoch_start") + ": "}
-                <TextValue>
-                  {t("component.nodes.NodesEpoch.block") + " #"}
-                  {epochStartHeight}
-                </TextValue>
-              </Col>
-            </Row>
+    return (
+      <NodesEpochRow>
+        <NodesEpochContent xs="12">
+          <Row noGutters>
+            <Col xs="7">
+              <Row className="d-none d-md-flex">
+                <Col>
+                  {t("component.nodes.NodesEpoch.current_epoch_start") + ": "}
+                  <TextValue>
+                    {t("component.nodes.NodesEpoch.block") + " #"}
+                    {epochStartHeight}
+                  </TextValue>
+                </Col>
+              </Row>
 
-            <Row className="d-xs-flex d-md-none">
-              <Col xs="12">
-                {t("component.nodes.NodesEpoch.current_epoch_start")}
-              </Col>
-              <Col xs="12">
-                <TextValue>
-                  {t("component.nodes.NodesEpoch.block") + " #"}
-                  {epochStartHeight}
-                </TextValue>
-              </Col>
-            </Row>
-          </Col>
+              <Row className="d-xs-flex d-md-none">
+                <Col xs="12">
+                  {t("component.nodes.NodesEpoch.current_epoch_start")}
+                </Col>
+                <Col xs="12">
+                  <TextValue>
+                    {t("component.nodes.NodesEpoch.block") + " #"}
+                    {epochStartHeight}
+                  </TextValue>
+                </Col>
+              </Row>
+            </Col>
 
-          <Col sm="5" className="text-right d-none d-md-block ">
-            <TextValueRemainedPercent>
-              {epochProgress.toFixed(0)}
-              {"% " + t("component.nodes.NodesEpoch.complete")}
-            </TextValueRemainedPercent>
-            {` (${moment.utc(timeRemaining).format("HH:mm:ss")} ${t(
-              "component.nodes.NodesEpoch.remaining"
-            )})`}
-          </Col>
+            <Col sm="5" className="text-right d-none d-md-block ">
+              <TextValueRemainedPercent>
+                {epochProgress.toFixed(0)}
+                {"% " + t("component.nodes.NodesEpoch.complete")}
+              </TextValueRemainedPercent>
+              {` (${moment.utc(timeRemaining).format("HH:mm:ss")} ${t(
+                "component.nodes.NodesEpoch.remaining"
+              )})`}
+            </Col>
 
-          <Col xs="5" className="text-right d-xs-block d-md-none">
-            <NodesEpochCircleProgress
-              percent={epochProgress}
-              strokeColor="#37dbf4"
-              trailColor="transparent"
-              type="circle"
-              strokeWidth={4}
-              label={
-                <NodesEpochCircleProgressLabel>
-                  {epochProgress.toFixed(0)}%
-                </NodesEpochCircleProgressLabel>
-              }
-            />
-          </Col>
-        </Row>
-      </NodesEpochContent>
-      <Col xs="12" className="d-none d-md-block px-0">
-        <NodesEpochLineProgress
-          percent={epochProgress}
-          strokeColor="#37dbf4"
-          trailColor="transparent"
-        />
-      </Col>
-    </NodesEpochRow>
-  );
-};
+            <Col xs="5" className="text-right d-xs-block d-md-none">
+              <NodesEpochCircleProgress
+                percent={epochProgress}
+                strokeColor="#37dbf4"
+                trailColor="transparent"
+                type="circle"
+                strokeWidth={4}
+                label={
+                  <NodesEpochCircleProgressLabel>
+                    {epochProgress.toFixed(0)}%
+                  </NodesEpochCircleProgressLabel>
+                }
+              />
+            </Col>
+          </Row>
+        </NodesEpochContent>
+        <Col xs="12" className="d-none d-md-block px-0">
+          <NodesEpochLineProgress
+            percent={epochProgress}
+            strokeColor="#37dbf4"
+            trailColor="transparent"
+          />
+        </Col>
+      </NodesEpochRow>
+    );
+  }
+);
 
 export default NodesEpoch;

--- a/frontend/src/components/nodes/ValidatingLabel.tsx
+++ b/frontend/src/components/nodes/ValidatingLabel.tsx
@@ -51,18 +51,15 @@ interface Props {
   tooltipKey: string;
 }
 
-const ValidatingLabel: React.FC<Props> = ({
-  type,
-  text,
-  tooltipKey,
-  children,
-}) => (
-  <OverlayTrigger
-    placement={"right"}
-    overlay={<Tooltip id={tooltipKey}>{text}</Tooltip>}
-  >
-    <ValidatingLabelWrapper type={type}>{children}</ValidatingLabelWrapper>
-  </OverlayTrigger>
+const ValidatingLabel: React.FC<Props> = React.memo(
+  ({ type, text, tooltipKey, children }) => (
+    <OverlayTrigger
+      placement={"right"}
+      overlay={<Tooltip id={tooltipKey}>{text}</Tooltip>}
+    >
+      <ValidatingLabelWrapper type={type}>{children}</ValidatingLabelWrapper>
+    </OverlayTrigger>
+  )
 );
 
 export default ValidatingLabel;

--- a/frontend/src/components/nodes/ValidatorCollapsedRow.tsx
+++ b/frontend/src/components/nodes/ValidatorCollapsedRow.tsx
@@ -21,40 +21,42 @@ interface Props {
   poolDescription?: string;
 }
 
-const ValidatorCollapsedRow: React.FC<Props> = ({
-  isRowActive,
-  progress,
-  latestProducedValidatorBlock,
-  lastSeen,
-  agentName,
-  agentVersion,
-  agentBuild,
-  poolWebsite,
-  poolEmail,
-  poolTwitter,
-  poolDiscord,
-  poolDescription,
-}) => (
-  <TableCollapseRow collapse={isRowActive}>
-    <td colSpan={8}>
-      <ValidatorTelemetryRow
-        progress={progress}
-        latestProducedValidatorBlock={latestProducedValidatorBlock}
-        lastSeen={lastSeen}
-        agentName={agentName}
-        agentVersion={agentVersion}
-        agentBuild={agentBuild}
-      />
+const ValidatorCollapsedRow: React.FC<Props> = React.memo(
+  ({
+    isRowActive,
+    progress,
+    latestProducedValidatorBlock,
+    lastSeen,
+    agentName,
+    agentVersion,
+    agentBuild,
+    poolWebsite,
+    poolEmail,
+    poolTwitter,
+    poolDiscord,
+    poolDescription,
+  }) => (
+    <TableCollapseRow collapse={isRowActive}>
+      <td colSpan={8}>
+        <ValidatorTelemetryRow
+          progress={progress}
+          latestProducedValidatorBlock={latestProducedValidatorBlock}
+          lastSeen={lastSeen}
+          agentName={agentName}
+          agentVersion={agentVersion}
+          agentBuild={agentBuild}
+        />
 
-      <ValidatorMetadataRow
-        poolWebsite={poolWebsite}
-        poolEmail={poolEmail}
-        poolTwitter={poolTwitter}
-        poolDiscord={poolDiscord}
-        poolDescription={poolDescription}
-      />
-    </td>
-  </TableCollapseRow>
+        <ValidatorMetadataRow
+          poolWebsite={poolWebsite}
+          poolEmail={poolEmail}
+          poolTwitter={poolTwitter}
+          poolDiscord={poolDiscord}
+          poolDescription={poolDescription}
+        />
+      </td>
+    </TableCollapseRow>
+  )
 );
 
 export default ValidatorCollapsedRow;

--- a/frontend/src/components/nodes/ValidatorMainRow.tsx
+++ b/frontend/src/components/nodes/ValidatorMainRow.tsx
@@ -75,218 +75,222 @@ const yoctoNearToNear = new BN(1)
   .muln(10 ** 6)
   .muln(10 ** 6);
 
-const ValidatorMainRow: React.FC<Props> = ({
-  isRowActive,
-  accountId,
-  index,
-  countryCode,
-  country,
-  stakingStatus,
-  publicKey,
-  validatorFee,
-  validatorDelegators,
-  currentStake,
-  proposedStakeForNextEpoch,
-  cumulativeStake,
-  totalStakeInPersnt,
-  handleClick,
-}) => {
-  const { t } = useTranslation();
-  const stakeProposedAmount =
-    currentStake &&
-    proposedStakeForNextEpoch &&
-    (new BN(currentStake).gt(new BN(proposedStakeForNextEpoch))
-      ? {
-          value: new BN(currentStake)
-            .sub(new BN(proposedStakeForNextEpoch))
-            .toString(),
-          increace: false,
-        }
-      : new BN(currentStake).lt(new BN(proposedStakeForNextEpoch))
-      ? {
-          value: new BN(proposedStakeForNextEpoch)
-            .sub(new BN(currentStake))
-            .toString(),
-          increace: true,
-        }
-      : undefined);
+const ValidatorMainRow: React.FC<Props> = React.memo(
+  ({
+    isRowActive,
+    accountId,
+    index,
+    countryCode,
+    country,
+    stakingStatus,
+    publicKey,
+    validatorFee,
+    validatorDelegators,
+    currentStake,
+    proposedStakeForNextEpoch,
+    cumulativeStake,
+    totalStakeInPersnt,
+    handleClick,
+  }) => {
+    const { t } = useTranslation();
+    const stakeProposedAmount =
+      currentStake &&
+      proposedStakeForNextEpoch &&
+      (new BN(currentStake).gt(new BN(proposedStakeForNextEpoch))
+        ? {
+            value: new BN(currentStake)
+              .sub(new BN(proposedStakeForNextEpoch))
+              .toString(),
+            increace: false,
+          }
+        : new BN(currentStake).lt(new BN(proposedStakeForNextEpoch))
+        ? {
+            value: new BN(proposedStakeForNextEpoch)
+              .sub(new BN(currentStake))
+              .toString(),
+            increace: true,
+          }
+        : undefined);
 
-  return (
-    <>
-      <TableRow className="mx-0" collapse={isRowActive} key={accountId}>
-        <CollapseRowArrow onClick={handleClick}>
-          <IconCellIcon
-            src={
-              isRowActive
-                ? "/static/images/icon-minimize.svg"
-                : "/static/images/icon-maximize.svg"
-            }
-          />
-        </CollapseRowArrow>
-
-        <OrderTableCell>{index}</OrderTableCell>
-        <td>
-          <CountryFlag
-            id={`country_flag_${accountId}`}
-            countryCode={countryCode}
-            country={country}
-          />
-        </td>
-
-        <td>
-          <Row noGutters className="align-items-center">
-            <ValidatorsNodeLabel>
-              {stakingStatus === "proposal" ? (
-                <ValidatingLabel
-                  type="proposal"
-                  text={t(
-                    "component.nodes.ValidatorMainRow.state.proposal.text"
-                  )}
-                  tooltipKey="nodes"
-                >
-                  {t("component.nodes.ValidatorMainRow.state.proposal.title")}
-                </ValidatingLabel>
-              ) : stakingStatus === "joining" ? (
-                <ValidatingLabel
-                  type="joining"
-                  text={t(
-                    "component.nodes.ValidatorMainRow.state.joining.text"
-                  )}
-                  tooltipKey="joining"
-                >
-                  {t("component.nodes.ValidatorMainRow.state.joining.title")}
-                </ValidatingLabel>
-              ) : stakingStatus === "leaving" ? (
-                <ValidatingLabel
-                  type="leaving"
-                  text={t(
-                    "component.nodes.ValidatorMainRow.state.leaving.text"
-                  )}
-                  tooltipKey="leaving"
-                >
-                  {t("component.nodes.ValidatorMainRow.state.leaving.title")}
-                </ValidatingLabel>
-              ) : stakingStatus === "active" ? (
-                <ValidatingLabel
-                  type="active"
-                  text={t("component.nodes.ValidatorMainRow.state.active.text")}
-                  tooltipKey="current"
-                >
-                  {t("component.nodes.ValidatorMainRow.state.active.title")}
-                </ValidatingLabel>
-              ) : stakingStatus === "idle" ? (
-                <ValidatingLabel
-                  type="idle"
-                  text={t("component.nodes.ValidatorMainRow.state.idle.text")}
-                  tooltipKey="idle"
-                >
-                  {t("component.nodes.ValidatorMainRow.state.idle.title")}
-                </ValidatingLabel>
-              ) : stakingStatus === "newcomer" ? (
-                <ValidatingLabel
-                  type="newcomer"
-                  text={t(
-                    "component.nodes.ValidatorMainRow.state.newcomer.text"
-                  )}
-                  tooltipKey="newcomer"
-                >
-                  {t("component.nodes.ValidatorMainRow.state.newcomer.title")}
-                </ValidatingLabel>
-              ) : stakingStatus === "on-hold" ? (
-                <ValidatingLabel
-                  type="on-hold"
-                  text={t(
-                    "component.nodes.ValidatorMainRow.state.on_hold.text"
-                  )}
-                  tooltipKey="on-hold"
-                >
-                  {t("component.nodes.ValidatorMainRow.state.on_hold.title")}
-                </ValidatingLabel>
-              ) : null}
-            </ValidatorsNodeLabel>
-
-            <ValidatorName>
-              <Row noGutters>
-                <ValidatorNameText title={`@${accountId}`}>
-                  {accountId}
-                </ValidatorNameText>
-              </Row>
-              {publicKey && (
-                <Row noGutters>
-                  <PublicKey title={publicKey}>{publicKey}</PublicKey>
-                </Row>
-              )}
-            </ValidatorName>
-          </Row>
-        </td>
-
-        <td>
-          {validatorFee === undefined ? (
-            <Spinner animation="border" size="sm" />
-          ) : validatorFee === null ? (
-            t("common.state.not_available")
-          ) : (
-            validatorFee
-          )}
-        </td>
-        <td>
-          {validatorDelegators === undefined ? (
-            <Spinner animation="border" size="sm" />
-          ) : validatorDelegators === null ? (
-            t("common.state.not_available")
-          ) : (
-            validatorDelegators
-          )}
-        </td>
-        <StakeText as="td" className="text-right">
-          {currentStake ? (
-            <Balance amount={currentStake} label="NEAR" fracDigits={0} />
-          ) : proposedStakeForNextEpoch ? (
-            <Balance
-              amount={proposedStakeForNextEpoch}
-              label="NEAR"
-              fracDigits={0}
+    return (
+      <>
+        <TableRow className="mx-0" collapse={isRowActive} key={accountId}>
+          <CollapseRowArrow onClick={handleClick}>
+            <IconCellIcon
+              src={
+                isRowActive
+                  ? "/static/images/icon-minimize.svg"
+                  : "/static/images/icon-maximize.svg"
+              }
             />
-          ) : (
-            "-"
-          )}
-          {stakeProposedAmount && (
-            <>
-              <br />
-              <small>
-                {typeof stakeProposedAmount !== undefined && (
-                  <>
-                    {stakeProposedAmount.increace ? "+" : "-"}
-                    {Number(
-                      new BN(stakeProposedAmount.value).div(yoctoNearToNear)
-                    ) < 1 ? (
-                      <Balance
-                        amount={stakeProposedAmount.value}
-                        label="NEAR"
-                        fracDigits={4}
-                      />
-                    ) : (
-                      <Balance
-                        amount={stakeProposedAmount.value}
-                        label="NEAR"
-                        fracDigits={0}
-                      />
+          </CollapseRowArrow>
+
+          <OrderTableCell>{index}</OrderTableCell>
+          <td>
+            <CountryFlag
+              id={`country_flag_${accountId}`}
+              countryCode={countryCode}
+              country={country}
+            />
+          </td>
+
+          <td>
+            <Row noGutters className="align-items-center">
+              <ValidatorsNodeLabel>
+                {stakingStatus === "proposal" ? (
+                  <ValidatingLabel
+                    type="proposal"
+                    text={t(
+                      "component.nodes.ValidatorMainRow.state.proposal.text"
                     )}
-                  </>
+                    tooltipKey="nodes"
+                  >
+                    {t("component.nodes.ValidatorMainRow.state.proposal.title")}
+                  </ValidatingLabel>
+                ) : stakingStatus === "joining" ? (
+                  <ValidatingLabel
+                    type="joining"
+                    text={t(
+                      "component.nodes.ValidatorMainRow.state.joining.text"
+                    )}
+                    tooltipKey="joining"
+                  >
+                    {t("component.nodes.ValidatorMainRow.state.joining.title")}
+                  </ValidatingLabel>
+                ) : stakingStatus === "leaving" ? (
+                  <ValidatingLabel
+                    type="leaving"
+                    text={t(
+                      "component.nodes.ValidatorMainRow.state.leaving.text"
+                    )}
+                    tooltipKey="leaving"
+                  >
+                    {t("component.nodes.ValidatorMainRow.state.leaving.title")}
+                  </ValidatingLabel>
+                ) : stakingStatus === "active" ? (
+                  <ValidatingLabel
+                    type="active"
+                    text={t(
+                      "component.nodes.ValidatorMainRow.state.active.text"
+                    )}
+                    tooltipKey="current"
+                  >
+                    {t("component.nodes.ValidatorMainRow.state.active.title")}
+                  </ValidatingLabel>
+                ) : stakingStatus === "idle" ? (
+                  <ValidatingLabel
+                    type="idle"
+                    text={t("component.nodes.ValidatorMainRow.state.idle.text")}
+                    tooltipKey="idle"
+                  >
+                    {t("component.nodes.ValidatorMainRow.state.idle.title")}
+                  </ValidatingLabel>
+                ) : stakingStatus === "newcomer" ? (
+                  <ValidatingLabel
+                    type="newcomer"
+                    text={t(
+                      "component.nodes.ValidatorMainRow.state.newcomer.text"
+                    )}
+                    tooltipKey="newcomer"
+                  >
+                    {t("component.nodes.ValidatorMainRow.state.newcomer.title")}
+                  </ValidatingLabel>
+                ) : stakingStatus === "on-hold" ? (
+                  <ValidatingLabel
+                    type="on-hold"
+                    text={t(
+                      "component.nodes.ValidatorMainRow.state.on_hold.text"
+                    )}
+                    tooltipKey="on-hold"
+                  >
+                    {t("component.nodes.ValidatorMainRow.state.on_hold.title")}
+                  </ValidatingLabel>
+                ) : null}
+              </ValidatorsNodeLabel>
+
+              <ValidatorName>
+                <Row noGutters>
+                  <ValidatorNameText title={`@${accountId}`}>
+                    {accountId}
+                  </ValidatorNameText>
+                </Row>
+                {publicKey && (
+                  <Row noGutters>
+                    <PublicKey title={publicKey}>{publicKey}</PublicKey>
+                  </Row>
                 )}
-              </small>
-            </>
-          )}
-        </StakeText>
-        <td>
-          <CumulativeStakeChart
-            total={cumulativeStake - totalStakeInPersnt}
-            current={cumulativeStake}
-          />
-        </td>
-      </TableRow>
-    </>
-  );
-};
+              </ValidatorName>
+            </Row>
+          </td>
+
+          <td>
+            {validatorFee === undefined ? (
+              <Spinner animation="border" size="sm" />
+            ) : validatorFee === null ? (
+              t("common.state.not_available")
+            ) : (
+              validatorFee
+            )}
+          </td>
+          <td>
+            {validatorDelegators === undefined ? (
+              <Spinner animation="border" size="sm" />
+            ) : validatorDelegators === null ? (
+              t("common.state.not_available")
+            ) : (
+              validatorDelegators
+            )}
+          </td>
+          <StakeText as="td" className="text-right">
+            {currentStake ? (
+              <Balance amount={currentStake} label="NEAR" fracDigits={0} />
+            ) : proposedStakeForNextEpoch ? (
+              <Balance
+                amount={proposedStakeForNextEpoch}
+                label="NEAR"
+                fracDigits={0}
+              />
+            ) : (
+              "-"
+            )}
+            {stakeProposedAmount && (
+              <>
+                <br />
+                <small>
+                  {typeof stakeProposedAmount !== undefined && (
+                    <>
+                      {stakeProposedAmount.increace ? "+" : "-"}
+                      {Number(
+                        new BN(stakeProposedAmount.value).div(yoctoNearToNear)
+                      ) < 1 ? (
+                        <Balance
+                          amount={stakeProposedAmount.value}
+                          label="NEAR"
+                          fracDigits={4}
+                        />
+                      ) : (
+                        <Balance
+                          amount={stakeProposedAmount.value}
+                          label="NEAR"
+                          fracDigits={0}
+                        />
+                      )}
+                    </>
+                  )}
+                </small>
+              </>
+            )}
+          </StakeText>
+          <td>
+            <CumulativeStakeChart
+              total={cumulativeStake - totalStakeInPersnt}
+              current={cumulativeStake}
+            />
+          </td>
+        </TableRow>
+      </>
+    );
+  }
+);
 
 export default ValidatorMainRow;

--- a/frontend/src/components/nodes/ValidatorMetadataRow.tsx
+++ b/frontend/src/components/nodes/ValidatorMetadataRow.tsx
@@ -23,140 +23,142 @@ interface Props {
   poolDescription?: string;
 }
 
-const ValidatorMetadataRow: React.FC<Props> = ({
-  poolWebsite,
-  poolEmail,
-  poolTwitter,
-  poolDiscord,
-  poolDescription,
-}) => {
-  const { t } = useTranslation();
-  const poolDetailsAvailable =
-    Boolean(poolWebsite) ||
-    Boolean(poolEmail) ||
-    Boolean(poolTwitter) ||
-    Boolean(poolDiscord) ||
-    Boolean(poolDescription);
+const ValidatorMetadataRow: React.FC<Props> = React.memo(
+  ({ poolWebsite, poolEmail, poolTwitter, poolDiscord, poolDescription }) => {
+    const { t } = useTranslation();
+    const poolDetailsAvailable =
+      Boolean(poolWebsite) ||
+      Boolean(poolEmail) ||
+      Boolean(poolTwitter) ||
+      Boolean(poolDiscord) ||
+      Boolean(poolDescription);
 
-  return (
-    <ValidatorNodesContentRow noGutters>
-      {poolDetailsAvailable ? (
-        <>
-          {poolWebsite && (
-            <ValidatorNodesContentCell xs="auto">
-              <Row noGutters>
-                <ValidatorNodesDetailsTitle>
-                  {t("component.nodes.ValidatorMetadataRow.pool_info.website")}
-                </ValidatorNodesDetailsTitle>
-              </Row>
-              <Row noGutters>
-                <ValidatorNodesText>
-                  <a
-                    href={
-                      poolWebsite.startsWith("http")
-                        ? poolWebsite
-                        : `http://${poolWebsite}`
-                    }
-                    rel="noreferrer noopener"
-                    target="_blank"
-                  >
-                    {poolWebsite}
-                  </a>
-                </ValidatorNodesText>
-              </Row>
-            </ValidatorNodesContentCell>
-          )}
-          {poolEmail && (
-            <ValidatorNodesContentCell xs="auto">
-              <Row noGutters>
-                <ValidatorNodesDetailsTitle>
-                  {t("component.nodes.ValidatorMetadataRow.pool_info.email")}
-                </ValidatorNodesDetailsTitle>
-              </Row>
-              <Row noGutters>
-                <ValidatorNodesText>
-                  <a href={`mailto:${poolEmail}`}>{poolEmail}</a>
-                </ValidatorNodesText>
-              </Row>
-            </ValidatorNodesContentCell>
-          )}
-          {poolTwitter && (
-            <ValidatorNodesContentCell xs="auto">
-              <Row noGutters>
-                <ValidatorNodesDetailsTitle>
-                  {t("component.nodes.ValidatorMetadataRow.pool_info.twitter")}
-                </ValidatorNodesDetailsTitle>
-              </Row>
-              <Row noGutters>
-                <ValidatorNodesText>
-                  <a
-                    href={`https://twitter.com/${poolTwitter}`}
-                    rel="noreferrer noopener"
-                    target="_blank"
-                  >
-                    {poolTwitter}
-                  </a>
-                </ValidatorNodesText>
-              </Row>
-            </ValidatorNodesContentCell>
-          )}
-          {poolDiscord && (
-            <ValidatorNodesContentCell xs="auto">
-              <Row noGutters>
-                <ValidatorNodesDetailsTitle>
-                  {t("component.nodes.ValidatorMetadataRow.pool_info.discord")}
-                </ValidatorNodesDetailsTitle>
-              </Row>
-              <Row noGutters>
-                <ValidatorNodesText>
-                  <a
-                    href={poolDiscord}
-                    rel="noreferrer noopener"
-                    target="_blank"
-                  >
-                    {poolDiscord}
-                  </a>
-                </ValidatorNodesText>
-              </Row>
-            </ValidatorNodesContentCell>
-          )}
-          {poolDescription && (
-            <ValidatorNodesContentCell>
-              <Row noGutters>
-                <ValidatorNodesDetailsTitle>
-                  {t(
-                    "component.nodes.ValidatorMetadataRow.pool_info.description"
-                  )}
-                </ValidatorNodesDetailsTitle>
-              </Row>
-              <Row noGutters>
-                <ValidatorNodesText>
-                  <small>{poolDescription}</small>
-                </ValidatorNodesText>
-              </Row>
-            </ValidatorNodesContentCell>
-          )}
-        </>
-      ) : (
-        <ValidatorNodesContentCell>
-          <p className="text-center">
-            <Trans
-              t={t}
-              i18nKey="component.nodes.ValidatorMetadataRow.pool_info_tip"
-              components={{
-                poolLink: (
-                  <a
-                    href="https://github.com/zavodil/near-pool-details#description"
-                    target="_blank"
-                  />
-                ),
-              }}
-            />
-          </p>
-        </ValidatorNodesContentCell>
-      )}
-    </ValidatorNodesContentRow>
-  );
-};
+    return (
+      <ValidatorNodesContentRow noGutters>
+        {poolDetailsAvailable ? (
+          <>
+            {poolWebsite && (
+              <ValidatorNodesContentCell xs="auto">
+                <Row noGutters>
+                  <ValidatorNodesDetailsTitle>
+                    {t(
+                      "component.nodes.ValidatorMetadataRow.pool_info.website"
+                    )}
+                  </ValidatorNodesDetailsTitle>
+                </Row>
+                <Row noGutters>
+                  <ValidatorNodesText>
+                    <a
+                      href={
+                        poolWebsite.startsWith("http")
+                          ? poolWebsite
+                          : `http://${poolWebsite}`
+                      }
+                      rel="noreferrer noopener"
+                      target="_blank"
+                    >
+                      {poolWebsite}
+                    </a>
+                  </ValidatorNodesText>
+                </Row>
+              </ValidatorNodesContentCell>
+            )}
+            {poolEmail && (
+              <ValidatorNodesContentCell xs="auto">
+                <Row noGutters>
+                  <ValidatorNodesDetailsTitle>
+                    {t("component.nodes.ValidatorMetadataRow.pool_info.email")}
+                  </ValidatorNodesDetailsTitle>
+                </Row>
+                <Row noGutters>
+                  <ValidatorNodesText>
+                    <a href={`mailto:${poolEmail}`}>{poolEmail}</a>
+                  </ValidatorNodesText>
+                </Row>
+              </ValidatorNodesContentCell>
+            )}
+            {poolTwitter && (
+              <ValidatorNodesContentCell xs="auto">
+                <Row noGutters>
+                  <ValidatorNodesDetailsTitle>
+                    {t(
+                      "component.nodes.ValidatorMetadataRow.pool_info.twitter"
+                    )}
+                  </ValidatorNodesDetailsTitle>
+                </Row>
+                <Row noGutters>
+                  <ValidatorNodesText>
+                    <a
+                      href={`https://twitter.com/${poolTwitter}`}
+                      rel="noreferrer noopener"
+                      target="_blank"
+                    >
+                      {poolTwitter}
+                    </a>
+                  </ValidatorNodesText>
+                </Row>
+              </ValidatorNodesContentCell>
+            )}
+            {poolDiscord && (
+              <ValidatorNodesContentCell xs="auto">
+                <Row noGutters>
+                  <ValidatorNodesDetailsTitle>
+                    {t(
+                      "component.nodes.ValidatorMetadataRow.pool_info.discord"
+                    )}
+                  </ValidatorNodesDetailsTitle>
+                </Row>
+                <Row noGutters>
+                  <ValidatorNodesText>
+                    <a
+                      href={poolDiscord}
+                      rel="noreferrer noopener"
+                      target="_blank"
+                    >
+                      {poolDiscord}
+                    </a>
+                  </ValidatorNodesText>
+                </Row>
+              </ValidatorNodesContentCell>
+            )}
+            {poolDescription && (
+              <ValidatorNodesContentCell>
+                <Row noGutters>
+                  <ValidatorNodesDetailsTitle>
+                    {t(
+                      "component.nodes.ValidatorMetadataRow.pool_info.description"
+                    )}
+                  </ValidatorNodesDetailsTitle>
+                </Row>
+                <Row noGutters>
+                  <ValidatorNodesText>
+                    <small>{poolDescription}</small>
+                  </ValidatorNodesText>
+                </Row>
+              </ValidatorNodesContentCell>
+            )}
+          </>
+        ) : (
+          <ValidatorNodesContentCell>
+            <p className="text-center">
+              <Trans
+                t={t}
+                i18nKey="component.nodes.ValidatorMetadataRow.pool_info_tip"
+                components={{
+                  poolLink: (
+                    <a
+                      href="https://github.com/zavodil/near-pool-details#description"
+                      target="_blank"
+                    />
+                  ),
+                }}
+              />
+            </p>
+          </ValidatorNodesContentCell>
+        )}
+      </ValidatorNodesContentRow>
+    );
+  }
+);
 
 export default ValidatorMetadataRow;

--- a/frontend/src/components/nodes/ValidatorRow.tsx
+++ b/frontend/src/components/nodes/ValidatorRow.tsx
@@ -50,94 +50,99 @@ interface Props {
 
 const networkHolder: Set<number> = new Set();
 
-const ValidatorRow: React.FC<Props> = ({ node, index, totalStake }) => {
-  const { t } = useTranslation();
-  const [isRowActive, setRowActive] = React.useState(false);
-  const switchRowActive = React.useCallback(() => setRowActive((x) => !x), [
-    setRowActive,
-  ]);
-  let totalStakeInPersnt = 0;
-  let cumulativeStake = 0;
-  let validatorFee =
-    typeof node.fee === "undefined"
-      ? undefined
-      : node.fee === null
-      ? null
-      : `${((node.fee.numerator / node.fee.denominator) * 100).toFixed(0)}%`;
-  let validatorDelegators =
-    typeof node.delegatorsCount === "undefined"
-      ? undefined
-      : node.delegatorsCount === null
-      ? null
-      : node.delegatorsCount;
+const ValidatorRow: React.FC<Props> = React.memo(
+  ({ node, index, totalStake }) => {
+    const { t } = useTranslation();
+    const [isRowActive, setRowActive] = React.useState(false);
+    const switchRowActive = React.useCallback(() => setRowActive((x) => !x), [
+      setRowActive,
+    ]);
+    let totalStakeInPersnt = 0;
+    let cumulativeStake = 0;
+    let validatorFee =
+      typeof node.fee === "undefined"
+        ? undefined
+        : node.fee === null
+        ? null
+        : `${((node.fee.numerator / node.fee.denominator) * 100).toFixed(0)}%`;
+    let validatorDelegators =
+      typeof node.delegatorsCount === "undefined"
+        ? undefined
+        : node.delegatorsCount === null
+        ? null
+        : node.delegatorsCount;
 
-  if (node.currentStake && totalStake) {
-    totalStakeInPersnt =
-      new BN(node.currentStake).mul(new BN(10000)).div(totalStake).toNumber() /
-      100;
+    if (node.currentStake && totalStake) {
+      totalStakeInPersnt =
+        new BN(node.currentStake)
+          .mul(new BN(10000))
+          .div(totalStake)
+          .toNumber() / 100;
+    }
+
+    const cumulativeStakeAmount =
+      node.cumulativeStakeAmount && new BN(node.cumulativeStakeAmount);
+    if (node.currentStake && totalStake && cumulativeStakeAmount) {
+      cumulativeStake =
+        cumulativeStakeAmount.mul(new BN(10000)).div(totalStake).toNumber() /
+        100;
+    }
+
+    if (
+      networkHolder.size === 0 &&
+      totalStake &&
+      cumulativeStakeAmount &&
+      cumulativeStakeAmount.gt(totalStake.divn(3))
+    ) {
+      networkHolder.add(index);
+    }
+
+    return (
+      <>
+        <ValidatorMainRow
+          isRowActive={isRowActive}
+          accountId={node.account_id}
+          index={index}
+          countryCode={node.poolDetails?.country_code}
+          country={node.poolDetails?.country}
+          stakingStatus={node.stakingStatus}
+          publicKey={node.public_key}
+          validatorFee={validatorFee}
+          validatorDelegators={validatorDelegators}
+          currentStake={node.currentStake}
+          proposedStakeForNextEpoch={node.proposedStake}
+          cumulativeStake={cumulativeStake}
+          totalStakeInPersnt={totalStakeInPersnt}
+          handleClick={switchRowActive}
+        />
+
+        <ValidatorCollapsedRow
+          isRowActive={isRowActive}
+          progress={node.progress}
+          latestProducedValidatorBlock={node.nodeInfo?.lastHeight}
+          lastSeen={node.nodeInfo?.lastSeen}
+          agentName={node.nodeInfo?.agentName}
+          agentVersion={node.nodeInfo?.agentVersion}
+          agentBuild={node.nodeInfo?.agentBuild}
+          poolWebsite={node.poolDetails?.url}
+          poolEmail={node.poolDetails?.email}
+          poolTwitter={node.poolDetails?.twitter}
+          poolDiscord={node.poolDetails?.discord}
+          poolDescription={node.poolDetails?.description}
+        />
+
+        {cumulativeStakeAmount && networkHolder.has(index) && (
+          <CumulativeStakeholdersRow>
+            <WarningText colSpan={8} className="text-center">
+              {t("component.nodes.ValidatorRow.warning_tip", {
+                node_tip_max: index,
+              })}
+            </WarningText>
+          </CumulativeStakeholdersRow>
+        )}
+      </>
+    );
   }
-
-  const cumulativeStakeAmount =
-    node.cumulativeStakeAmount && new BN(node.cumulativeStakeAmount);
-  if (node.currentStake && totalStake && cumulativeStakeAmount) {
-    cumulativeStake =
-      cumulativeStakeAmount.mul(new BN(10000)).div(totalStake).toNumber() / 100;
-  }
-
-  if (
-    networkHolder.size === 0 &&
-    totalStake &&
-    cumulativeStakeAmount &&
-    cumulativeStakeAmount.gt(totalStake.divn(3))
-  ) {
-    networkHolder.add(index);
-  }
-
-  return (
-    <>
-      <ValidatorMainRow
-        isRowActive={isRowActive}
-        accountId={node.account_id}
-        index={index}
-        countryCode={node.poolDetails?.country_code}
-        country={node.poolDetails?.country}
-        stakingStatus={node.stakingStatus}
-        publicKey={node.public_key}
-        validatorFee={validatorFee}
-        validatorDelegators={validatorDelegators}
-        currentStake={node.currentStake}
-        proposedStakeForNextEpoch={node.proposedStake}
-        cumulativeStake={cumulativeStake}
-        totalStakeInPersnt={totalStakeInPersnt}
-        handleClick={switchRowActive}
-      />
-
-      <ValidatorCollapsedRow
-        isRowActive={isRowActive}
-        progress={node.progress}
-        latestProducedValidatorBlock={node.nodeInfo?.lastHeight}
-        lastSeen={node.nodeInfo?.lastSeen}
-        agentName={node.nodeInfo?.agentName}
-        agentVersion={node.nodeInfo?.agentVersion}
-        agentBuild={node.nodeInfo?.agentBuild}
-        poolWebsite={node.poolDetails?.url}
-        poolEmail={node.poolDetails?.email}
-        poolTwitter={node.poolDetails?.twitter}
-        poolDiscord={node.poolDetails?.discord}
-        poolDescription={node.poolDetails?.description}
-      />
-
-      {cumulativeStakeAmount && networkHolder.has(index) && (
-        <CumulativeStakeholdersRow>
-          <WarningText colSpan={8} className="text-center">
-            {t("component.nodes.ValidatorRow.warning_tip", {
-              node_tip_max: index,
-            })}
-          </WarningText>
-        </CumulativeStakeholdersRow>
-      )}
-    </>
-  );
-};
+);
 
 export default ValidatorRow;

--- a/frontend/src/components/nodes/ValidatorTelemetryRow.tsx
+++ b/frontend/src/components/nodes/ValidatorTelemetryRow.tsx
@@ -33,193 +33,199 @@ interface Props {
   agentBuild?: string;
 }
 
-const ValidatorTelemetryRow: React.FC<Props> = ({
-  progress,
-  latestProducedValidatorBlock,
-  lastSeen,
-  agentName,
-  agentVersion,
-  agentBuild,
-}) => {
-  const { t } = useTranslation();
-  const isTelemetryAvailable =
-    Boolean(progress) ||
-    Boolean(latestProducedValidatorBlock) ||
-    Boolean(lastSeen) ||
-    Boolean(agentName) ||
-    Boolean(agentVersion) ||
-    Boolean(agentBuild);
+const ValidatorTelemetryRow: React.FC<Props> = React.memo(
+  ({
+    progress,
+    latestProducedValidatorBlock,
+    lastSeen,
+    agentName,
+    agentVersion,
+    agentBuild,
+  }) => {
+    const { t } = useTranslation();
+    const isTelemetryAvailable =
+      Boolean(progress) ||
+      Boolean(latestProducedValidatorBlock) ||
+      Boolean(lastSeen) ||
+      Boolean(agentName) ||
+      Boolean(agentVersion) ||
+      Boolean(agentBuild);
 
-  const latestBlockHeight = useLatestBlockHeight();
+    const latestBlockHeight = useLatestBlockHeight();
 
-  if (!isTelemetryAvailable) return null;
+    if (!isTelemetryAvailable) return null;
 
-  return (
-    <ValidatorNodesContentRow noGutters>
-      <link
-        href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@500&display=swap"
-        rel="stylesheet"
-      />
-      <ValidatorNodesContentCell>
-        <Row noGutters>
-          <ValidatorNodesDetailsTitle>
-            <Term
-              title={t("component.nodes.ValidatorTelemetryRow.uptime.title")}
-              text={t("component.nodes.ValidatorTelemetryRow.uptime.text")}
-              href="https://nomicon.io/Economics/README.html#rewards-calculation"
-            />
-          </ValidatorNodesDetailsTitle>
-        </Row>
-        <Row noGutters>
-          <Uptime>
-            {progress ? (
-              <>
-                <OverlayTrigger
-                  placement={"bottom"}
-                  overlay={
-                    <Tooltip id="produced-blocks-chunks">
-                      {t(
-                        "component.nodes.ValidatorTelemetryRow.produced_blocks_and_chunks",
-                        {
-                          num_produced_blocks: progress.blocks.produced,
-                          num_expected_blocks: progress.blocks.total,
-                          num_produced_chunks: progress.chunks.produced,
-                          num_expected_chunks: progress.chunks.total,
-                        }
-                      )}
-                    </Tooltip>
-                  }
-                >
-                  <span>
-                    {(
-                      (progress.blocks.produced / progress.blocks.total) *
-                      100
-                    ).toFixed(3)}
-                    %
-                  </span>
-                </OverlayTrigger>
-              </>
-            ) : (
-              t("common.state.not_available")
-            )}
-          </Uptime>
-        </Row>
-      </ValidatorNodesContentCell>
-
-      <ValidatorNodesContentCell>
-        <Row noGutters>
-          <ValidatorNodesDetailsTitle>
-            <Term
-              title={t(
-                "component.nodes.ValidatorTelemetryRow.latest_produced_block.title"
+    return (
+      <ValidatorNodesContentRow noGutters>
+        <link
+          href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@500&display=swap"
+          rel="stylesheet"
+        />
+        <ValidatorNodesContentCell>
+          <Row noGutters>
+            <ValidatorNodesDetailsTitle>
+              <Term
+                title={t("component.nodes.ValidatorTelemetryRow.uptime.title")}
+                text={t("component.nodes.ValidatorTelemetryRow.uptime.text")}
+                href="https://nomicon.io/Economics/README.html#rewards-calculation"
+              />
+            </ValidatorNodesDetailsTitle>
+          </Row>
+          <Row noGutters>
+            <Uptime>
+              {progress ? (
+                <>
+                  <OverlayTrigger
+                    placement={"bottom"}
+                    overlay={
+                      <Tooltip id="produced-blocks-chunks">
+                        {t(
+                          "component.nodes.ValidatorTelemetryRow.produced_blocks_and_chunks",
+                          {
+                            num_produced_blocks: progress.blocks.produced,
+                            num_expected_blocks: progress.blocks.total,
+                            num_produced_chunks: progress.chunks.produced,
+                            num_expected_chunks: progress.chunks.total,
+                          }
+                        )}
+                      </Tooltip>
+                    }
+                  >
+                    <span>
+                      {(
+                        (progress.blocks.produced / progress.blocks.total) *
+                        100
+                      ).toFixed(3)}
+                      %
+                    </span>
+                  </OverlayTrigger>
+                </>
+              ) : (
+                t("common.state.not_available")
               )}
-              text={t(
-                "component.nodes.ValidatorTelemetryRow.latest_produced_block.text"
-              )}
-            />
-          </ValidatorNodesDetailsTitle>
-        </Row>
-        <Row noGutters>
-          <ValidatorNodesText
-            className={
-              latestBlockHeight === undefined ||
-              latestProducedValidatorBlock === undefined
-                ? undefined
-                : Math.abs(
-                    latestProducedValidatorBlock - latestBlockHeight.toNumber()
-                  ) > 1000
-                ? "text-danger"
-                : Math.abs(
-                    latestProducedValidatorBlock - latestBlockHeight.toNumber()
-                  ) > 50
-                ? "text-warning"
-                : undefined
-            }
-            md={3}
-          >
-            {latestProducedValidatorBlock ?? t("common.state.not_available")}
-          </ValidatorNodesText>
-        </Row>
-      </ValidatorNodesContentCell>
+            </Uptime>
+          </Row>
+        </ValidatorNodesContentCell>
 
-      <ValidatorNodesContentCell>
-        <Row noGutters>
-          <ValidatorNodesDetailsTitle>
-            <Term
-              title={t(
-                "component.nodes.ValidatorTelemetryRow.latest_telemetry_update.title"
-              )}
-              text={t(
-                "component.nodes.ValidatorTelemetryRow.latest_telemetry_update.text"
-              )}
-            />
-          </ValidatorNodesDetailsTitle>
-        </Row>
-        <Row noGutters>
-          <ValidatorNodesText>
-            {lastSeen ? (
-              <Timer time={lastSeen} />
-            ) : (
-              t("common.state.not_available")
-            )}
-          </ValidatorNodesText>
-        </Row>
-      </ValidatorNodesContentCell>
-
-      <ValidatorNodesContentCell>
-        <Row noGutters>
-          <ValidatorNodesDetailsTitle>
-            <Term
-              title={t(
-                "component.nodes.ValidatorTelemetryRow.node_agent_name.title"
-              )}
-              text={
-                <Trans
-                  i18nKey="component.nodes.ValidatorTelemetryRow.node_agent_name.text"
-                  components={{
-                    nearCoreLink: <a href="https://github.com/near/nearcore" />,
-                  }}
-                />
+        <ValidatorNodesContentCell>
+          <Row noGutters>
+            <ValidatorNodesDetailsTitle>
+              <Term
+                title={t(
+                  "component.nodes.ValidatorTelemetryRow.latest_produced_block.title"
+                )}
+                text={t(
+                  "component.nodes.ValidatorTelemetryRow.latest_produced_block.text"
+                )}
+              />
+            </ValidatorNodesDetailsTitle>
+          </Row>
+          <Row noGutters>
+            <ValidatorNodesText
+              className={
+                latestBlockHeight === undefined ||
+                latestProducedValidatorBlock === undefined
+                  ? undefined
+                  : Math.abs(
+                      latestProducedValidatorBlock -
+                        latestBlockHeight.toNumber()
+                    ) > 1000
+                  ? "text-danger"
+                  : Math.abs(
+                      latestProducedValidatorBlock -
+                        latestBlockHeight.toNumber()
+                    ) > 50
+                  ? "text-warning"
+                  : undefined
               }
-            />
-          </ValidatorNodesDetailsTitle>
-        </Row>
-        <Row noGutters>
-          <ValidatorNodesText>
-            {agentName ? (
-              <AgentNameBadge variant="secondary">{agentName}</AgentNameBadge>
-            ) : (
-              t("common.state.not_available")
-            )}
-          </ValidatorNodesText>
-        </Row>
-      </ValidatorNodesContentCell>
+              md={3}
+            >
+              {latestProducedValidatorBlock ?? t("common.state.not_available")}
+            </ValidatorNodesText>
+          </Row>
+        </ValidatorNodesContentCell>
 
-      <ValidatorNodesContentCell>
-        <Row noGutters>
-          <ValidatorNodesDetailsTitle>
-            {t(
-              "component.nodes.ValidatorTelemetryRow.node_agent_version_or_build.title"
-            )}
-          </ValidatorNodesDetailsTitle>
-        </Row>
-        <Row noGutters>
-          <ValidatorNodesText>
-            {agentVersion || agentBuild ? (
-              <AgentNameBadge variant="secondary">
-                {`${agentVersion ?? "-"}
+        <ValidatorNodesContentCell>
+          <Row noGutters>
+            <ValidatorNodesDetailsTitle>
+              <Term
+                title={t(
+                  "component.nodes.ValidatorTelemetryRow.latest_telemetry_update.title"
+                )}
+                text={t(
+                  "component.nodes.ValidatorTelemetryRow.latest_telemetry_update.text"
+                )}
+              />
+            </ValidatorNodesDetailsTitle>
+          </Row>
+          <Row noGutters>
+            <ValidatorNodesText>
+              {lastSeen ? (
+                <Timer time={lastSeen} />
+              ) : (
+                t("common.state.not_available")
+              )}
+            </ValidatorNodesText>
+          </Row>
+        </ValidatorNodesContentCell>
+
+        <ValidatorNodesContentCell>
+          <Row noGutters>
+            <ValidatorNodesDetailsTitle>
+              <Term
+                title={t(
+                  "component.nodes.ValidatorTelemetryRow.node_agent_name.title"
+                )}
+                text={
+                  <Trans
+                    i18nKey="component.nodes.ValidatorTelemetryRow.node_agent_name.text"
+                    components={{
+                      nearCoreLink: (
+                        <a href="https://github.com/near/nearcore" />
+                      ),
+                    }}
+                  />
+                }
+              />
+            </ValidatorNodesDetailsTitle>
+          </Row>
+          <Row noGutters>
+            <ValidatorNodesText>
+              {agentName ? (
+                <AgentNameBadge variant="secondary">{agentName}</AgentNameBadge>
+              ) : (
+                t("common.state.not_available")
+              )}
+            </ValidatorNodesText>
+          </Row>
+        </ValidatorNodesContentCell>
+
+        <ValidatorNodesContentCell>
+          <Row noGutters>
+            <ValidatorNodesDetailsTitle>
+              {t(
+                "component.nodes.ValidatorTelemetryRow.node_agent_version_or_build.title"
+              )}
+            </ValidatorNodesDetailsTitle>
+          </Row>
+          <Row noGutters>
+            <ValidatorNodesText>
+              {agentVersion || agentBuild ? (
+                <AgentNameBadge variant="secondary">
+                  {`${agentVersion ?? "-"}
                               /
                               ${agentBuild ?? "-"}
                             `}
-              </AgentNameBadge>
-            ) : (
-              t("common.state.not_available")
-            )}
-          </ValidatorNodesText>
-        </Row>
-      </ValidatorNodesContentCell>
-    </ValidatorNodesContentRow>
-  );
-};
+                </AgentNameBadge>
+              ) : (
+                t("common.state.not_available")
+              )}
+            </ValidatorNodesText>
+          </Row>
+        </ValidatorNodesContentCell>
+      </ValidatorNodesContentRow>
+    );
+  }
+);
 
 export default ValidatorTelemetryRow;

--- a/frontend/src/components/nodes/Validators.tsx
+++ b/frontend/src/components/nodes/Validators.tsx
@@ -16,7 +16,7 @@ const ValidatorNodePagination = styled(PaginateWrapper, {
 
 const ITEMS_PER_PAGE = 120;
 
-const Validators: React.FC = () => {
+const Validators: React.FC = React.memo(() => {
   const { t } = useTranslation();
   const [activePage, setActivePage] = React.useState(0);
   const [startPage, setStartPage] = React.useState(1);
@@ -78,6 +78,6 @@ const Validators: React.FC = () => {
       </tbody>
     </Table>
   );
-};
+});
 
 export default Validators;

--- a/frontend/src/components/nodes/ValidatorsList.tsx
+++ b/frontend/src/components/nodes/ValidatorsList.tsx
@@ -16,78 +16,77 @@ interface Props {
   };
 }
 
-const ValidatorsList: React.FC<Props> = ({
-  validators,
-  pages: { startPage, endPage, activePage, itemsPerPage },
-}) => {
-  let validatorsList = validators.sort((a, b) => {
-    // we take "active", "joining", "leaving" validators and sort them firstly
-    // after then we sort the rest
-    const validatingGroup = ["active", "joining", "leaving"];
+const ValidatorsList: React.FC<Props> = React.memo(
+  ({ validators, pages: { startPage, endPage, activePage, itemsPerPage } }) => {
+    let validatorsList = validators.sort((a, b) => {
+      // we take "active", "joining", "leaving" validators and sort them firstly
+      // after then we sort the rest
+      const validatingGroup = ["active", "joining", "leaving"];
 
-    const aInValidatingGroup =
-      a.stakingStatus && validatingGroup.indexOf(a.stakingStatus) >= 0;
-    const bInValidatingGroup =
-      b.stakingStatus && validatingGroup.indexOf(b.stakingStatus) >= 0;
+      const aInValidatingGroup =
+        a.stakingStatus && validatingGroup.indexOf(a.stakingStatus) >= 0;
+      const bInValidatingGroup =
+        b.stakingStatus && validatingGroup.indexOf(b.stakingStatus) >= 0;
 
-    if (aInValidatingGroup && bInValidatingGroup) {
-      return new BN(b.currentStake).cmp(new BN(a.currentStake));
-    } else if (aInValidatingGroup) {
-      return -1;
-    } else if (bInValidatingGroup) {
-      return 1;
-    } else {
-      const aStake = BN.max(
-        new BN(b.proposedStake || 0),
-        new BN(b.currentStake || 0)
-      );
-      const bStake = BN.max(
-        new BN(a.proposedStake || 0),
-        new BN(a.currentStake || 0)
-      );
-      return aStake.cmp(bStake);
-    }
-  });
+      if (aInValidatingGroup && bInValidatingGroup) {
+        return new BN(b.currentStake).cmp(new BN(a.currentStake));
+      } else if (aInValidatingGroup) {
+        return -1;
+      } else if (bInValidatingGroup) {
+        return 1;
+      } else {
+        const aStake = BN.max(
+          new BN(b.proposedStake || 0),
+          new BN(b.currentStake || 0)
+        );
+        const bStake = BN.max(
+          new BN(a.proposedStake || 0),
+          new BN(a.currentStake || 0)
+        );
+        return aStake.cmp(bStake);
+      }
+    });
 
-  // filter validators list by 'active' and 'leaving' validators to calculate cumulative
-  // stake only for those validators
-  const activeValidatorsList = validatorsList.filter(
-    (i) =>
-      i.stakingStatus && ["active", "leaving"].indexOf(i.stakingStatus) >= 0
-  );
+    // filter validators list by 'active' and 'leaving' validators to calculate cumulative
+    // stake only for those validators
+    const activeValidatorsList = validatorsList.filter(
+      (i) =>
+        i.stakingStatus && ["active", "leaving"].indexOf(i.stakingStatus) >= 0
+    );
 
-  const totalStake = activeValidatorsList.reduce(
-    (acc, node) => acc.add(new BN(node.currentStake)),
-    new BN(0)
-  );
+    const totalStake = activeValidatorsList.reduce(
+      (acc, node) => acc.add(new BN(node.currentStake)),
+      new BN(0)
+    );
 
-  activeValidatorsList.forEach((validator, index) => {
-    let total = new BN(0);
-    for (let i = 0; i <= index; i++) {
-      total = total.add(new BN(activeValidatorsList[i].currentStake));
-      epochValidatorsStake.set(validator.account_id, total);
-    }
-  });
+    activeValidatorsList.forEach((validator, index) => {
+      let total = new BN(0);
+      for (let i = 0; i <= index; i++) {
+        total = total.add(new BN(activeValidatorsList[i].currentStake));
+        epochValidatorsStake.set(validator.account_id, total);
+      }
+    });
 
-  validatorsList.forEach((validator, index) => {
-    const validatorCumStake = epochValidatorsStake.get(validator.account_id);
-    if (validatorCumStake) {
-      validatorsList[index].cumulativeStakeAmount = validatorCumStake;
-    }
-  });
+    validatorsList.forEach((validator, index) => {
+      const validatorCumStake = epochValidatorsStake.get(validator.account_id);
+      if (validatorCumStake) {
+        validatorsList[index].cumulativeStakeAmount = validatorCumStake;
+      }
+    });
 
-  return (
-    <>
-      {validatorsList.slice(startPage - 1, endPage).map((node, index) => (
-        <ValidatorRow
-          key={node.account_id}
-          node={node}
-          index={activePage * itemsPerPage + index + 1}
-          totalStake={totalStake}
-        />
-      ))}
-    </>
-  );
-};
+    return (
+      <>
+        {validatorsList.slice(startPage - 1, endPage).map((node, index) => (
+          <ValidatorRow
+            key={node.account_id}
+            node={node}
+            index={activePage * itemsPerPage + index + 1}
+            totalStake={totalStake}
+          />
+        ))}
+      </>
+    );
+  }
+);
 
 export default ValidatorsList;

--- a/frontend/src/components/receipts/ReceiptExecutionStatus.tsx
+++ b/frontend/src/components/receipts/ReceiptExecutionStatus.tsx
@@ -1,15 +1,19 @@
+import * as React from "react";
 import { useTranslation } from "react-i18next";
 import { ReceiptExecutionStatus } from "../../libraries/wamp/types";
 
 export interface Props {
   status: ReceiptExecutionStatus;
 }
-const ReceiptExecutionStatusComponent = ({ status }: Props) => {
-  const { t } = useTranslation();
-  // The "SuccessReceiptId" transaction execution status will be recursively deferred to the status of the receipt id,
-  // but given we only care about the details when we display the whole transaction execution plan,
-  // it is fine to just report the receipt status as "Succeeded"
-  return <>{t(`common.receipts.status.${status}`)}</>;
-};
+
+const ReceiptExecutionStatusComponent: React.FC<Props> = React.memo(
+  ({ status }) => {
+    const { t } = useTranslation();
+    // The "SuccessReceiptId" transaction execution status will be recursively deferred to the status of the receipt id,
+    // but given we only care about the details when we display the whole transaction execution plan,
+    // it is fine to just report the receipt status as "Succeeded"
+    return <>{t(`common.receipts.status.${status}`)}</>;
+  }
+);
 
 export default ReceiptExecutionStatusComponent;

--- a/frontend/src/components/receipts/Receipts.tsx
+++ b/frontend/src/components/receipts/Receipts.tsx
@@ -11,7 +11,7 @@ interface Props {
   receipts: Receipt[];
 }
 
-const Receipts: React.FC<Props> = ({ receipts }) => {
+const Receipts: React.FC<Props> = React.memo(({ receipts }) => {
   const { t } = useTranslation();
   return (
     <>
@@ -37,6 +37,6 @@ const Receipts: React.FC<Props> = ({ receipts }) => {
       ))}
     </>
   );
-};
+});
 
 export default Receipts;

--- a/frontend/src/components/receipts/ReceiptsExecutedInBlock.tsx
+++ b/frontend/src/components/receipts/ReceiptsExecutedInBlock.tsx
@@ -7,12 +7,12 @@ interface Props {
   blockHash: string;
 }
 
-const ReceiptsExecutedInBlock: React.FC<Props> = ({ blockHash }) => {
+const ReceiptsExecutedInBlock: React.FC<Props> = React.memo(({ blockHash }) => {
   const receiptsList = useWampSimpleQuery(
     "executed-receipts-list-by-block-hash",
     [blockHash]
   );
   return <ReceiptsList receiptsList={receiptsList} />;
-};
+});
 
 export default ReceiptsExecutedInBlock;

--- a/frontend/src/components/receipts/ReceiptsIncludedInBlock.tsx
+++ b/frontend/src/components/receipts/ReceiptsIncludedInBlock.tsx
@@ -7,12 +7,12 @@ interface Props {
   blockHash: string;
 }
 
-const ReceiptsIncludedInBlock: React.FC<Props> = ({ blockHash }) => {
+const ReceiptsIncludedInBlock: React.FC<Props> = React.memo(({ blockHash }) => {
   const receiptsList = useWampSimpleQuery(
     "included-receipts-list-by-block-hash",
     [blockHash]
   );
   return <ReceiptsList receiptsList={receiptsList} />;
-};
+});
 
 export default ReceiptsIncludedInBlock;

--- a/frontend/src/components/receipts/ReceiptsList.tsx
+++ b/frontend/src/components/receipts/ReceiptsList.tsx
@@ -11,7 +11,7 @@ interface Props {
   receiptsList?: Receipt[];
 }
 
-const ReceiptsList: React.FC<Props> = ({ receiptsList }) => {
+const ReceiptsList: React.FC<Props> = React.memo(({ receiptsList }) => {
   const { t } = useTranslation();
   return (
     <>
@@ -26,6 +26,6 @@ const ReceiptsList: React.FC<Props> = ({ receiptsList }) => {
       )}
     </>
   );
-};
+});
 
 export default ReceiptsList;

--- a/frontend/src/components/stats/ActiveAccountsByDate.tsx
+++ b/frontend/src/components/stats/ActiveAccountsByDate.tsx
@@ -8,7 +8,7 @@ import { Props } from "./TransactionsByDate";
 import { useTranslation } from "react-i18next";
 import { useWampSimpleQuery } from "../../hooks/wamp";
 
-const ActiveAccountsByDate = ({ chartStyle }: Props) => {
+const ActiveAccountsByDate: React.FC<Props> = React.memo(({ chartStyle }) => {
   const { t } = useTranslation();
   const accountsByWeekCount =
     useWampSimpleQuery("active-accounts-count-aggregated-by-week", []) ?? [];
@@ -144,6 +144,6 @@ const ActiveAccountsByDate = ({ chartStyle }: Props) => {
       </Tab>
     </Tabs>
   );
-};
+});
 
 export default ActiveAccountsByDate;

--- a/frontend/src/components/stats/ActiveAccountsList.tsx
+++ b/frontend/src/components/stats/ActiveAccountsList.tsx
@@ -8,7 +8,7 @@ import { Props } from "./TransactionsByDate";
 import { useTranslation } from "react-i18next";
 import { useWampQuery } from "../../hooks/wamp";
 
-const ActiveAccountsList = ({ chartStyle }: Props) => {
+const ActiveAccountsList: React.FC<Props> = React.memo(({ chartStyle }) => {
   const { t } = useTranslation();
   const accounts =
     useWampQuery(
@@ -61,6 +61,6 @@ const ActiveAccountsList = ({ chartStyle }: Props) => {
   };
 
   return <ReactEcharts option={getOption()} style={chartStyle} />;
-};
+});
 
 export default ActiveAccountsList;

--- a/frontend/src/components/stats/ActiveContractsByDate.tsx
+++ b/frontend/src/components/stats/ActiveContractsByDate.tsx
@@ -7,7 +7,7 @@ import { Props } from "./TransactionsByDate";
 import { useTranslation } from "react-i18next";
 import { useWampSimpleQuery } from "../../hooks/wamp";
 
-const ActiveContractsByDate = ({ chartStyle }: Props) => {
+const ActiveContractsByDate: React.FC<Props> = React.memo(({ chartStyle }) => {
   const { t } = useTranslation();
   const contractsByDate =
     useWampSimpleQuery("active-contracts-count-aggregated-by-date", []) ?? [];
@@ -112,6 +112,6 @@ const ActiveContractsByDate = ({ chartStyle }: Props) => {
       style={chartStyle}
     />
   );
-};
+});
 
 export default ActiveContractsByDate;

--- a/frontend/src/components/stats/ActiveContractsList.tsx
+++ b/frontend/src/components/stats/ActiveContractsList.tsx
@@ -8,7 +8,7 @@ import { Props } from "./TransactionsByDate";
 import { useTranslation } from "react-i18next";
 import { useWampQuery } from "../../hooks/wamp";
 
-const ActiveContractsList = ({ chartStyle }: Props) => {
+const ActiveContractsList: React.FC<Props> = React.memo(({ chartStyle }) => {
   const { t } = useTranslation();
   const activeContracts =
     useWampQuery(
@@ -61,6 +61,6 @@ const ActiveContractsList = ({ chartStyle }: Props) => {
   };
 
   return <ReactEcharts option={getOption()} style={chartStyle} />;
-};
+});
 
 export default ActiveContractsList;

--- a/frontend/src/components/stats/CirculatingSupplyStats.tsx
+++ b/frontend/src/components/stats/CirculatingSupplyStats.tsx
@@ -24,7 +24,7 @@ const SupplySubHeader = styled("div", {
   fontWeight: 500,
 });
 
-const CirculatingSupplyStats = ({ chartStyle }: Props) => {
+const CirculatingSupplyStats: React.FC<Props> = React.memo(({ chartStyle }) => {
   const { t } = useTranslation();
   const circulatingSupply =
     useWampSimpleQuery("circulating-supply-stats", []) ?? [];
@@ -192,6 +192,6 @@ const CirculatingSupplyStats = ({ chartStyle }: Props) => {
       />
     </>
   );
-};
+});
 
 export default CirculatingSupplyStats;

--- a/frontend/src/components/stats/GasUsedByDate.tsx
+++ b/frontend/src/components/stats/GasUsedByDate.tsx
@@ -12,7 +12,7 @@ import { useLatestGasPrice } from "../../hooks/data";
 import { useWampSimpleQuery } from "../../hooks/wamp";
 import { cumulativeSumArray } from "../../libraries/stats";
 
-const GasUsedByDateChart = ({ chartStyle }: Props) => {
+const GasUsedByDateChart: React.FC<Props> = React.memo(({ chartStyle }) => {
   const { t } = useTranslation();
   const latestGasPrice = useLatestGasPrice();
   const gasUsedByDate =
@@ -158,6 +158,6 @@ const GasUsedByDateChart = ({ chartStyle }: Props) => {
       )}
     </Tabs>
   );
-};
+});
 
 export default GasUsedByDateChart;

--- a/frontend/src/components/stats/NewAccountsByDate.tsx
+++ b/frontend/src/components/stats/NewAccountsByDate.tsx
@@ -10,7 +10,7 @@ import { Props } from "./TransactionsByDate";
 import { useTranslation } from "react-i18next";
 import { useWampSimpleQuery } from "../../hooks/wamp";
 
-const NewAccountsByDate = ({ chartStyle }: Props) => {
+const NewAccountsByDate: React.FC<Props> = React.memo(({ chartStyle }) => {
   const { t } = useTranslation();
   const liveAccounts =
     useWampSimpleQuery("live-accounts-count-aggregated-by-date", []) ?? [];
@@ -158,6 +158,6 @@ const NewAccountsByDate = ({ chartStyle }: Props) => {
       </Tab>
     </Tabs>
   );
-};
+});
 
 export default NewAccountsByDate;

--- a/frontend/src/components/stats/NewContractsByDate.tsx
+++ b/frontend/src/components/stats/NewContractsByDate.tsx
@@ -10,7 +10,7 @@ import { Props } from "./TransactionsByDate";
 import { useTranslation } from "react-i18next";
 import { useWampSimpleQuery } from "../../hooks/wamp";
 
-const NewContractsByDate = ({ chartStyle }: Props) => {
+const NewContractsByDate: React.FC<Props> = React.memo(({ chartStyle }) => {
   const { t } = useTranslation();
   const uniqueDeployedContracts =
     useWampSimpleQuery(
@@ -170,6 +170,6 @@ const NewContractsByDate = ({ chartStyle }: Props) => {
       </Tab>
     </Tabs>
   );
-};
+});
 
 export default NewContractsByDate;

--- a/frontend/src/components/stats/PartnerFirst3MonthTransactionsList.tsx
+++ b/frontend/src/components/stats/PartnerFirst3MonthTransactionsList.tsx
@@ -3,7 +3,7 @@ import ReactEcharts from "echarts-for-react";
 
 import { useWampSimpleQuery } from "../../hooks/wamp";
 
-const PartnerFirst3MonthTransactionList = () => {
+const PartnerFirst3MonthTransactionList: React.FC = React.memo(() => {
   const partnerFirst3MonthTransactions =
     useWampSimpleQuery("partner-first-3-month-transactions-count", []) ?? [];
   const partnerFirst3MonthTransactionsAccounts = React.useMemo(
@@ -65,6 +65,6 @@ const PartnerFirst3MonthTransactionList = () => {
       }}
     />
   );
-};
+});
 
 export default PartnerFirst3MonthTransactionList;

--- a/frontend/src/components/stats/PartnerTotalTransactionList.tsx
+++ b/frontend/src/components/stats/PartnerTotalTransactionList.tsx
@@ -3,7 +3,7 @@ import ReactEcharts from "echarts-for-react";
 
 import { useWampSimpleQuery } from "../../hooks/wamp";
 
-const PartnerTotalTransactionList = () => {
+const PartnerTotalTransactionList: React.FC = React.memo(() => {
   const partnerTotalTransactions =
     useWampSimpleQuery("partner-total-transactions-count", []) ?? [];
   const partnerTotalTransactionsAccounts = React.useMemo(
@@ -63,6 +63,6 @@ const PartnerTotalTransactionList = () => {
       }}
     />
   );
-};
+});
 
 export default PartnerTotalTransactionList;

--- a/frontend/src/components/stats/ProtocolConfigInfo.tsx
+++ b/frontend/src/components/stats/ProtocolConfigInfo.tsx
@@ -32,7 +32,7 @@ const BalanceSuffix = styled("span", {
   alignSelf: "flex-end",
 });
 
-const ProtocolConfigInfo = () => {
+const ProtocolConfigInfo: React.FC = React.memo(() => {
   const { t } = useTranslation();
   const networkStats = useNetworkStats();
   const epochStartBlock = useEpochStartBlock();
@@ -174,6 +174,6 @@ const ProtocolConfigInfo = () => {
       </ProtocolConfig>
     </>
   );
-};
+});
 
 export default ProtocolConfigInfo;

--- a/frontend/src/components/stats/TransactionsByDate.tsx
+++ b/frontend/src/components/stats/TransactionsByDate.tsx
@@ -12,133 +12,135 @@ export interface Props {
   chartStyle: object;
 }
 
-const TransactionsByDateChart = ({ chartStyle }: Props) => {
-  const { t } = useTranslation();
-  const transactionCountByDate =
-    useWampSimpleQuery("transactions-count-aggregated-by-date", []) ?? [];
-  const transactionsByDate = React.useMemo(
-    () =>
-      transactionCountByDate.map(({ transactionsCount }) =>
-        Number(transactionsCount)
-      ),
-    [transactionCountByDate]
-  );
-  const transactionsByDateCumulative = React.useMemo(
-    () => cumulativeSumArray(transactionsByDate),
-    [transactionsByDate]
-  );
-  const transactionDates = React.useMemo(
-    () => transactionCountByDate.map(({ date }) => date.slice(0, 10)),
-    [transactionCountByDate]
-  );
+const TransactionsByDateChart: React.FC<Props> = React.memo(
+  ({ chartStyle }) => {
+    const { t } = useTranslation();
+    const transactionCountByDate =
+      useWampSimpleQuery("transactions-count-aggregated-by-date", []) ?? [];
+    const transactionsByDate = React.useMemo(
+      () =>
+        transactionCountByDate.map(({ transactionsCount }) =>
+          Number(transactionsCount)
+        ),
+      [transactionCountByDate]
+    );
+    const transactionsByDateCumulative = React.useMemo(
+      () => cumulativeSumArray(transactionsByDate),
+      [transactionsByDate]
+    );
+    const transactionDates = React.useMemo(
+      () => transactionCountByDate.map(({ date }) => date.slice(0, 10)),
+      [transactionCountByDate]
+    );
 
-  const getOption = (
-    title: string,
-    seriesName: string,
-    data: Array<number>
-  ) => {
-    return {
-      title: {
-        text: title,
-      },
-      tooltip: {
-        trigger: "axis",
-      },
-      grid: {
-        left: "3%",
-        right: "4%",
-        bottom: "3%",
-        containLabel: true,
-        backgroundColor: "#F9F9F9",
-        show: true,
-        color: "white",
-      },
-      xAxis: [
-        {
-          type: "category",
-          boundaryGap: false,
-          data: transactionDates,
+    const getOption = (
+      title: string,
+      seriesName: string,
+      data: Array<number>
+    ) => {
+      return {
+        title: {
+          text: title,
         },
-      ],
-      yAxis: [
-        {
-          type: "value",
-          splitLine: {
-            lineStyle: {
-              color: "white",
+        tooltip: {
+          trigger: "axis",
+        },
+        grid: {
+          left: "3%",
+          right: "4%",
+          bottom: "3%",
+          containLabel: true,
+          backgroundColor: "#F9F9F9",
+          show: true,
+          color: "white",
+        },
+        xAxis: [
+          {
+            type: "category",
+            boundaryGap: false,
+            data: transactionDates,
+          },
+        ],
+        yAxis: [
+          {
+            type: "value",
+            splitLine: {
+              lineStyle: {
+                color: "white",
+              },
             },
           },
-        },
-      ],
-      dataZoom: [
-        {
-          type: "inside",
-          start: 0,
-          end: 100,
-          filterMode: "filter",
-        },
-        {
-          start: 0,
-          end: 100,
-        },
-      ],
-      series: [
-        {
-          name: seriesName,
-          type: "line",
-          lineStyle: {
-            color: "#00C1DE",
-            width: 2,
+        ],
+        dataZoom: [
+          {
+            type: "inside",
+            start: 0,
+            end: 100,
+            filterMode: "filter",
           },
-          symbol: "circle",
-          itemStyle: {
-            color: "#25272A",
+          {
+            start: 0,
+            end: 100,
           },
-          areaStyle: {
-            color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
-              {
-                offset: 0,
-                color: "rgb(0, 193, 222)",
-              },
-              {
-                offset: 1,
-                color: "rgb(197, 247, 255)",
-              },
-            ]),
+        ],
+        series: [
+          {
+            name: seriesName,
+            type: "line",
+            lineStyle: {
+              color: "#00C1DE",
+              width: 2,
+            },
+            symbol: "circle",
+            itemStyle: {
+              color: "#25272A",
+            },
+            areaStyle: {
+              color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
+                {
+                  offset: 0,
+                  color: "rgb(0, 193, 222)",
+                },
+                {
+                  offset: 1,
+                  color: "rgb(197, 247, 255)",
+                },
+              ]),
+            },
+            data: data,
           },
-          data: data,
-        },
-      ],
+        ],
+      };
     };
-  };
-  return (
-    <Tabs defaultActiveKey="daily" id="transactionByDate">
-      <Tab eventKey="daily" title={t("common.stats.daily")}>
-        <ReactEcharts
-          option={getOption(
-            t(
-              "component.stats.TransactionsByDate.daily_number_of_transactions"
-            ),
-            t("component.stats.TransactionsByDate.transactions"),
-            transactionsByDate
-          )}
-          style={chartStyle}
-        />
-      </Tab>
-      <Tab eventKey="total" title={t("common.stats.total")}>
-        <ReactEcharts
-          option={getOption(
-            t(
-              "component.stats.TransactionsByDate.total_number_of_transactions"
-            ),
-            t("component.stats.TransactionsByDate.transactions"),
-            transactionsByDateCumulative
-          )}
-          style={chartStyle}
-        />
-      </Tab>
-    </Tabs>
-  );
-};
+    return (
+      <Tabs defaultActiveKey="daily" id="transactionByDate">
+        <Tab eventKey="daily" title={t("common.stats.daily")}>
+          <ReactEcharts
+            option={getOption(
+              t(
+                "component.stats.TransactionsByDate.daily_number_of_transactions"
+              ),
+              t("component.stats.TransactionsByDate.transactions"),
+              transactionsByDate
+            )}
+            style={chartStyle}
+          />
+        </Tab>
+        <Tab eventKey="total" title={t("common.stats.total")}>
+          <ReactEcharts
+            option={getOption(
+              t(
+                "component.stats.TransactionsByDate.total_number_of_transactions"
+              ),
+              t("component.stats.TransactionsByDate.transactions"),
+              transactionsByDateCumulative
+            )}
+            style={chartStyle}
+          />
+        </Tab>
+      </Tabs>
+    );
+  }
+);
 
 export default TransactionsByDateChart;

--- a/frontend/src/components/transactions/ActionGroup.tsx
+++ b/frontend/src/components/transactions/ActionGroup.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import BN from "bn.js";
 
 import BatchTransactionIcon from "../../../public/static/images/icon-m-batch.svg";
@@ -14,65 +15,60 @@ interface Props {
   status?: React.ReactNode;
   viewMode?: ViewMode;
   title: string;
-  icon?: React.ReactElement;
+  icon?: React.ReactNode;
 }
 
-const ActionGroup = ({
-  actionGroup,
-  detailsLink,
-  status,
-  viewMode,
-  title,
-  icon,
-}: Props) => {
-  const finalBlockTimestampNanosecond = useFinalBlockTimestampNanosecond();
+const ActionGroup: React.FC<Props> = React.memo(
+  ({ actionGroup, detailsLink, status, viewMode, title, icon }) => {
+    const finalBlockTimestampNanosecond = useFinalBlockTimestampNanosecond();
 
-  if (!actionGroup?.actions) return null;
+    if (!actionGroup?.actions) return null;
 
-  const isFinal = finalBlockTimestampNanosecond
-    ? new BN(actionGroup.blockTimestamp).lte(
-        finalBlockTimestampNanosecond.divn(10 ** 6)
-      )
-    : undefined;
+    const isFinal = finalBlockTimestampNanosecond
+      ? new BN(actionGroup.blockTimestamp).lte(
+          finalBlockTimestampNanosecond.divn(10 ** 6)
+        )
+      : undefined;
 
-  return (
-    <>
-      {actionGroup.actions.length !== 1 ? (
-        <ActionRowBlock
-          viewMode={viewMode}
-          signerId={actionGroup.signerId}
-          blockTimestamp={actionGroup.blockTimestamp}
-          detailsLink={detailsLink}
-          icon={icon ?? <BatchTransactionIcon />}
-          title={title}
-          status={status}
-          isFinal={isFinal}
-        >
-          <ActionsList
-            actions={actionGroup.actions}
-            blockTimestamp={actionGroup.blockTimestamp}
+    return (
+      <>
+        {actionGroup.actions.length !== 1 ? (
+          <ActionRowBlock
+            viewMode={viewMode}
             signerId={actionGroup.signerId}
+            blockTimestamp={actionGroup.blockTimestamp}
+            detailsLink={detailsLink}
+            icon={icon ?? <BatchTransactionIcon />}
+            title={title}
+            status={status}
+            isFinal={isFinal}
+          >
+            <ActionsList
+              actions={actionGroup.actions}
+              blockTimestamp={actionGroup.blockTimestamp}
+              signerId={actionGroup.signerId}
+              receiverId={actionGroup.receiverId}
+              detailsLink={detailsLink}
+              viewMode={viewMode}
+              detalizationMode="minimal"
+            />
+          </ActionRowBlock>
+        ) : (
+          <ActionRow
+            action={actionGroup.actions[0]}
+            signerId={actionGroup.signerId}
+            blockTimestamp={actionGroup.blockTimestamp}
             receiverId={actionGroup.receiverId}
             detailsLink={detailsLink}
             viewMode={viewMode}
-            detalizationMode="minimal"
+            detalizationMode="detailed"
+            status={status}
+            isFinal={isFinal}
           />
-        </ActionRowBlock>
-      ) : (
-        <ActionRow
-          action={actionGroup.actions[0]}
-          signerId={actionGroup.signerId}
-          blockTimestamp={actionGroup.blockTimestamp}
-          receiverId={actionGroup.receiverId}
-          detailsLink={detailsLink}
-          viewMode={viewMode}
-          detalizationMode="detailed"
-          status={status}
-          isFinal={isFinal}
-        />
-      )}
-    </>
-  );
-};
+        )}
+      </>
+    );
+  }
+);
 
 export default ActionGroup;

--- a/frontend/src/components/transactions/ActionMessage.tsx
+++ b/frontend/src/components/transactions/ActionMessage.tsx
@@ -1,20 +1,12 @@
+import * as React from "react";
 import { hexy } from "hexy";
 
 import AccountLink from "../utils/AccountLink";
 import Balance from "../utils/Balance";
 import CodePreview from "../utils/CodePreview";
 
-import { TFunction, useTranslation } from "react-i18next";
-import {
-  AddKey,
-  CreateAccount,
-  DeleteAccount,
-  DeleteKey,
-  DeployContract,
-  FunctionCall,
-  Stake,
-  Transfer,
-} from "../../libraries/wamp/types";
+import { useTranslation } from "react-i18next";
+import * as wamp from "../../libraries/wamp/types";
 
 export interface Props<A> {
   actionKind: keyof TransactionMessageRenderers;
@@ -24,27 +16,28 @@ export interface Props<A> {
 }
 
 type AnyAction =
-  | CreateAccount
-  | DeleteAccount
-  | DeployContract
-  | FunctionCall
-  | Transfer
-  | Stake
-  | AddKey
-  | DeleteKey;
+  | wamp.CreateAccount
+  | wamp.DeleteAccount
+  | wamp.DeployContract
+  | wamp.FunctionCall
+  | wamp.Transfer
+  | wamp.Stake
+  | wamp.AddKey
+  | wamp.DeleteKey;
 
 interface TransactionMessageRenderers {
-  CreateAccount: React.FC<Props<CreateAccount>>;
-  DeleteAccount: React.FC<Props<DeleteAccount>>;
-  DeployContract: React.FC<Props<DeployContract>>;
-  FunctionCall: React.FC<Props<FunctionCall>>;
-  Transfer: React.FC<Props<Transfer>>;
-  Stake: React.FC<Props<Stake>>;
-  AddKey: React.FC<Props<AddKey>>;
-  DeleteKey: React.FC<Props<DeleteKey>>;
+  CreateAccount: React.FC<Props<wamp.CreateAccount>>;
+  DeleteAccount: React.FC<Props<wamp.DeleteAccount>>;
+  DeployContract: React.FC<Props<wamp.DeployContract>>;
+  FunctionCall: React.FC<Props<wamp.FunctionCall>>;
+  Transfer: React.FC<Props<wamp.Transfer>>;
+  Stake: React.FC<Props<wamp.Stake>>;
+  AddKey: React.FC<Props<wamp.AddKey>>;
+  DeleteKey: React.FC<Props<wamp.DeleteKey>>;
 }
 
-export const displayArgs = (args: string, t: TFunction<"common">) => {
+export const Args: React.FC<{ args: string }> = React.memo(({ args }) => {
+  const { t } = useTranslation();
   const decodedArgs = Buffer.from(args, "base64");
   let prettyArgs: string;
   try {
@@ -64,10 +57,10 @@ export const displayArgs = (args: string, t: TFunction<"common">) => {
       value={prettyArgs}
     />
   );
-};
+});
 
-const transactionMessageRenderers: TransactionMessageRenderers = {
-  CreateAccount: ({ receiverId }: Props<CreateAccount>) => {
+const CreateAccount: React.FC<Props<wamp.CreateAccount>> = React.memo(
+  ({ receiverId }) => {
     const { t } = useTranslation();
     return (
       <>
@@ -77,8 +70,11 @@ const transactionMessageRenderers: TransactionMessageRenderers = {
         <AccountLink accountId={receiverId} />
       </>
     );
-  },
-  DeleteAccount: ({ receiverId, actionArgs }: Props<DeleteAccount>) => {
+  }
+);
+
+const DeleteAccount: React.FC<Props<wamp.DeleteAccount>> = React.memo(
+  ({ receiverId, actionArgs }) => {
     const { t } = useTranslation();
     return (
       <>
@@ -90,8 +86,11 @@ const transactionMessageRenderers: TransactionMessageRenderers = {
         <AccountLink accountId={actionArgs.beneficiary_id} />
       </>
     );
-  },
-  DeployContract: ({ receiverId }: Props<DeployContract>) => {
+  }
+);
+
+const DeployContract: React.FC<Props<wamp.DeployContract>> = React.memo(
+  ({ receiverId }) => {
     const { t } = useTranslation();
     return (
       <>
@@ -101,12 +100,11 @@ const transactionMessageRenderers: TransactionMessageRenderers = {
         <AccountLink accountId={receiverId} />
       </>
     );
-  },
-  FunctionCall: ({
-    receiverId,
-    actionArgs,
-    showDetails,
-  }: Props<FunctionCall>) => {
+  }
+);
+
+const FunctionCall: React.FC<Props<wamp.FunctionCall>> = React.memo(
+  ({ receiverId, actionArgs, showDetails }) => {
     const { t } = useTranslation();
     let args;
     if (showDetails) {
@@ -118,7 +116,7 @@ const transactionMessageRenderers: TransactionMessageRenderers = {
       ) {
         args = <p>The arguments are empty</p>;
       } else {
-        args = displayArgs(actionArgs.args, t);
+        args = <Args args={actionArgs.args} />;
       }
     }
     return (
@@ -140,8 +138,11 @@ const transactionMessageRenderers: TransactionMessageRenderers = {
         ) : null}
       </>
     );
-  },
-  Transfer: ({ receiverId, actionArgs: { deposit } }: Props<Transfer>) => {
+  }
+);
+
+const Transfer: React.FC<Props<wamp.Transfer>> = React.memo(
+  ({ receiverId, actionArgs: { deposit } }) => {
     const { t } = useTranslation();
     return (
       <>
@@ -151,8 +152,11 @@ const transactionMessageRenderers: TransactionMessageRenderers = {
         <AccountLink accountId={receiverId} />
       </>
     );
-  },
-  Stake: ({ actionArgs: { stake, public_key } }: Props<Stake>) => {
+  }
+);
+
+const Stake: React.FC<Props<wamp.Stake>> = React.memo(
+  ({ actionArgs: { stake, public_key } }) => {
     const { t } = useTranslation();
     return (
       <>
@@ -163,8 +167,11 @@ const transactionMessageRenderers: TransactionMessageRenderers = {
         })}
       </>
     );
-  },
-  AddKey: ({ receiverId, actionArgs }: Props<AddKey>) => {
+  }
+);
+
+const AddKey: React.FC<Props<wamp.AddKey>> = React.memo(
+  ({ receiverId, actionArgs }) => {
     const { t } = useTranslation();
     return (
       <>
@@ -231,8 +238,11 @@ const transactionMessageRenderers: TransactionMessageRenderers = {
         )}
       </>
     );
-  },
-  DeleteKey: ({ actionArgs: { public_key } }: Props<DeleteKey>) => {
+  }
+);
+
+const DeleteKey: React.FC<Props<wamp.DeleteKey>> = React.memo(
+  ({ actionArgs: { public_key } }) => {
     const { t } = useTranslation();
     return (
       <>
@@ -241,10 +251,21 @@ const transactionMessageRenderers: TransactionMessageRenderers = {
         })}
       </>
     );
-  },
+  }
+);
+
+const transactionMessageRenderers: TransactionMessageRenderers = {
+  CreateAccount,
+  DeleteAccount,
+  DeployContract,
+  FunctionCall,
+  Transfer,
+  Stake,
+  AddKey,
+  DeleteKey,
 };
 
-const ActionMessage = (props: Props<AnyAction>) => {
+const ActionMessage: React.FC<Props<AnyAction>> = React.memo((props) => {
   const MessageRenderer = transactionMessageRenderers[props.actionKind];
   if (MessageRenderer === undefined) {
     return (
@@ -256,6 +277,6 @@ const ActionMessage = (props: Props<AnyAction>) => {
   return (
     <MessageRenderer {...(props as any)} showDetails={props.showDetails} />
   );
-};
+});
 
 export default ActionMessage;

--- a/frontend/src/components/transactions/ActionRow.tsx
+++ b/frontend/src/components/transactions/ActionRow.tsx
@@ -18,39 +18,41 @@ export interface Props {
   viewMode?: ViewMode;
 }
 
-const ActionRow: React.FC<Props> = ({
-  viewMode = "sparse",
-  detalizationMode = "detailed",
-  signerId,
-  receiverId,
-  blockTimestamp,
-  detailsLink,
-  action,
-  showDetails,
-  status,
-  isFinal,
-}) => {
-  const ActionIcon = actionIcons[action.kind];
-  return (
-    <ActionRowBlock
-      viewMode={viewMode}
-      detalizationMode={detalizationMode}
-      signerId={signerId}
-      blockTimestamp={blockTimestamp}
-      detailsLink={detailsLink}
-      icon={ActionIcon && <ActionIcon />}
-      title={
-        <ActionMessage
-          receiverId={receiverId}
-          actionKind={action.kind}
-          actionArgs={action.args}
-          showDetails={showDetails}
-        />
-      }
-      status={status}
-      isFinal={isFinal}
-    />
-  );
-};
+const ActionRow: React.FC<Props> = React.memo(
+  ({
+    viewMode = "sparse",
+    detalizationMode = "detailed",
+    signerId,
+    receiverId,
+    blockTimestamp,
+    detailsLink,
+    action,
+    showDetails,
+    status,
+    isFinal,
+  }) => {
+    const ActionIcon = actionIcons[action.kind];
+    return (
+      <ActionRowBlock
+        viewMode={viewMode}
+        detalizationMode={detalizationMode}
+        signerId={signerId}
+        blockTimestamp={blockTimestamp}
+        detailsLink={detailsLink}
+        icon={ActionIcon && <ActionIcon />}
+        title={
+          <ActionMessage
+            receiverId={receiverId}
+            actionKind={action.kind}
+            actionArgs={action.args}
+            showDetails={showDetails}
+          />
+        }
+        status={status}
+        isFinal={isFinal}
+      />
+    );
+  }
+);
 
 export default ActionRow;

--- a/frontend/src/components/transactions/ActionRowBlock.tsx
+++ b/frontend/src/components/transactions/ActionRowBlock.tsx
@@ -137,75 +137,77 @@ export interface Props {
   detailsLink?: React.ReactNode;
   viewMode?: ViewMode;
   detalizationMode?: DetalizationMode;
-  icon: React.ReactElement;
-  title: React.ReactElement | string;
+  icon: React.ReactNode;
+  title: React.ReactNode | string;
   children?: React.ReactNode;
   status?: React.ReactNode;
   isFinal?: boolean;
 }
 
-const ActionRowBlock: React.FC<Props> = ({
-  viewMode = "sparse",
-  detalizationMode = "detailed",
-  signerId,
-  blockTimestamp,
-  detailsLink,
-  icon,
-  title,
-  status,
-  isFinal,
-  children,
-}) => {
-  const { t } = useTranslation();
-  return (
-    <>
-      <ActionRow noGutters type={viewMode} className="mx-0">
-        <Col xs="auto">
-          <ActionRowImage type={viewMode}>{icon}</ActionRowImage>
-        </Col>
-        <ActionRowDetails type={viewMode}>
-          <ActionRowMessage type={viewMode} noGutters>
-            <Col md="8" xs="7">
-              <Row noGutters>
-                <ActionRowTitle>{title}</ActionRowTitle>
-              </Row>
-              {detalizationMode === "detailed" ? (
+const ActionRowBlock: React.FC<Props> = React.memo(
+  ({
+    viewMode = "sparse",
+    detalizationMode = "detailed",
+    signerId,
+    blockTimestamp,
+    detailsLink,
+    icon,
+    title,
+    status,
+    isFinal,
+    children,
+  }) => {
+    const { t } = useTranslation();
+    return (
+      <>
+        <ActionRow noGutters type={viewMode} className="mx-0">
+          <Col xs="auto">
+            <ActionRowImage type={viewMode}>{icon}</ActionRowImage>
+          </Col>
+          <ActionRowDetails type={viewMode}>
+            <ActionRowMessage type={viewMode} noGutters>
+              <Col md="8" xs="7">
                 <Row noGutters>
-                  <ActionRowText>
-                    {t("component.transactions.ActionRowBlock.by")}{" "}
-                    <AccountLink accountId={signerId} />
-                  </ActionRowText>
+                  <ActionRowTitle>{title}</ActionRowTitle>
                 </Row>
-              ) : null}
-            </Col>
-            {detalizationMode === "detailed" ? (
-              <Col md="4" xs="5" className="ml-auto text-right">
-                <Row>
-                  <ActionRowTransaction>{detailsLink}</ActionRowTransaction>
-                </Row>
-                <Row>
-                  <ActionRowTimer>
-                    <ActionRowTimerStatus>
-                      {status ?? (
-                        <>{t("common.blocks.status.fetching_status")}</>
-                      )}
-                      {isFinal === undefined
-                        ? "/" + t("common.blocks.status.checking_finality")
-                        : isFinal === true
-                        ? ""
-                        : "/" + t("common.blocks.status.finalizing")}
-                    </ActionRowTimerStatus>{" "}
-                    {blockTimestamp && <Timer time={blockTimestamp} />}
-                  </ActionRowTimer>
-                </Row>
+                {detalizationMode === "detailed" ? (
+                  <Row noGutters>
+                    <ActionRowText>
+                      {t("component.transactions.ActionRowBlock.by")}{" "}
+                      <AccountLink accountId={signerId} />
+                    </ActionRowText>
+                  </Row>
+                ) : null}
               </Col>
-            ) : null}
-          </ActionRowMessage>
-          {children}
-        </ActionRowDetails>
-      </ActionRow>
-    </>
-  );
-};
+              {detalizationMode === "detailed" ? (
+                <Col md="4" xs="5" className="ml-auto text-right">
+                  <Row>
+                    <ActionRowTransaction>{detailsLink}</ActionRowTransaction>
+                  </Row>
+                  <Row>
+                    <ActionRowTimer>
+                      <ActionRowTimerStatus>
+                        {status ?? (
+                          <>{t("common.blocks.status.fetching_status")}</>
+                        )}
+                        {isFinal === undefined
+                          ? "/" + t("common.blocks.status.checking_finality")
+                          : isFinal === true
+                          ? ""
+                          : "/" + t("common.blocks.status.finalizing")}
+                      </ActionRowTimerStatus>{" "}
+                      {blockTimestamp && <Timer time={blockTimestamp} />}
+                    </ActionRowTimer>
+                  </Row>
+                </Col>
+              ) : null}
+            </ActionRowMessage>
+            {children}
+          </ActionRowDetails>
+        </ActionRow>
+      </>
+    );
+  }
+);
 
 export default ActionRowBlock;

--- a/frontend/src/components/transactions/ActionsList.tsx
+++ b/frontend/src/components/transactions/ActionsList.tsx
@@ -15,33 +15,35 @@ export interface Props {
   viewMode?: ViewMode;
 }
 
-const ActionList: React.FC<Props> = ({
-  actions,
-  blockTimestamp,
-  signerId,
-  receiverId,
-  detailsLink,
-  viewMode,
-  detalizationMode,
-  showDetails,
-}) => {
-  return (
-    <>
-      {actions.map((action, actionIndex) => (
-        <ActionRow
-          key={signerId + actionIndex}
-          action={action}
-          signerId={signerId}
-          receiverId={receiverId}
-          blockTimestamp={blockTimestamp}
-          detailsLink={detailsLink}
-          viewMode={viewMode}
-          detalizationMode={detalizationMode}
-          showDetails={showDetails}
-        />
-      ))}
-    </>
-  );
-};
+const ActionList: React.FC<Props> = React.memo(
+  ({
+    actions,
+    blockTimestamp,
+    signerId,
+    receiverId,
+    detailsLink,
+    viewMode,
+    detalizationMode,
+    showDetails,
+  }) => {
+    return (
+      <>
+        {actions.map((action, actionIndex) => (
+          <ActionRow
+            key={signerId + actionIndex}
+            action={action}
+            signerId={signerId}
+            receiverId={receiverId}
+            blockTimestamp={blockTimestamp}
+            detailsLink={detailsLink}
+            viewMode={viewMode}
+            detalizationMode={detalizationMode}
+            showDetails={showDetails}
+          />
+        ))}
+      </>
+    );
+  }
+);
 
 export default ActionList;

--- a/frontend/src/components/transactions/ReceiptRow.tsx
+++ b/frontend/src/components/transactions/ReceiptRow.tsx
@@ -9,7 +9,7 @@ import Balance from "../utils/Balance";
 import AccountLink from "../utils/AccountLink";
 import BlockLink from "../utils/BlockLink";
 import ReceiptLink from "../utils/ReceiptLink";
-import { displayArgs } from "./ActionMessage";
+import { Args } from "./ActionMessage";
 import ActionRow from "./ActionRow";
 
 import { useTranslation } from "react-i18next";
@@ -84,166 +84,173 @@ export interface Props {
   transactionHash: string;
 }
 
-const ReceiptRow: React.FC<Props> = ({ receipt, transactionHash }) => {
-  const { t } = useTranslation();
-  let statusInfo;
-  if ("SuccessValue" in (receipt.outcome.status as RpcReceiptSuccessValue)) {
-    const { SuccessValue } = receipt.outcome.status as RpcReceiptSuccessValue;
-    if (SuccessValue === null) {
-      statusInfo = t("component.transactions.ReceiptRow.no_result");
-    } else if (SuccessValue.length === 0) {
-      statusInfo = t("component.transactions.ReceiptRow.empty_result");
-    } else {
+const ReceiptRow: React.FC<Props> = React.memo(
+  ({ receipt, transactionHash }) => {
+    const { t } = useTranslation();
+    let statusInfo;
+    if ("SuccessValue" in (receipt.outcome.status as RpcReceiptSuccessValue)) {
+      const { SuccessValue } = receipt.outcome.status as RpcReceiptSuccessValue;
+      if (SuccessValue === null) {
+        statusInfo = t("component.transactions.ReceiptRow.no_result");
+      } else if (SuccessValue.length === 0) {
+        statusInfo = t("component.transactions.ReceiptRow.empty_result");
+      } else {
+        statusInfo = (
+          <>
+            <i>{t("component.transactions.ReceiptRow.result")}: </i>
+            <Args args={SuccessValue} />
+          </>
+        );
+      }
+    } else if ("Failure" in (receipt.outcome.status as RpcReceiptFailure)) {
+      const { Failure } = receipt.outcome.status as RpcReceiptFailure;
       statusInfo = (
         <>
-          <i>{t("component.transactions.ReceiptRow.result")}: </i>
-          {displayArgs(SuccessValue, t)}
+          <i>{t("component.transactions.ReceiptRow.failure")}: </i>
+          <pre>{JSON.stringify(Failure, null, 2)}</pre>
+        </>
+      );
+    } else if (
+      "SuccessReceiptId" in (receipt.outcome.status as RpcReceiptSuccessId)
+    ) {
+      const { SuccessReceiptId } = receipt.outcome
+        .status as RpcReceiptSuccessId;
+      statusInfo = (
+        <>
+          <i>{t("component.transactions.ReceiptRow.success_receipt_id")}: </i>
+          <pre>{SuccessReceiptId}</pre>
         </>
       );
     }
-  } else if ("Failure" in (receipt.outcome.status as RpcReceiptFailure)) {
-    const { Failure } = receipt.outcome.status as RpcReceiptFailure;
-    statusInfo = (
-      <>
-        <i>{t("component.transactions.ReceiptRow.failure")}: </i>
-        <pre>{JSON.stringify(Failure, null, 2)}</pre>
-      </>
-    );
-  } else if (
-    "SuccessReceiptId" in (receipt.outcome.status as RpcReceiptSuccessId)
-  ) {
-    const { SuccessReceiptId } = receipt.outcome.status as RpcReceiptSuccessId;
-    statusInfo = (
-      <>
-        <i>{t("component.transactions.ReceiptRow.success_receipt_id")}: </i>
-        <pre>{SuccessReceiptId}</pre>
-      </>
-    );
-  }
 
-  let gasBurnedByReceipt = new BN(0);
-  let tokensBurnedByReceipt = new BN(0);
-  if (receipt && receipt.outcome) {
-    gasBurnedByReceipt = new BN(receipt.outcome.gas_burnt);
-    tokensBurnedByReceipt = new BN(receipt.outcome.tokens_burnt);
-  }
-  return (
-    <ReceiptRowWrapper
-      noGutters
-      key={receipt.receipt_id}
-      id={receipt.receipt_id}
-    >
-      <Col>
-        <Row noGutters>
-          <ReceiptRowHashTitle>
-            <b>{t("common.receipts.receipt")}:</b>
-          </ReceiptRowHashTitle>
-        </Row>
+    let gasBurnedByReceipt = new BN(0);
+    let tokensBurnedByReceipt = new BN(0);
+    if (receipt && receipt.outcome) {
+      gasBurnedByReceipt = new BN(receipt.outcome.gas_burnt);
+      tokensBurnedByReceipt = new BN(receipt.outcome.tokens_burnt);
+    }
+    return (
+      <ReceiptRowWrapper
+        noGutters
+        key={receipt.receipt_id}
+        id={receipt.receipt_id}
+      >
+        <Col>
+          <Row noGutters>
+            <ReceiptRowHashTitle>
+              <b>{t("common.receipts.receipt")}:</b>
+            </ReceiptRowHashTitle>
+          </Row>
 
-        <ReceiptRowSection noGutters>
-          <ReceiptRowTitle>{t("common.receipts.receipt_id")}:</ReceiptRowTitle>
-          <ReceiptRowReceiptHash truncateLink>
-            <ReceiptLink
-              transactionHash={transactionHash}
-              receiptId={receipt.receipt_id}
-              truncate={false}
-            />
-          </ReceiptRowReceiptHash>
-        </ReceiptRowSection>
+          <ReceiptRowSection noGutters>
+            <ReceiptRowTitle>
+              {t("common.receipts.receipt_id")}:
+            </ReceiptRowTitle>
+            <ReceiptRowReceiptHash truncateLink>
+              <ReceiptLink
+                transactionHash={transactionHash}
+                receiptId={receipt.receipt_id}
+                truncate={false}
+              />
+            </ReceiptRowReceiptHash>
+          </ReceiptRowSection>
 
-        <ReceiptRowSection noGutters>
-          <ReceiptRowTitle>
-            {t("common.receipts.executed_in_block")}:
-          </ReceiptRowTitle>
-          <ReceiptRowReceiptHash truncateLink>
-            <BlockLink blockHash={receipt.block_hash} truncate={false} />
-          </ReceiptRowReceiptHash>
-        </ReceiptRowSection>
+          <ReceiptRowSection noGutters>
+            <ReceiptRowTitle>
+              {t("common.receipts.executed_in_block")}:
+            </ReceiptRowTitle>
+            <ReceiptRowReceiptHash truncateLink>
+              <BlockLink blockHash={receipt.block_hash} truncate={false} />
+            </ReceiptRowReceiptHash>
+          </ReceiptRowSection>
 
-        <ReceiptRowSection noGutters>
-          <ReceiptRowTitle>
-            {t("common.receipts.predecessor_id")}:
-          </ReceiptRowTitle>
-          <ReceiptRowReceiptHash title={receipt.predecessor_id}>
-            <AccountLink accountId={receipt.predecessor_id} />
-          </ReceiptRowReceiptHash>
-        </ReceiptRowSection>
+          <ReceiptRowSection noGutters>
+            <ReceiptRowTitle>
+              {t("common.receipts.predecessor_id")}:
+            </ReceiptRowTitle>
+            <ReceiptRowReceiptHash title={receipt.predecessor_id}>
+              <AccountLink accountId={receipt.predecessor_id} />
+            </ReceiptRowReceiptHash>
+          </ReceiptRowSection>
 
-        <ReceiptRowSection noGutters>
-          <ReceiptRowTitle>{t("common.receipts.receiver_id")}:</ReceiptRowTitle>
-          <ReceiptRowReceiptHash title={receipt.receiver_id}>
-            <AccountLink accountId={receipt.receiver_id} />
-          </ReceiptRowReceiptHash>
-        </ReceiptRowSection>
+          <ReceiptRowSection noGutters>
+            <ReceiptRowTitle>
+              {t("common.receipts.receiver_id")}:
+            </ReceiptRowTitle>
+            <ReceiptRowReceiptHash title={receipt.receiver_id}>
+              <AccountLink accountId={receipt.receiver_id} />
+            </ReceiptRowReceiptHash>
+          </ReceiptRowSection>
 
-        <ReceiptRowSection noGutters>
-          <ReceiptRowTitle>
-            {t("common.transactions.execution.gas_burned")}:
-          </ReceiptRowTitle>
-          <ReceiptRowReceiptHash>
-            {gasBurnedByReceipt ? <Gas gas={gasBurnedByReceipt} /> : "..."}
-          </ReceiptRowReceiptHash>
-        </ReceiptRowSection>
+          <ReceiptRowSection noGutters>
+            <ReceiptRowTitle>
+              {t("common.transactions.execution.gas_burned")}:
+            </ReceiptRowTitle>
+            <ReceiptRowReceiptHash>
+              {gasBurnedByReceipt ? <Gas gas={gasBurnedByReceipt} /> : "..."}
+            </ReceiptRowReceiptHash>
+          </ReceiptRowSection>
 
-        <ReceiptRowSection noGutters>
-          <ReceiptRowTitle>
-            {t("common.transactions.execution.tokens_burned")}:
-          </ReceiptRowTitle>
-          <ReceiptRowReceiptHash>
-            {tokensBurnedByReceipt ? (
-              <Balance amount={tokensBurnedByReceipt.toString()} />
-            ) : (
-              "..."
-            )}
-          </ReceiptRowReceiptHash>
-        </ReceiptRowSection>
+          <ReceiptRowSection noGutters>
+            <ReceiptRowTitle>
+              {t("common.transactions.execution.tokens_burned")}:
+            </ReceiptRowTitle>
+            <ReceiptRowReceiptHash>
+              {tokensBurnedByReceipt ? (
+                <Balance amount={tokensBurnedByReceipt.toString()} />
+              ) : (
+                "..."
+              )}
+            </ReceiptRowReceiptHash>
+          </ReceiptRowSection>
 
-        <ReceiptRowSection noGutters>
-          <ReceiptRowText>
-            {receipt.actions && receipt.actions.length > 0
-              ? receipt.actions.map((action, index) => (
-                  <ActionRow
-                    key={receipt.receipt_id + index}
-                    action={action}
-                    receiverId={receipt.receiver_id}
-                    signerId={receipt.predecessor_id}
-                    detalizationMode="minimal"
-                    showDetails
+          <ReceiptRowSection noGutters>
+            <ReceiptRowText>
+              {receipt.actions && receipt.actions.length > 0
+                ? receipt.actions.map((action, index) => (
+                    <ActionRow
+                      key={receipt.receipt_id + index}
+                      action={action}
+                      receiverId={receipt.receiver_id}
+                      signerId={receipt.predecessor_id}
+                      detalizationMode="minimal"
+                      showDetails
+                    />
+                  ))
+                : t("component.transactions.ReceiptRow.no_actions")}
+            </ReceiptRowText>
+          </ReceiptRowSection>
+
+          <ReceiptRowSection noGutters>
+            <ReceiptRowStatus>{statusInfo}</ReceiptRowStatus>
+          </ReceiptRowSection>
+
+          <ReceiptRowSection noGutters>
+            <ReceiptRowText>
+              {receipt.outcome.logs.length === 0 ? (
+                t("component.transactions.ReceiptRow.no_logs")
+              ) : (
+                <pre>{receipt.outcome.logs.join("\n")}</pre>
+              )}
+            </ReceiptRowText>
+          </ReceiptRowSection>
+
+          {receipt.outcome.outgoing_receipts &&
+            receipt.outcome.outgoing_receipts.length > 0 &&
+            receipt.outcome.outgoing_receipts.map((executedReceipt) => (
+              <ExecutedReceiptRow noGutters key={executedReceipt.receipt_id}>
+                <Col>
+                  <ReceiptRow
+                    transactionHash={transactionHash}
+                    receipt={executedReceipt}
                   />
-                ))
-              : t("component.transactions.ReceiptRow.no_actions")}
-          </ReceiptRowText>
-        </ReceiptRowSection>
-
-        <ReceiptRowSection noGutters>
-          <ReceiptRowStatus>{statusInfo}</ReceiptRowStatus>
-        </ReceiptRowSection>
-
-        <ReceiptRowSection noGutters>
-          <ReceiptRowText>
-            {receipt.outcome.logs.length === 0 ? (
-              t("component.transactions.ReceiptRow.no_logs")
-            ) : (
-              <pre>{receipt.outcome.logs.join("\n")}</pre>
-            )}
-          </ReceiptRowText>
-        </ReceiptRowSection>
-
-        {receipt.outcome.outgoing_receipts &&
-          receipt.outcome.outgoing_receipts.length > 0 &&
-          receipt.outcome.outgoing_receipts.map((executedReceipt) => (
-            <ExecutedReceiptRow noGutters key={executedReceipt.receipt_id}>
-              <Col>
-                <ReceiptRow
-                  transactionHash={transactionHash}
-                  receipt={executedReceipt}
-                />
-              </Col>
-            </ExecutedReceiptRow>
-          ))}
-      </Col>
-    </ReceiptRowWrapper>
-  );
-};
+                </Col>
+              </ExecutedReceiptRow>
+            ))}
+        </Col>
+      </ReceiptRowWrapper>
+    );
+  }
+);
 
 export default ReceiptRow;

--- a/frontend/src/components/transactions/TransactionAction.tsx
+++ b/frontend/src/components/transactions/TransactionAction.tsx
@@ -17,47 +17,46 @@ export interface Props {
   viewMode?: ViewMode;
 }
 
-const TransactionAction: React.FC<Props> = ({
-  transaction,
-  viewMode = "sparse",
-}) => {
-  const { t } = useTranslation();
-  const executionStatus = useWampQuery(
-    React.useCallback(
-      async (wampCall) => {
-        // TODO: Expose transaction status via transactions list from chunk
-        // RPC, and store it during Explorer synchronization.
-        //
-        // Meanwhile, we query this information in a non-effective manner,
-        // that is making a separate query per transaction to nearcore RPC.
-        const transactionExtraInfo = await wampCall("nearcore-tx", [
-          transaction.hash,
-          transaction.signerId,
-        ]);
-        return Object.keys(transactionExtraInfo.status)[0] as ExecutionStatus;
-      },
-      [transaction.hash, transaction.signerId]
-    )
-  );
+const TransactionAction: React.FC<Props> = React.memo(
+  ({ transaction, viewMode = "sparse" }) => {
+    const { t } = useTranslation();
+    const executionStatus = useWampQuery(
+      React.useCallback(
+        async (wampCall) => {
+          // TODO: Expose transaction status via transactions list from chunk
+          // RPC, and store it during Explorer synchronization.
+          //
+          // Meanwhile, we query this information in a non-effective manner,
+          // that is making a separate query per transaction to nearcore RPC.
+          const transactionExtraInfo = await wampCall("nearcore-tx", [
+            transaction.hash,
+            transaction.signerId,
+          ]);
+          return Object.keys(transactionExtraInfo.status)[0] as ExecutionStatus;
+        },
+        [transaction.hash, transaction.signerId]
+      )
+    );
 
-  if (!transaction.actions) {
-    return null;
+    if (!transaction.actions) {
+      return null;
+    }
+    return (
+      <ActionGroup
+        actionGroup={transaction}
+        detailsLink={<TransactionLink transactionHash={transaction.hash} />}
+        status={
+          executionStatus ? (
+            <TransactionExecutionStatus status={executionStatus} />
+          ) : (
+            t("common.transactions.status.fetching_status")
+          )
+        }
+        viewMode={viewMode}
+        title={t("component.transactions.TransactionAction.batch_transaction")}
+      />
+    );
   }
-  return (
-    <ActionGroup
-      actionGroup={transaction}
-      detailsLink={<TransactionLink transactionHash={transaction.hash} />}
-      status={
-        executionStatus ? (
-          <TransactionExecutionStatus status={executionStatus} />
-        ) : (
-          t("common.transactions.status.fetching_status")
-        )
-      }
-      viewMode={viewMode}
-      title={t("component.transactions.TransactionAction.batch_transaction")}
-    />
-  );
-};
+);
 
 export default TransactionAction;

--- a/frontend/src/components/transactions/TransactionDetails.tsx
+++ b/frontend/src/components/transactions/TransactionDetails.tsx
@@ -62,7 +62,7 @@ export interface State {
   transactionFee?: BN;
 }
 
-const TransactionDetails: React.FC<Props> = ({ transaction }) => {
+const TransactionDetails: React.FC<Props> = React.memo(({ transaction }) => {
   const { t } = useTranslation();
   const deposit = React.useMemo(() => {
     return transaction.actions
@@ -330,6 +330,6 @@ const TransactionDetails: React.FC<Props> = ({ transaction }) => {
       </Row>
     </TransactionInfoContainer>
   );
-};
+});
 
 export default TransactionDetails;

--- a/frontend/src/components/transactions/TransactionExecutionStatus.tsx
+++ b/frontend/src/components/transactions/TransactionExecutionStatus.tsx
@@ -1,12 +1,15 @@
+import * as React from "react";
 import { ExecutionStatus } from "../../libraries/wamp/types";
 import { useTranslation } from "react-i18next";
 
 export interface Props {
   status: ExecutionStatus;
 }
-const TransactionExecutionStatusComponent = ({ status }: Props) => {
-  const { t } = useTranslation();
-  return <>{t(`common.transactions.status.${status}`)}</>;
-};
+const TransactionExecutionStatusComponent: React.FC<Props> = React.memo(
+  ({ status }) => {
+    const { t } = useTranslation();
+    return <>{t(`common.transactions.status.${status}`)}</>;
+  }
+);
 
 export default TransactionExecutionStatusComponent;

--- a/frontend/src/components/transactions/TransactionOutcome.tsx
+++ b/frontend/src/components/transactions/TransactionOutcome.tsx
@@ -38,7 +38,7 @@ export interface Props {
   transaction: TTransactionOutcome;
 }
 
-const TransactionOutcome: React.FC<Props> = ({ transaction }) => {
+const TransactionOutcome: React.FC<Props> = React.memo(({ transaction }) => {
   const { t } = useTranslation();
   const gasBurnt = new BN(transaction.outcome?.gas_burnt ?? 0);
   const tokensBurnt = new BN(transaction.outcome?.tokens_burnt ?? 0);
@@ -75,6 +75,6 @@ const TransactionOutcome: React.FC<Props> = ({ transaction }) => {
       </Col>
     </Row>
   );
-};
+});
 
 export default TransactionOutcome;

--- a/frontend/src/components/transactions/Transactions.tsx
+++ b/frontend/src/components/transactions/Transactions.tsx
@@ -21,49 +21,47 @@ export interface OuterProps {
 
 const TRANSACTIONS_PER_PAGE = 15;
 
-const TransactionsWrapper: React.FC<OuterProps> = ({
-  accountId,
-  blockHash,
-  count = TRANSACTIONS_PER_PAGE,
-}) => {
-  const fetchDataFn = React.useCallback(
-    (
-      wampCall: WampCall,
-      count: number,
-      paginationIndexer?: TransactionPagination
-    ) => {
-      if (accountId) {
-        return wampCall("transactions-list-by-account-id", [
-          accountId,
-          count,
-          paginationIndexer,
-        ]);
-      }
-      if (blockHash) {
-        return wampCall("transactions-list-by-block-hash", [
-          blockHash,
-          count,
-          paginationIndexer,
-        ]);
-      }
-      return wampCall("transactions-list", [count, paginationIndexer]);
-    },
-    [accountId, blockHash]
-  );
-  return (
-    <TransactionsList
-      key={accountId || blockHash}
-      count={count}
-      fetchDataFn={fetchDataFn}
-    />
-  );
-};
+const TransactionsWrapper: React.FC<OuterProps> = React.memo(
+  ({ accountId, blockHash, count = TRANSACTIONS_PER_PAGE }) => {
+    const fetchDataFn = React.useCallback(
+      (
+        wampCall: WampCall,
+        count: number,
+        paginationIndexer?: TransactionPagination
+      ) => {
+        if (accountId) {
+          return wampCall("transactions-list-by-account-id", [
+            accountId,
+            count,
+            paginationIndexer,
+          ]);
+        }
+        if (blockHash) {
+          return wampCall("transactions-list-by-block-hash", [
+            blockHash,
+            count,
+            paginationIndexer,
+          ]);
+        }
+        return wampCall("transactions-list", [count, paginationIndexer]);
+      },
+      [accountId, blockHash]
+    );
+    return (
+      <TransactionsList
+        key={accountId || blockHash}
+        count={count}
+        fetchDataFn={fetchDataFn}
+      />
+    );
+  }
+);
 
 interface InnerProps {
   items: TransactionBaseInfo[];
 }
 
-const Transactions: React.FC<InnerProps> = ({ items }) => {
+const Transactions: React.FC<InnerProps> = React.memo(({ items }) => {
   const { t } = useTranslation();
   if (items?.length === 0) {
     return (
@@ -82,7 +80,7 @@ const Transactions: React.FC<InnerProps> = ({ items }) => {
       ))}
     </FlipMove>
   );
-};
+});
 
 const TransactionsList = ListHandler({
   Component: Transactions,

--- a/frontend/src/components/transactions/__tests__/__snapshots__/ActionsList.test.tsx.snap
+++ b/frontend/src/components/transactions/__tests__/__snapshots__/ActionsList.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ActionsList /> renders ActionsList for Receipts without transactionHash 1`] = `
-<ActionList
+<Memo
   actions={
     Array [
       Object {
@@ -14,7 +14,7 @@ exports[`<ActionsList /> renders ActionsList for Receipts without transactionHas
   }
   blockTimestamp={1621931941926}
   detailsLink={
-    <ReceiptLink
+    <Memo
       receiptId="D6a85wNQ47v3dPy8bGF2WQpKQu5di2dnx4EMohm9f5fc"
       transactionHash={null}
     />

--- a/frontend/src/components/utils/AccountLink.tsx
+++ b/frontend/src/components/utils/AccountLink.tsx
@@ -1,6 +1,7 @@
 import Link from "../utils/Link";
 import { truncateAccountId } from "../../libraries/formatting";
 import { styled } from "../../libraries/styles";
+import * as React from "react";
 
 const AccountLinkWrapper = styled("a", {
   whiteSpace: "nowrap",
@@ -10,12 +11,12 @@ export interface Props {
   accountId: string;
 }
 
-const AccountLink = ({ accountId }: Props) => {
+const AccountLink: React.FC<Props> = React.memo(({ accountId }) => {
   return (
     <Link href={`/accounts/${accountId}`} passHref>
       <AccountLinkWrapper>{truncateAccountId(accountId)}</AccountLinkWrapper>
     </Link>
   );
-};
+});
 
 export default AccountLink;

--- a/frontend/src/components/utils/Balance.tsx
+++ b/frontend/src/components/utils/Balance.tsx
@@ -13,38 +13,40 @@ interface Props {
   fracDigits?: number;
 }
 
-const Balance: React.FC<Props> = ({
-  amount,
-  label = null,
-  suffix = undefined,
-  className,
-  formulatedAmount = undefined,
-  fracDigits = 5,
-}) => {
-  if (!amount) {
-    throw new Error("amount property should not be null");
+const Balance: React.FC<Props> = React.memo(
+  ({
+    amount,
+    label = null,
+    suffix = undefined,
+    className,
+    formulatedAmount = undefined,
+    fracDigits = 5,
+  }) => {
+    if (!amount) {
+      throw new Error("amount property should not be null");
+    }
+
+    const defaultLabel = "Ⓝ";
+
+    let amountShow = !formulatedAmount
+      ? formatNEAR(amount, fracDigits)
+      : formulatedAmount;
+    let amountPrecise = showInYocto(amount.toString());
+    return (
+      <OverlayTrigger
+        placement={"bottom"}
+        overlay={<Tooltip id="balance">{amountPrecise}</Tooltip>}
+      >
+        <span className={className}>
+          {amountShow}
+          {suffix}
+          &nbsp;
+          {label ?? defaultLabel}
+        </span>
+      </OverlayTrigger>
+    );
   }
-
-  const defaultLabel = "Ⓝ";
-
-  let amountShow = !formulatedAmount
-    ? formatNEAR(amount, fracDigits)
-    : formulatedAmount;
-  let amountPrecise = showInYocto(amount.toString());
-  return (
-    <OverlayTrigger
-      placement={"bottom"}
-      overlay={<Tooltip id="balance">{amountPrecise}</Tooltip>}
-    >
-      <span className={className}>
-        {amountShow}
-        {suffix}
-        &nbsp;
-        {label ?? defaultLabel}
-      </span>
-    </OverlayTrigger>
-  );
-};
+);
 
 export const formatNEAR = (amount: string | BN, fracDigits = 5): string => {
   let ret = utils.format.formatNearAmount(amount.toString(), fracDigits);

--- a/frontend/src/components/utils/BlockLink.tsx
+++ b/frontend/src/components/utils/BlockLink.tsx
@@ -1,16 +1,20 @@
+import * as React from "react";
 import Link from "../utils/Link";
+
 export interface Props {
   blockHash: string;
   truncate?: boolean;
   children?: React.ReactNode;
 }
 
-const BlockLink = ({ blockHash, children, truncate = true }: Props) => (
-  <Link href={`/blocks/${blockHash}`}>
-    <a>
-      {children || (truncate ? `${blockHash.substring(0, 7)}...` : blockHash)}
-    </a>
-  </Link>
+const BlockLink: React.FC<Props> = React.memo(
+  ({ blockHash, children, truncate = true }) => (
+    <Link href="/blocks/[hash]" as={`/blocks/${blockHash}`}>
+      <a>
+        {children || (truncate ? `${blockHash.substring(0, 7)}...` : blockHash)}
+      </a>
+    </Link>
+  )
 );
 
 export default BlockLink;

--- a/frontend/src/components/utils/CardCell.tsx
+++ b/frontend/src/components/utils/CardCell.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { Row, Col, Card, Spinner } from "react-bootstrap";
 import { styled } from "../../libraries/styles";
 import { TermInfoIcon } from "./Term";
@@ -47,26 +48,32 @@ export const CardCellText = styled(Col, {
 
 export interface Props {
   className?: string;
-  title: React.ReactElement | string;
+  title: React.ReactNode;
   imgLink?: string;
-  text: React.ReactElement | string;
+  text: React.ReactNode;
   loading?: boolean;
 }
 
-const CardCell = ({ title, imgLink, text, className, loading }: Props) => (
-  <CardCellWrapper className={className}>
-    <Card.Body>
-      <Row noGutters>
-        <CardCellTitle xs="auto" md="12" className="align-self-center">
-          {imgLink && <CardCellTitleImage src={imgLink} />}
-          {title}
-        </CardCellTitle>
-        <CardCellText xs="auto" md="12" className="ml-auto align-self-center">
-          {loading ? <Spinner animation="border" variant="secondary" /> : text}
-        </CardCellText>
-      </Row>
-    </Card.Body>
-  </CardCellWrapper>
+const CardCell: React.FC<Props> = React.memo(
+  ({ title, imgLink, text, className, loading }) => (
+    <CardCellWrapper className={className}>
+      <Card.Body>
+        <Row noGutters>
+          <CardCellTitle xs="auto" md="12" className="align-self-center">
+            {imgLink && <CardCellTitleImage src={imgLink} />}
+            {title}
+          </CardCellTitle>
+          <CardCellText xs="auto" md="12" className="ml-auto align-self-center">
+            {loading ? (
+              <Spinner animation="border" variant="secondary" />
+            ) : (
+              text
+            )}
+          </CardCellText>
+        </Row>
+      </Card.Body>
+    </CardCellWrapper>
+  )
 );
 
 export default CardCell;

--- a/frontend/src/components/utils/CodePreview.tsx
+++ b/frontend/src/components/utils/CodePreview.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import ReactTextCollapse from "react-text-collapse";
 import { styled } from "../../libraries/styles";
 
@@ -22,7 +23,7 @@ export interface Props {
   value: string;
 }
 
-const CodePreview = (props: Props) => {
+const CodePreview: React.FC<Props> = React.memo((props) => {
   return (
     <ReactTextCollapse options={props.collapseOptions}>
       <link
@@ -32,6 +33,6 @@ const CodePreview = (props: Props) => {
       <CodePreviewWrapper readOnly value={props.value} />
     </ReactTextCollapse>
   );
-};
+});
 
 export default CodePreview;

--- a/frontend/src/components/utils/Content.tsx
+++ b/frontend/src/components/utils/Content.tsx
@@ -34,46 +34,48 @@ export interface Props {
   className?: string;
 }
 
-const Content: React.FC<Props> = ({
-  border = true,
-  icon,
-  className,
-  title,
-  fluid,
-  contentFluid,
-  header,
-  overrideHeader,
-  children,
-}) => {
-  const Header = overrideHeader || ContentHeader;
-  return (
-    <ContentContainer className={className} fluid={fluid}>
-      {title ? (
-        <Header bordered={border}>
-          <Col className="px-0">
-            <Row>
-              {icon ? <Col xs="auto">{icon}</Col> : null}
-              <Col
-                className={cx(
-                  "text-md-left",
-                  "text-center",
-                  icon ? "px-0" : undefined
-                )}
-              >
-                {title}
-              </Col>
-            </Row>
-          </Col>
-        </Header>
-      ) : header ? (
-        <Header bordered={border}>
-          <Col className="px-0">{header}</Col>
-        </Header>
-      ) : null}
+const Content: React.FC<Props> = React.memo(
+  ({
+    border = true,
+    icon,
+    className,
+    title,
+    fluid,
+    contentFluid,
+    header,
+    overrideHeader,
+    children,
+  }) => {
+    const Header = overrideHeader || ContentHeader;
+    return (
+      <ContentContainer className={className} fluid={fluid}>
+        {title ? (
+          <Header bordered={border}>
+            <Col className="px-0">
+              <Row>
+                {icon ? <Col xs="auto">{icon}</Col> : null}
+                <Col
+                  className={cx(
+                    "text-md-left",
+                    "text-center",
+                    icon ? "px-0" : undefined
+                  )}
+                >
+                  {title}
+                </Col>
+              </Row>
+            </Col>
+          </Header>
+        ) : header ? (
+          <Header bordered={border}>
+            <Col className="px-0">{header}</Col>
+          </Header>
+        ) : null}
 
-      <Container fluid={contentFluid}>{children}</Container>
-    </ContentContainer>
-  );
-};
+        <Container fluid={contentFluid}>{children}</Container>
+      </ContentContainer>
+    );
+  }
+);
 
 export default Content;

--- a/frontend/src/components/utils/CountryFlag.tsx
+++ b/frontend/src/components/utils/CountryFlag.tsx
@@ -25,7 +25,7 @@ interface Props {
   country?: string;
 }
 
-const CountryFlag = (props: Props) => {
+const CountryFlag: React.FC<Props> = React.memo((props) => {
   // sometimes in 'country' can be actually countryCode
   let countryCode: string | undefined = props.countryCode?.toUpperCase();
   if (!(countryCode! in countries)) {
@@ -56,6 +56,6 @@ const CountryFlag = (props: Props) => {
       )}
     </>
   );
-};
+});
 
 export default CountryFlag;

--- a/frontend/src/components/utils/DashboardCard.tsx
+++ b/frontend/src/components/utils/DashboardCard.tsx
@@ -45,28 +45,23 @@ interface Props {
   children?: React.ReactNode;
 }
 
-const DashboardCard = ({
-  iconPath,
-  title,
-  headerRight,
-  className,
-  dataId,
-  children,
-}: Props) => (
-  <DashboardCardWrapper noGutters className={className} data-id={dataId}>
-    <Col xs="12">
-      <DashboardCardHeader>
-        <Col>
-          <DashboardIcon src={iconPath} />
-          {title}
-        </Col>
-        <DashboardCardHeaderRight xs="auto">
-          {headerRight}
-        </DashboardCardHeaderRight>
-      </DashboardCardHeader>
-    </Col>
-    <Col xs="12">{children}</Col>
-  </DashboardCardWrapper>
+const DashboardCard: React.FC<Props> = React.memo(
+  ({ iconPath, title, headerRight, className, dataId, children }) => (
+    <DashboardCardWrapper noGutters className={className} data-id={dataId}>
+      <Col xs="12">
+        <DashboardCardHeader>
+          <Col>
+            <DashboardIcon src={iconPath} />
+            {title}
+          </Col>
+          <DashboardCardHeaderRight xs="auto">
+            {headerRight}
+          </DashboardCardHeaderRight>
+        </DashboardCardHeader>
+      </Col>
+      <Col xs="12">{children}</Col>
+    </DashboardCardWrapper>
+  )
 );
 
 export default DashboardCard;

--- a/frontend/src/components/utils/FlipMove.tsx
+++ b/frontend/src/components/utils/FlipMove.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import FlipMove from "react-flip-move";
 
 export interface Props {
@@ -6,11 +7,11 @@ export interface Props {
   children?: React.ReactNode;
 }
 
-const FlipMoveEx = ({ children, ...props }: Props) => {
+const FlipMoveEx: React.FC<Props> = React.memo(({ children, ...props }) => {
   if (typeof document === "undefined" || document.hidden) {
     return <div>{children}</div>;
   }
   return <FlipMove {...props}>{children}</FlipMove>;
-};
+});
 
 export default FlipMoveEx;

--- a/frontend/src/components/utils/Footer.tsx
+++ b/frontend/src/components/utils/Footer.tsx
@@ -106,7 +106,7 @@ const NearkatWrapper = styled("div", {
   },
 });
 
-const Footer: React.FC = () => {
+const Footer: React.FC = React.memo(() => {
   const { t } = useTranslation();
   const track = useAnalyticsTrack();
 
@@ -166,6 +166,6 @@ const Footer: React.FC = () => {
       </NearkatWrapper>
     </FooterContainer>
   );
-};
+});
 
 export default Footer;

--- a/frontend/src/components/utils/Gas.tsx
+++ b/frontend/src/components/utils/Gas.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import BN from "bn.js";
 
 interface Props {
@@ -8,7 +9,7 @@ const MGAS = new BN(10 ** 6);
 const GGAS = new BN(1000).mul(MGAS);
 export const TGAS = new BN(1000).mul(GGAS);
 
-const Gas = ({ gas }: Props) => {
+const Gas: React.FC<Props> = React.memo(({ gas }) => {
   let gasShow;
   if (gas.gte(TGAS)) {
     gasShow = `${gas.div(TGAS).toString()} Tgas`;
@@ -20,6 +21,6 @@ const Gas = ({ gas }: Props) => {
     gasShow = `${gas.toString()} gas`;
   }
   return <>{gasShow}</>;
-};
+});
 
 export default Gas;

--- a/frontend/src/components/utils/GasPrice.tsx
+++ b/frontend/src/components/utils/GasPrice.tsx
@@ -9,7 +9,7 @@ interface Props {
   gasPrice: BN;
 }
 
-const GasPrice: React.FC<Props> = ({ gasPrice }) => {
+const GasPrice: React.FC<Props> = React.memo(({ gasPrice }) => {
   let gasPricePerTeragas = new BN(gasPrice).mul(TGAS);
   return (
     <OverlayTrigger
@@ -21,6 +21,6 @@ const GasPrice: React.FC<Props> = ({ gasPrice }) => {
       <span>{formatNEAR(gasPricePerTeragas)} Ⓝ/Tgas</span>
     </OverlayTrigger>
   );
-};
+});
 
 export default GasPrice;

--- a/frontend/src/components/utils/Header.tsx
+++ b/frontend/src/components/utils/Header.tsx
@@ -52,7 +52,7 @@ const HeaderHome = styled("a", {
   textDecoration: "none",
 });
 
-const Header: React.FC = () => {
+const Header: React.FC = React.memo(() => {
   const { t } = useTranslation();
   const router = useRouter();
 
@@ -122,6 +122,6 @@ const Header: React.FC = () => {
       </Row>
     </HeaderContainer>
   );
-};
+});
 
 export default Header;

--- a/frontend/src/components/utils/HeaderNavDropdown.tsx
+++ b/frontend/src/components/utils/HeaderNavDropdown.tsx
@@ -53,16 +53,18 @@ interface Props {
   text: React.ReactNode;
 }
 
-const HeaderNavItem: React.FC<Props> = ({ link, IconElement, text }) => {
-  return (
-    <Link href={link} passHref>
-      <HeaderNavLink>
-        <Icon as={IconElement} />
-        <NavText>{text}</NavText>
-      </HeaderNavLink>
-    </Link>
-  );
-};
+const HeaderNavItem: React.FC<Props> = React.memo(
+  ({ link, IconElement, text }) => {
+    return (
+      <Link href={link} passHref>
+        <HeaderNavLink>
+          <Icon as={IconElement} />
+          <NavText>{text}</NavText>
+        </HeaderNavLink>
+      </Link>
+    );
+  }
+);
 
 const ChainHeader = styled(Dropdown.Toggle, {
   color: "#000000",
@@ -106,7 +108,7 @@ const globalStyles = globalCss({
   },
 });
 
-const HeaderNavDropdown: React.FC = () => {
+const HeaderNavDropdown: React.FC = React.memo(() => {
   const { t } = useTranslation();
   globalStyles();
   return (
@@ -144,6 +146,6 @@ const HeaderNavDropdown: React.FC = () => {
       </HeaderDropdownMenu>
     </Dropdown>
   );
-};
+});
 
 export default HeaderNavDropdown;

--- a/frontend/src/components/utils/HeaderNetworkDropdown.tsx
+++ b/frontend/src/components/utils/HeaderNetworkDropdown.tsx
@@ -24,7 +24,7 @@ interface Props {
   title: NetworkName;
 }
 
-const HeaderDropdownItem: React.FC<Props> = ({ link, title }) => {
+const HeaderDropdownItem: React.FC<Props> = React.memo(({ link, title }) => {
   const track = useAnalyticsTrack();
 
   return (
@@ -38,7 +38,7 @@ const HeaderDropdownItem: React.FC<Props> = ({ link, title }) => {
       {title}
     </HeaderNetworkItemDropdown>
   );
-};
+});
 
 const HeaderNetwork = styled(Dropdown.Toggle, {
   background: "#ffffff",
@@ -112,7 +112,7 @@ const IconRight = styled("img", {
   marginTop: -3,
 });
 
-const HeaderNetworkDropdown: React.FC = () => {
+const HeaderNetworkDropdown: React.FC = React.memo(() => {
   const { currentNetwork, networks } = useNetworkContext();
   return (
     <Dropdown>
@@ -135,6 +135,6 @@ const HeaderNetworkDropdown: React.FC = () => {
       </HeaderNetworkDropdownMenu>
     </Dropdown>
   );
-};
+});
 
 export default HeaderNetworkDropdown;

--- a/frontend/src/components/utils/InfoCard.tsx
+++ b/frontend/src/components/utils/InfoCard.tsx
@@ -22,10 +22,12 @@ interface InfoCardCellProps {
   cellOptions?: object;
 }
 
-const InfoCard: React.FC<InfoCardProps> = ({ children, className }) => (
-  <InfoCardWrapper noGutters className={className}>
-    {children}
-  </InfoCardWrapper>
+const InfoCard: React.FC<InfoCardProps> = React.memo(
+  ({ children, className }) => (
+    <InfoCardWrapper noGutters className={className}>
+      {children}
+    </InfoCardWrapper>
+  )
 );
 
 const InfoCardTitle = styled(Col, {
@@ -44,20 +46,17 @@ export const InfoCardText = styled(Col, {
   fontFeatureSettings: '"zero", on',
 });
 
-const InfoCardCell = ({
-  children,
-  className,
-  title,
-  cellOptions = undefined,
-}: InfoCardCellProps) => (
-  <Col {...cellOptions} className={className}>
-    <Row noGutters>
-      <InfoCardTitle xs="12">{title}</InfoCardTitle>
-      <InfoCardText xs="12">
-        {!children ? <Spinner animation="border" size="sm" /> : children}
-      </InfoCardText>
-    </Row>
-  </Col>
+const InfoCardCell: React.FC<InfoCardCellProps> = React.memo(
+  ({ children, className, title, cellOptions = undefined }) => (
+    <Col {...cellOptions} className={className}>
+      <Row noGutters>
+        <InfoCardTitle xs="12">{title}</InfoCardTitle>
+        <InfoCardText xs="12">
+          {!children ? <Spinner animation="border" size="sm" /> : children}
+        </InfoCardText>
+      </Row>
+    </Col>
+  )
 );
 
 export { InfoCard, InfoCardCell };

--- a/frontend/src/components/utils/LanguageToggle.tsx
+++ b/frontend/src/components/utils/LanguageToggle.tsx
@@ -61,7 +61,7 @@ type Props = {
   mobile?: boolean;
 };
 
-const LanguageToggle: React.FC<Props> = (props) => {
+const LanguageToggle: React.FC<Props> = React.memo((props) => {
   const { i18n, ready } = useTranslation();
   const [language, setLanguage] = useCookie(LANGUAGE_COOKIE, DEFAULT_LANGUAGE);
   React.useEffect(() => {
@@ -91,6 +91,6 @@ const LanguageToggle: React.FC<Props> = (props) => {
       ))}
     </LangSelector>
   );
-};
+});
 
 export default LanguageToggle;

--- a/frontend/src/components/utils/Link.tsx
+++ b/frontend/src/components/utils/Link.tsx
@@ -2,20 +2,22 @@ import Link from "next/link";
 import * as React from "react";
 import { useAnalyticsTrack } from "../../hooks/analytics/use-analytics-track";
 
-const LinkWrapper = (props: React.ComponentProps<typeof Link>) => {
-  const track = useAnalyticsTrack();
+const LinkWrapper: React.FC<React.ComponentProps<typeof Link>> = React.memo(
+  (props) => {
+    const track = useAnalyticsTrack();
 
-  return (
-    <span
-      onClick={() =>
-        track("Explorer Click Link", {
-          href: props.href,
-        })
-      }
-    >
-      <Link {...props} />
-    </span>
-  );
-};
+    return (
+      <span
+        onClick={() =>
+          track("Explorer Click Link", {
+            href: props.href,
+          })
+        }
+      >
+        <Link {...props} />
+      </span>
+    );
+  }
+);
 
 export default LinkWrapper;

--- a/frontend/src/components/utils/ListHandler.tsx
+++ b/frontend/src/components/utils/ListHandler.tsx
@@ -52,20 +52,22 @@ type UpdateBlockHeightProps = {
   onClick: () => void;
 };
 
-const UpdateBlockHeight: React.FC<UpdateBlockHeightProps> = (props) => {
-  const { t } = useTranslation();
-  const latestBlockHeight = useLatestBlockHeight();
-  return (
-    <div onClick={props.onClick}>
-      <Update>{`${t(
-        "utils.ListHandler.last_block"
-      )}#${latestBlockHeight}.`}</Update>
-    </div>
-  );
-};
+const UpdateBlockHeight: React.FC<UpdateBlockHeightProps> = React.memo(
+  (props) => {
+    const { t } = useTranslation();
+    const latestBlockHeight = useLatestBlockHeight();
+    return (
+      <div onClick={props.onClick}>
+        <Update>{`${t(
+          "utils.ListHandler.last_block"
+        )}#${latestBlockHeight}.`}</Update>
+      </div>
+    );
+  }
+);
 
 const Wrapper = <T, I>(config: StaticConfig<T, I>): React.FC<Props<T, I>> => {
-  return (props) => {
+  return React.memo((props) => {
     const { t } = useTranslation();
     const [items, setItems] = React.useState<T[]>([]);
     const [shouldShow, setShouldShow] = React.useState(false);
@@ -147,7 +149,7 @@ const Wrapper = <T, I>(config: StaticConfig<T, I>): React.FC<Props<T, I>> => {
         </InfiniteScroll>
       </>
     );
-  };
+  });
 };
 
 export default Wrapper;

--- a/frontend/src/components/utils/LongCardCell.tsx
+++ b/frontend/src/components/utils/LongCardCell.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { Row, Col, Spinner } from "react-bootstrap";
 
 import RightArrowSvg from "../../../public/static/images/right-arrow.svg";
@@ -62,48 +63,50 @@ const RightArrow = styled(Col, {
 });
 
 export interface Props {
-  title: React.ReactElement | string;
-  text?: React.ReactElement | string;
+  title: React.ReactNode;
+  text?: React.ReactNode;
   loading?: boolean;
   href?: string;
   className?: string;
 }
 
-const LongCardCell = ({ title, text, loading, href, className }: Props) => {
-  const plainCell = (
-    <Row noGutters>
-      <LongCardCellTitle xs="12" className="align-self-center">
-        {title}
-      </LongCardCellTitle>
-      <CardCellText xs="12" md="12" className="ml-auto align-self-center">
-        {loading ? <Spinner animation="border" variant="secondary" /> : text}
-      </CardCellText>
-    </Row>
-  );
-  return (
-    <>
-      {href ? (
-        <Link href={href}>
-          <a>
-            <LongCardCellWrapper
-              className={cx("href-cell", className)}
-              withLink
-              noGutters
-            >
-              <Col>{plainCell}</Col>
-              <RightArrow xs="auto">
-                <RightArrowSvg />
-              </RightArrow>
-            </LongCardCellWrapper>
-          </a>
-        </Link>
-      ) : (
-        <LongCardCellWrapper className={className} noGutters>
-          <Col>{plainCell}</Col>
-        </LongCardCellWrapper>
-      )}
-    </>
-  );
-};
+const LongCardCell: React.FC<Props> = React.memo(
+  ({ title, text, loading, href, className }) => {
+    const plainCell = (
+      <Row noGutters>
+        <LongCardCellTitle xs="12" className="align-self-center">
+          {title}
+        </LongCardCellTitle>
+        <CardCellText xs="12" md="12" className="ml-auto align-self-center">
+          {loading ? <Spinner animation="border" variant="secondary" /> : text}
+        </CardCellText>
+      </Row>
+    );
+    return (
+      <>
+        {href ? (
+          <Link href={href}>
+            <a>
+              <LongCardCellWrapper
+                className={cx("href-cell", className)}
+                withLink
+                noGutters
+              >
+                <Col>{plainCell}</Col>
+                <RightArrow xs="auto">
+                  <RightArrowSvg />
+                </RightArrow>
+              </LongCardCellWrapper>
+            </a>
+          </Link>
+        ) : (
+          <LongCardCellWrapper className={className} noGutters>
+            <Col>{plainCell}</Col>
+          </LongCardCellWrapper>
+        )}
+      </>
+    );
+  }
+);
 
 export default LongCardCell;

--- a/frontend/src/components/utils/MobileHeaderNavDropdown.tsx
+++ b/frontend/src/components/utils/MobileHeaderNavDropdown.tsx
@@ -46,16 +46,18 @@ interface Props {
   text: React.ReactNode;
 }
 
-const MobileNavItem: React.FC<Props> = ({ link, IconElement, text }) => {
-  return (
-    <Link href={link} passHref>
-      <HeaderNavLink>
-        <Icon as={IconElement} />
-        <NavText>{text}</NavText>
-      </HeaderNavLink>
-    </Link>
-  );
-};
+const MobileNavItem: React.FC<Props> = React.memo(
+  ({ link, IconElement, text }) => {
+    return (
+      <Link href={link} passHref>
+        <HeaderNavLink>
+          <Icon as={IconElement} />
+          <NavText>{text}</NavText>
+        </HeaderNavLink>
+      </Link>
+    );
+  }
+);
 
 const MobileHeaderNav = styled("div", {
   display: "inline-block",
@@ -115,7 +117,7 @@ const LinkWrapper = styled("a", {
   width: "100%",
 });
 
-const MobileNavDropdown = () => {
+const MobileNavDropdown: React.FC = React.memo(() => {
   const { t } = useTranslation();
   const [isMenuShown, setMenuShown] = React.useState(false);
   const dropdownWrapperRef = React.useRef<HTMLDivElement>(null);
@@ -211,6 +213,6 @@ const MobileNavDropdown = () => {
       </MobileHeaderNav>
     </>
   );
-};
+});
 
 export default MobileNavDropdown;

--- a/frontend/src/components/utils/Pagination.tsx
+++ b/frontend/src/components/utils/Pagination.tsx
@@ -71,7 +71,7 @@ export interface Props {
   onPageChange: OnPageChange;
 }
 
-const Arrow = () => (
+const Arrow: React.FC = React.memo(() => (
   <svg fill="none" xmlns="http://www.w3.org/2000/svg">
     <path
       d="m7 13.5-6-6 6-6"
@@ -80,26 +80,28 @@ const Arrow = () => (
       strokeLinejoin="round"
     />
   </svg>
-);
+));
 
-const Pagination: React.FC<Props> = ({
-  overrideComponent,
-  pageCount,
-  marginPagesDisplayed,
-  pageRangeDisplayed,
-  onPageChange,
-}) => {
-  const Component = overrideComponent || PaginateWrapper;
-  return (
-    <Component
-      previousLabel={<Arrow />}
-      nextLabel={<Arrow />}
-      pageCount={pageCount}
-      marginPagesDisplayed={marginPagesDisplayed}
-      pageRangeDisplayed={pageRangeDisplayed}
-      onPageChange={onPageChange}
-    />
-  );
-};
+const Pagination: React.FC<Props> = React.memo(
+  ({
+    overrideComponent,
+    pageCount,
+    marginPagesDisplayed,
+    pageRangeDisplayed,
+    onPageChange,
+  }) => {
+    const Component = overrideComponent || PaginateWrapper;
+    return (
+      <Component
+        previousLabel={<Arrow />}
+        nextLabel={<Arrow />}
+        pageCount={pageCount}
+        marginPagesDisplayed={marginPagesDisplayed}
+        pageRangeDisplayed={pageRangeDisplayed}
+        onPageChange={onPageChange}
+      />
+    );
+  }
+);
 
 export default Pagination;

--- a/frontend/src/components/utils/PaginationSpinner.tsx
+++ b/frontend/src/components/utils/PaginationSpinner.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Row, Col, Spinner } from "react-bootstrap";
 
-const PaginationSpinner: React.FC = () => (
+const PaginationSpinner: React.FC = React.memo(() => (
   <div>
     <Row>
       <Col xs="auto" className="mx-auto">
@@ -11,6 +11,6 @@ const PaginationSpinner: React.FC = () => (
       </Col>
     </Row>
   </div>
-);
+));
 
 export default PaginationSpinner;

--- a/frontend/src/components/utils/Placeholder.tsx
+++ b/frontend/src/components/utils/Placeholder.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { styled } from "../../libraries/styles";
 
 const PlaceholderWrapper = styled("div", {
@@ -13,13 +14,13 @@ const PlaceholderText = styled("p", {
 });
 
 export interface Props {
-  children: string | React.ReactNode;
+  children: React.ReactNode;
 }
 
-const Placeholder = ({ children }: Props) => (
+const Placeholder: React.FC<Props> = React.memo(({ children }) => (
   <PlaceholderWrapper>
     <PlaceholderText>{children}</PlaceholderText>
   </PlaceholderWrapper>
-);
+));
 
 export default Placeholder;

--- a/frontend/src/components/utils/ProgressBar.tsx
+++ b/frontend/src/components/utils/ProgressBar.tsx
@@ -28,29 +28,26 @@ interface Props {
   type?: "line" | "circle";
   className?: string;
   percent?: number;
-  label?: React.ReactNode | string;
+  label?: React.ReactNode;
 }
 
-const ProgressBarEx: React.FC<Props> = ({
-  type = "line",
-  className,
-  label,
-  ...props
-}) => {
-  const wrapperClassName = cx(className, "progress-bar");
-  if (type === "circle") {
+const ProgressBarEx: React.FC<Props> = React.memo(
+  ({ type = "line", className, label, ...props }) => {
+    const wrapperClassName = cx(className, "progress-bar");
+    if (type === "circle") {
+      return (
+        <ProgressBarWrapper className={wrapperClassName}>
+          <ProgressBarElement as={Circle} strokeLinecap="square" {...props} />
+          {label && <ProgressBarLabel>{label}</ProgressBarLabel>}
+        </ProgressBarWrapper>
+      );
+    }
     return (
       <ProgressBarWrapper className={wrapperClassName}>
-        <ProgressBarElement as={Circle} strokeLinecap="square" {...props} />
-        {label && <ProgressBarLabel>{label}</ProgressBarLabel>}
+        <ProgressBarElement as={Line} strokeLinecap="square" {...props} />
       </ProgressBarWrapper>
     );
   }
-  return (
-    <ProgressBarWrapper className={wrapperClassName}>
-      <ProgressBarElement as={Line} strokeLinecap="square" {...props} />
-    </ProgressBarWrapper>
-  );
-};
+);
 
 export default ProgressBarEx;

--- a/frontend/src/components/utils/ReceiptLink.tsx
+++ b/frontend/src/components/utils/ReceiptLink.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { styled } from "../../libraries/styles";
 import Link from "./Link";
 
@@ -12,20 +13,18 @@ export interface Props {
   children?: React.ReactNode;
 }
 
-const ReceiptLink = ({
-  transactionHash,
-  receiptId,
-  truncate = true,
-}: Props) => {
-  const children = truncate ? `${receiptId.substring(0, 7)}...` : receiptId;
-  if (!transactionHash) {
-    return <DisabledLink title={receiptId}>{children}</DisabledLink>;
+const ReceiptLink: React.FC<Props> = React.memo(
+  ({ transactionHash, receiptId, truncate = true }) => {
+    const children = truncate ? `${receiptId.substring(0, 7)}...` : receiptId;
+    if (!transactionHash) {
+      return <DisabledLink title={receiptId}>{children}</DisabledLink>;
+    }
+    return (
+      <Link href={`/transactions/${transactionHash}#${receiptId}`}>
+        <a>{children}</a>
+      </Link>
+    );
   }
-  return (
-    <Link href={`/transactions/${transactionHash}#${receiptId}`}>
-      <a>{children}</a>
-    </Link>
-  );
-};
+);
 
 export default ReceiptLink;

--- a/frontend/src/components/utils/Search.tsx
+++ b/frontend/src/components/utils/Search.tsx
@@ -172,7 +172,7 @@ interface Props {
   dashboard?: boolean;
 }
 
-const Search: React.FC<Props> = ({ dashboard }) => {
+const Search: React.FC<Props> = React.memo(({ dashboard }) => {
   const { t } = useTranslation();
   const track = useAnalyticsTrack();
 
@@ -274,6 +274,6 @@ const Search: React.FC<Props> = ({ dashboard }) => {
       </SearchBox>
     </SearchWrapper>
   );
-};
+});
 
 export default Search;

--- a/frontend/src/components/utils/StorageSize.tsx
+++ b/frontend/src/components/utils/StorageSize.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { OverlayTrigger, Tooltip } from "react-bootstrap";
 import { useTranslation } from "react-i18next";
 import { formatWithCommas } from "../utils/Balance";
@@ -5,7 +6,7 @@ import { formatWithCommas } from "../utils/Balance";
 interface Props {
   value: number;
 }
-const StorageSize = ({ value }: Props) => {
+const StorageSize: React.FC<Props> = React.memo(({ value }) => {
   const { t } = useTranslation();
   const formatStoreSize = (value: number): string => {
     let showStorage = value.toString();
@@ -54,6 +55,6 @@ const StorageSize = ({ value }: Props) => {
       <span>{formatStoreSize(value)}</span>
     </OverlayTrigger>
   );
-};
+});
 
 export default StorageSize;

--- a/frontend/src/components/utils/Table.tsx
+++ b/frontend/src/components/utils/Table.tsx
@@ -70,21 +70,25 @@ interface Props {
   pagination?: PaginationProps;
 }
 
-const TableRow: React.FC<Props> = ({ className, children, collapse }) => {
-  return (
-    <TableRowWrapper className={className} expanded={collapse}>
-      {children}
-    </TableRowWrapper>
-  );
-};
-
-const TableCollapseRow: React.FC<Props> = ({ children, collapse }) => {
-  if (!collapse) {
-    return null;
+const TableRow: React.FC<Props> = React.memo(
+  ({ className, children, collapse }) => {
+    return (
+      <TableRowWrapper className={className} expanded={collapse}>
+        {children}
+      </TableRowWrapper>
+    );
   }
+);
 
-  return <TableExpandRow>{children}</TableExpandRow>;
-};
+const TableCollapseRow: React.FC<Props> = React.memo(
+  ({ children, collapse }) => {
+    if (!collapse) {
+      return null;
+    }
+
+    return <TableExpandRow>{children}</TableExpandRow>;
+  }
+);
 
 const TableSection = styled("div", {
   backgroundColor: "#fafafa",
@@ -112,11 +116,13 @@ const TableSectionWrapper = styled(BaseTable, {
   marginBottom: 0,
 });
 
-const Table: React.FC<Props> = ({ className, children, pagination }) => (
-  <TableSection className={className}>
-    <TableSectionWrapper responsive>{children}</TableSectionWrapper>
-    {pagination && <Pagination {...pagination} />}
-  </TableSection>
+const Table: React.FC<Props> = React.memo(
+  ({ className, children, pagination }) => (
+    <TableSection className={className}>
+      <TableSectionWrapper responsive>{children}</TableSectionWrapper>
+      {pagination && <Pagination {...pagination} />}
+    </TableSection>
+  )
 );
 
 export type { OnPageChange } from "../utils/Pagination";

--- a/frontend/src/components/utils/Term.tsx
+++ b/frontend/src/components/utils/Term.tsx
@@ -20,12 +20,12 @@ export const TermInfoIcon = styled("img", {
 });
 
 interface Props {
-  title: string | React.ReactNode;
-  text: string | React.ReactNode;
+  title: React.ReactNode;
+  text: React.ReactNode;
   href?: string;
 }
 
-const Term: React.FC<Props> = ({ title, text, href }) => {
+const Term: React.FC<Props> = React.memo(({ title, text, href }) => {
   const { t } = useTranslation();
   const [isModalShown, setModalShown] = React.useState(false);
   const track = useAnalyticsTrack();
@@ -70,6 +70,6 @@ const Term: React.FC<Props> = ({ title, text, href }) => {
       </TermHelper>
     </>
   );
-};
+});
 
 export default Term;

--- a/frontend/src/components/utils/Timer.tsx
+++ b/frontend/src/components/utils/Timer.tsx
@@ -7,7 +7,7 @@ interface Props {
   time?: number;
 }
 
-const Timer: React.FC<Props> = (props) => {
+const Timer: React.FC<Props> = React.memo((props) => {
   const getTimer = React.useCallback(
     () => (props.time === undefined ? new Date() : props.time),
     [props.time]
@@ -18,6 +18,6 @@ const Timer: React.FC<Props> = (props) => {
     return () => clearInterval(timerId);
   }, [props.time, setTimestamp]);
   return <span>{Moment(timestamp).fromNow()}</span>;
-};
+});
 
 export default Timer;

--- a/frontend/src/components/utils/TransactionLink.tsx
+++ b/frontend/src/components/utils/TransactionLink.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import Link from "../utils/Link";
 
 export interface Props {
@@ -5,10 +6,12 @@ export interface Props {
   children?: React.ReactNode;
 }
 
-const TransactionLink = ({ transactionHash, children }: Props) => (
-  <Link href={`/transactions/${transactionHash}`}>
-    <a>{children || `${transactionHash.substring(0, 7)}...`}</a>
-  </Link>
+const TransactionLink: React.FC<Props> = React.memo(
+  ({ transactionHash, children }) => (
+    <Link href="/transactions/[hash]" as={`/transactions/${transactionHash}`}>
+      <a>{children || `${transactionHash.substring(0, 7)}...`}</a>
+    </Link>
+  )
 );
 
 export default TransactionLink;

--- a/frontend/src/components/utils/Update.tsx
+++ b/frontend/src/components/utils/Update.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import Placeholder, { Props as PlaceholderProps } from "./Placeholder";
 
 import { useTranslation } from "react-i18next";
@@ -9,7 +10,7 @@ const UpdateWrapper = styled(Placeholder, {
   },
 });
 
-const Update = ({ children }: PlaceholderProps) => {
+const Update: React.FC<PlaceholderProps> = React.memo(({ children }) => {
   const { t } = useTranslation();
   return (
     <UpdateWrapper>
@@ -17,6 +18,6 @@ const Update = ({ children }: PlaceholderProps) => {
       {t("utils.Update.refresh")}
     </UpdateWrapper>
   );
-};
+});
 
 export default Update;

--- a/frontend/src/components/utils/WalletLink.tsx
+++ b/frontend/src/components/utils/WalletLink.tsx
@@ -13,33 +13,32 @@ export interface Props {
   nearWalletProfilePrefix: string;
 }
 
-const WalletLink: React.FC<Props> = ({
-  accountId,
-  nearWalletProfilePrefix,
-}) => {
-  const { t } = useTranslation();
-  const track = useAnalyticsTrack();
-  return (
-    <span
-      onClick={() =>
-        track("Explorer Click for wallet profile", {
-          accountId: accountId,
-          walletPrefix: nearWalletProfilePrefix,
-        })
-      }
-    >
-      <AccountLink
-        target="_blank"
-        rel="noopener"
-        href={`${nearWalletProfilePrefix}/${accountId}`}
+const WalletLink: React.FC<Props> = React.memo(
+  ({ accountId, nearWalletProfilePrefix }) => {
+    const { t } = useTranslation();
+    const track = useAnalyticsTrack();
+    return (
+      <span
+        onClick={() =>
+          track("Explorer Click for wallet profile", {
+            accountId: accountId,
+            walletPrefix: nearWalletProfilePrefix,
+          })
+        }
       >
-        {t("utils.WalletLink", {
-          account_id: truncateAccountId(accountId, 20).toString(),
-          wallet_name: "Wallet",
-        })}
-      </AccountLink>
-    </span>
-  );
-};
+        <AccountLink
+          target="_blank"
+          rel="noopener"
+          href={`${nearWalletProfilePrefix}/${accountId}`}
+        >
+          {t("utils.WalletLink", {
+            account_id: truncateAccountId(accountId, 20).toString(),
+            wallet_name: "Wallet",
+          })}
+        </AccountLink>
+      </span>
+    );
+  }
+);
 
 export default WalletLink;

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -78,65 +78,69 @@ declare module "next/app" {
   }
 }
 
-const App: AppType = ({
-  Component,
-  currentNearNetwork,
-  language,
-  pageProps,
-}) => {
-  if (typeof window !== "undefined" && language) {
-    setMomentLanguage(language);
-    // There is no react way of waiting till i18n is initialized before render
-    // But at the moment SSR should render content properly
-    void initializeI18n(language);
-  }
-  useAnalyticsInit();
-  globalStyles();
+const App: AppType = React.memo(
+  ({ Component, currentNearNetwork, language, pageProps }) => {
+    if (typeof window !== "undefined" && language) {
+      setMomentLanguage(language);
+      // There is no react way of waiting till i18n is initialized before render
+      // But at the moment SSR should render content properly
+      void initializeI18n(language);
+    }
+    useAnalyticsInit();
+    globalStyles();
 
-  const networkState = React.useMemo(
-    () => ({
-      currentNetwork: currentNearNetwork,
-      networks: nearNetworks,
-    }),
-    [currentNearNetwork, nearNetworks]
-  );
+    const networkState = React.useMemo(
+      () => ({
+        currentNetwork: currentNearNetwork,
+        networks: nearNetworks,
+      }),
+      [currentNearNetwork, nearNetworks]
+    );
 
-  return (
-    <>
-      <Head>
-        <link rel="shortcut icon" type="image/png" href="/static/favicon.ico" />
-        <meta name="viewport" content="initial-scale=1.0, width=device-width" />
-      </Head>
-      <NetworkContext.Provider value={networkState}>
-        <AppWrapper>
-          <Header />
-          <BackgroundImage src="/static/images/explorer-bg.svg" />
-          <Component {...pageProps} />
-        </AppWrapper>
-        <Footer />
-      </NetworkContext.Provider>
-      {googleAnalytics ? (
-        <>
-          <script
-            async
-            src={`https://www.googletagmanager.com/gtag/js?id=${googleAnalytics}`}
+    return (
+      <>
+        <Head>
+          <link
+            rel="shortcut icon"
+            type="image/png"
+            href="/static/favicon.ico"
           />
-          <script
-            dangerouslySetInnerHTML={{
-              __html: `
+          <meta
+            name="viewport"
+            content="initial-scale=1.0, width=device-width"
+          />
+        </Head>
+        <NetworkContext.Provider value={networkState}>
+          <AppWrapper>
+            <Header />
+            <BackgroundImage src="/static/images/explorer-bg.svg" />
+            <Component {...pageProps} />
+          </AppWrapper>
+          <Footer />
+        </NetworkContext.Provider>
+        {googleAnalytics ? (
+          <>
+            <script
+              async
+              src={`https://www.googletagmanager.com/gtag/js?id=${googleAnalytics}`}
+            />
+            <script
+              dangerouslySetInnerHTML={{
+                __html: `
                 window.dataLayer = window.dataLayer || [];
                 function gtag(){dataLayer.push(arguments);}
                 gtag('js', new Date());
 
                 gtag('config', '${googleAnalytics}');
               `,
-            }}
-          />
-        </>
-      ) : null}
-    </>
-  );
-};
+              }}
+            />
+          </>
+        ) : null}
+      </>
+    );
+  }
+);
 
 App.getInitialProps = async (appContext) => {
   const req = appContext.ctx.req;

--- a/frontend/src/pages/_document.tsx
+++ b/frontend/src/pages/_document.tsx
@@ -11,11 +11,11 @@ import * as React from "react";
 import { getCssText } from "../libraries/styles";
 
 interface DocumentType {
-  (props: DocumentProps): React.ReactElement;
+  (props: DocumentProps): React.ReactNode;
   getInitialProps?: (context: DocumentContext) => Promise<DocumentInitialProps>;
 }
 
-const Document: DocumentType = () => {
+const Document: DocumentType = React.memo(() => {
   return (
     <Html>
       <Head>
@@ -39,7 +39,7 @@ const Document: DocumentType = () => {
       </body>
     </Html>
   );
-};
+});
 
 Document.getInitialProps = NextDocument.getInitialProps;
 

--- a/frontend/src/pages/accounts/[id].tsx
+++ b/frontend/src/pages/accounts/[id].tsx
@@ -16,6 +16,7 @@ import wampApi from "../../libraries/wamp/api";
 import { getNearNetwork } from "../../libraries/config";
 import { Account, getAccount } from "../../providers/accounts";
 import { styled } from "../../libraries/styles";
+import * as React from "react";
 
 const TransactionIcon = styled(TransactionIconSvg, {
   width: 22,
@@ -28,59 +29,56 @@ interface Props {
   accountError?: unknown;
 }
 
-const AccountDetail: NextPage<Props> = ({
-  accountId,
-  account,
-  accountError,
-  accountFetchingError,
-}) => {
-  const { t } = useTranslation();
-  useAnalyticsTrackOnMount("Explorer View Individual Account", {
-    accountId,
-  });
+const AccountDetail: NextPage<Props> = React.memo(
+  ({ accountId, account, accountError, accountFetchingError }) => {
+    const { t } = useTranslation();
+    useAnalyticsTrackOnMount("Explorer View Individual Account", {
+      accountId,
+    });
 
-  return (
-    <>
-      <Head>
-        <title>NEAR Explorer | Account</title>
-      </Head>
-      <Content
-        title={
-          <h1>
-            {t("common.accounts.account")}
-            {`: @${accountId}`}
-          </h1>
-        }
-        border={false}
-      >
-        {account ? (
-          <AccountDetails account={account} />
-        ) : accountError ? (
-          t("page.accounts.error.account_not_found", {
-            account_id: accountId,
-          })
-        ) : (
-          t("page.accounts.error.account_fetching", {
-            account_id: accountId,
-          })
+    return (
+      <>
+        <Head>
+          <title>NEAR Explorer | Account</title>
+        </Head>
+        <Content
+          title={
+            <h1>
+              {t("common.accounts.account")}
+              {`: @${accountId}`}
+            </h1>
+          }
+          border={false}
+        >
+          {account ? (
+            <AccountDetails account={account} />
+          ) : accountError ? (
+            t("page.accounts.error.account_not_found", {
+              account_id: accountId,
+            })
+          ) : (
+            t("page.accounts.error.account_fetching", {
+              account_id: accountId,
+            })
+          )}
+        </Content>
+        {accountError || accountFetchingError ? null : (
+          <>
+            <Container>
+              <ContractDetails accountId={accountId} />
+            </Container>
+            <Content
+              icon={<TransactionIcon />}
+              title={<h2>{t("common.transactions.transactions")}</h2>}
+            >
+              <Transactions accountId={accountId} count={10} />
+            </Content>
+          </>
         )}
-      </Content>
-      {accountError || accountFetchingError ? null : (
-        <>
-          <Container>
-            <ContractDetails accountId={accountId} />
-          </Container>
-          <Content
-            icon={<TransactionIcon />}
-            title={<h2>{t("common.transactions.transactions")}</h2>}
-          >
-            <Transactions accountId={accountId} count={10} />
-          </Content>
-        </>
-      )}
-    </>
-  );
-};
+      </>
+    );
+  }
+);
 
 export const getServerSideProps: GetServerSideProps<
   Props,

--- a/frontend/src/pages/accounts/index.tsx
+++ b/frontend/src/pages/accounts/index.tsx
@@ -6,8 +6,9 @@ import Content from "../../components/utils/Content";
 import { useTranslation } from "react-i18next";
 import { NextPage } from "next";
 import { useAnalyticsTrackOnMount } from "../../hooks/analytics/use-analytics-track-on-mount";
+import * as React from "react";
 
-const AccountsPage: NextPage = () => {
+const AccountsPage: NextPage = React.memo(() => {
   const { t } = useTranslation();
   useAnalyticsTrackOnMount("Explorer View Accounts Page");
 
@@ -21,6 +22,6 @@ const AccountsPage: NextPage = () => {
       </Content>
     </>
   );
-};
+});
 
 export default AccountsPage;

--- a/frontend/src/pages/blocks/[hash].tsx
+++ b/frontend/src/pages/blocks/[hash].tsx
@@ -15,6 +15,7 @@ import { getNearNetwork } from "../../libraries/config";
 import wampApi from "../../libraries/wamp/api";
 import { Block, getBlock } from "../../providers/blocks";
 import { styled } from "../../libraries/styles";
+import * as React from "react";
 
 const TransactionIcon = styled(TransactionIconSvg, {
   width: 22,
@@ -26,7 +27,7 @@ type Props = {
   err?: unknown;
 };
 
-const BlockDetail: NextPage<Props> = (props) => {
+const BlockDetail: NextPage<Props> = React.memo((props) => {
   const { t } = useTranslation();
   useAnalyticsTrackOnMount("Explorer View Individual Block", {
     block: props.hash,
@@ -78,7 +79,7 @@ const BlockDetail: NextPage<Props> = (props) => {
       ) : null}
     </>
   );
-};
+});
 
 export const getServerSideProps: GetServerSideProps<
   Props,

--- a/frontend/src/pages/blocks/index.tsx
+++ b/frontend/src/pages/blocks/index.tsx
@@ -6,8 +6,9 @@ import Content from "../../components/utils/Content";
 import { useTranslation } from "react-i18next";
 import { NextPage } from "next";
 import { useAnalyticsTrackOnMount } from "../../hooks/analytics/use-analytics-track-on-mount";
+import * as React from "react";
 
-const BlocksPage: NextPage = () => {
+const BlocksPage: NextPage = React.memo(() => {
   const { t } = useTranslation();
   useAnalyticsTrackOnMount("Explorer View Blocks Page");
 
@@ -21,6 +22,6 @@ const BlocksPage: NextPage = () => {
       </Content>
     </>
   );
-};
+});
 
 export default BlocksPage;

--- a/frontend/src/pages/contracts/index.tsx
+++ b/frontend/src/pages/contracts/index.tsx
@@ -1,14 +1,15 @@
 import { NextPage } from "next";
 import Head from "next/head";
 import Content from "../../components/utils/Content";
+import * as React from "react";
 
-const Contracts: NextPage = () => (
+const Contracts: NextPage = React.memo(() => (
   <>
     <Head>
       <title>NEAR Explorer | Contracts</title>
     </Head>
     <Content title={<h1>Contracts</h1>}></Content>
   </>
-);
+));
 
 export default Contracts;

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -10,6 +10,8 @@ import { useTranslation } from "react-i18next";
 import { useAnalyticsTrackOnMount } from "../hooks/analytics/use-analytics-track-on-mount";
 import { styled } from "../libraries/styles";
 import { DashboardCardWrapper } from "../components/utils/DashboardCard";
+import * as React from "react";
+import { NextPage } from "next";
 
 const InnerContent = styled(Row, {
   margin: "71px 185px",
@@ -47,7 +49,7 @@ const DashboardContainer = styled(Container, {
   },
 });
 
-const Dashboard = () => {
+const Dashboard: NextPage = React.memo(() => {
   const { t } = useTranslation();
   useAnalyticsTrackOnMount("Explorer View Landing Page");
 
@@ -84,6 +86,6 @@ const Dashboard = () => {
       </DashboardContainer>
     </>
   );
-};
+});
 
 export default Dashboard;

--- a/frontend/src/pages/nodes/online-nodes.tsx
+++ b/frontend/src/pages/nodes/online-nodes.tsx
@@ -15,6 +15,7 @@ import {
   useFinalBlockTimestampNanosecond,
 } from "../../hooks/data";
 import { styled } from "../../libraries/styles";
+import * as React from "react";
 
 const OnlineNodesWrapper = styled(Content, {
   backgroundColor: "#ffffff",
@@ -39,7 +40,7 @@ const ContentHeaderWrapper = styled(ContentHeader, {
   },
 });
 
-const OnlineNodes: NextPage = () => {
+const OnlineNodes: NextPage = React.memo(() => {
   useAnalyticsTrackOnMount("Explorer View Online Node page");
 
   const networkStats = useNetworkStats();
@@ -83,6 +84,6 @@ const OnlineNodes: NextPage = () => {
       </OnlineNodesWrapper>
     </>
   );
-};
+});
 
 export default OnlineNodes;

--- a/frontend/src/pages/nodes/validators.tsx
+++ b/frontend/src/pages/nodes/validators.tsx
@@ -17,6 +17,7 @@ import {
   useFinalBlockTimestampNanosecond,
 } from "../../hooks/data";
 import { styled } from "../../libraries/styles";
+import * as React from "react";
 
 const NodesPage = styled(Content, {
   backgroundColor: "#ffffff",
@@ -46,7 +47,7 @@ const ValidatorsWrapper = styled(Container, {
   paddingBottom: 50,
 });
 
-const ValidatorsPage: NextPage = () => {
+const ValidatorsPage: NextPage = React.memo(() => {
   useAnalyticsTrackOnMount("Explorer View Validator Node page");
 
   const networkStats = useNetworkStats();
@@ -106,6 +107,6 @@ const ValidatorsPage: NextPage = () => {
       </NodesPage>
     </>
   );
-};
+});
 
 export default ValidatorsPage;

--- a/frontend/src/pages/partner/index.tsx
+++ b/frontend/src/pages/partner/index.tsx
@@ -6,8 +6,9 @@ import PartnerTotalTransactionList from "../../components/stats/PartnerTotalTran
 import PartnerFirst3MonthTransactionslist from "../../components/stats/PartnerFirst3MonthTransactionsList";
 import { NextPage } from "next";
 import { useAnalyticsTrackOnMount } from "../../hooks/analytics/use-analytics-track-on-mount";
+import * as React from "react";
 
-const Partner: NextPage = () => {
+const Partner: NextPage = React.memo(() => {
   useAnalyticsTrackOnMount("Explorer View Partner page");
 
   return (
@@ -26,6 +27,6 @@ const Partner: NextPage = () => {
       </Content>
     </>
   );
-};
+});
 
 export default Partner;

--- a/frontend/src/pages/stats/index.tsx
+++ b/frontend/src/pages/stats/index.tsx
@@ -16,6 +16,7 @@ import { useNetworkContext } from "../../hooks/use-network-context";
 import { useTranslation } from "react-i18next";
 import { NextPage } from "next";
 import { useAnalyticsTrackOnMount } from "../../hooks/analytics/use-analytics-track-on-mount";
+import * as React from "react";
 
 const chartStyle = {
   height: 480,
@@ -24,7 +25,7 @@ const chartStyle = {
   marginLeft: 24,
 };
 
-const Stats: NextPage = () => {
+const Stats: NextPage = React.memo(() => {
   const { t } = useTranslation();
   useAnalyticsTrackOnMount("Explorer View Stats page");
   const { currentNetwork } = useNetworkContext();
@@ -77,6 +78,6 @@ const Stats: NextPage = () => {
       </Content>
     </>
   );
-};
+});
 
 export default Stats;

--- a/frontend/src/pages/transactions/[hash].tsx
+++ b/frontend/src/pages/transactions/[hash].tsx
@@ -25,6 +25,7 @@ import {
 import wampApi from "../../libraries/wamp/api";
 import { getNearNetwork } from "../../libraries/config";
 import { styled } from "../../libraries/styles";
+import * as React from "react";
 
 const TransactionIcon = styled(TransactionIconSvg, {
   width: 22,
@@ -36,7 +37,7 @@ type Props = {
   err?: unknown;
 };
 
-const TransactionDetailsPage: NextPage<Props> = (props) => {
+const TransactionDetailsPage: NextPage<Props> = React.memo((props) => {
   const { t } = useTranslation();
   useAnalyticsTrackOnMount("Explorer View Individual Transaction Page", {
     transaction_hash: props.hash,
@@ -99,7 +100,7 @@ const TransactionDetailsPage: NextPage<Props> = (props) => {
       )}
     </>
   );
-};
+});
 
 export type TransactionOutcome = {
   id: string;

--- a/frontend/src/pages/transactions/index.tsx
+++ b/frontend/src/pages/transactions/index.tsx
@@ -6,8 +6,9 @@ import Transactions from "../../components/transactions/Transactions";
 import { useTranslation } from "react-i18next";
 import { NextPage } from "next";
 import { useAnalyticsTrackOnMount } from "../../hooks/analytics/use-analytics-track-on-mount";
+import * as React from "react";
 
-const TransactionsPage: NextPage = () => {
+const TransactionsPage: NextPage = React.memo(() => {
   const { t } = useTranslation();
   useAnalyticsTrackOnMount("Explorer View Transactions Page");
 
@@ -21,6 +22,6 @@ const TransactionsPage: NextPage = () => {
       </Content>
     </>
   );
-};
+});
 
 export default TransactionsPage;

--- a/frontend/src/testing/utils.tsx
+++ b/frontend/src/testing/utils.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { setI18n } from "react-i18next";
 import renderer, {
   ReactTestRenderer,

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -28,6 +28,7 @@
   "include": [
     "next-env.d.ts",
     "additional.d.ts",
+    "svg.d.ts",
     "i18n.d.ts",
     "**/*.ts",
     "**/*.tsx"


### PR DESCRIPTION
This PR should raise a discussion about using namespaces.
Should it be
```
import * as React from 'react';
const MyComp: React.FC = () => {...};
```
or
```
import {FC} from 'react';
const MyComp: FC = () => {...};
```
?

The chosen option should be enforced by linter.
@shelegdmitriy any ideas?