### PR TITLE
Feature: render.com plan change

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -4,6 +4,7 @@ services:
   - type: web
     name: frontend
     env: node
+    plan: starter plus
     repo: https://github.com/near/near-explorer.git
     buildCommand: cd frontend && npm clean-install && npm run build
     startCommand: cd frontend && npm run start
@@ -57,7 +58,7 @@ services:
   - type: web
     name: wamp
     env: docker
-    plan: pro plus
+    plan: standard
     previewPlan: starter
     dockerfilePath: ./wamp/Dockerfile
     dockerContext: ./wamp


### PR DESCRIPTION
In this PR:
- we upgrade plan for `frontend` service as it is not a docker image at the moment and required more RAM (will fix later);
- we downgrade plan for `wamp` service as it usually doesn't consume more than 2GB RAM and 1 CPU, if it does - something's wrong.