### PR TITLE
Fix: validators fee as null

### DIFF
--- a/frontend/src/components/nodes/ValidatorMainRow.tsx
+++ b/frontend/src/components/nodes/ValidatorMainRow.tsx
@@ -61,6 +61,7 @@ interface Props {
   stakingStatus?: StakingStatus;
   publicKey?: string;
   stakingPoolInfo?: StakingPoolInfo;
+  currentStake?: string;
   proposedStakeForNextEpoch?: string;
   cumulativeStake: number;
   totalStakeInPersnt: number;
@@ -83,13 +84,13 @@ const ValidatorMainRow: React.FC<Props> = React.memo(
     stakingStatus,
     publicKey,
     stakingPoolInfo,
+    currentStake,
     proposedStakeForNextEpoch,
     cumulativeStake,
     totalStakeInPersnt,
     handleClick,
   }) => {
     const { t } = useTranslation();
-    const currentStake = stakingPoolInfo?.currentStake;
     const stakeProposedAmount =
       currentStake &&
       proposedStakeForNextEpoch &&

--- a/frontend/src/components/nodes/ValidatorMainRow.tsx
+++ b/frontend/src/components/nodes/ValidatorMainRow.tsx
@@ -9,7 +9,7 @@ import { OrderTableCell, TableRow } from "../utils/Table";
 import CountryFlag from "../utils/CountryFlag";
 import ValidatingLabel from "./ValidatingLabel";
 import CumulativeStakeChart from "./CumulativeStakeChart";
-import { StakingStatus } from "../../libraries/wamp/types";
+import { StakingPoolInfo, StakingStatus } from "../../libraries/wamp/types";
 import { styled } from "../../libraries/styles";
 
 const ValidatorNodesText = styled(Col, {
@@ -60,9 +60,7 @@ interface Props {
   country?: string;
   stakingStatus?: StakingStatus;
   publicKey?: string;
-  validatorFee?: string | null;
-  validatorDelegators?: number | string | null;
-  currentStake?: string;
+  stakingPoolInfo?: StakingPoolInfo;
   proposedStakeForNextEpoch?: string;
   cumulativeStake: number;
   totalStakeInPersnt: number;
@@ -84,15 +82,14 @@ const ValidatorMainRow: React.FC<Props> = React.memo(
     country,
     stakingStatus,
     publicKey,
-    validatorFee,
-    validatorDelegators,
-    currentStake,
+    stakingPoolInfo,
     proposedStakeForNextEpoch,
     cumulativeStake,
     totalStakeInPersnt,
     handleClick,
   }) => {
     const { t } = useTranslation();
+    const currentStake = stakingPoolInfo?.currentStake;
     const stakeProposedAmount =
       currentStake &&
       proposedStakeForNextEpoch &&
@@ -224,21 +221,25 @@ const ValidatorMainRow: React.FC<Props> = React.memo(
           </td>
 
           <td>
-            {validatorFee === undefined ? (
+            {stakingPoolInfo === undefined ? (
               <Spinner animation="border" size="sm" />
-            ) : validatorFee === null ? (
+            ) : stakingPoolInfo.fee === null ? (
               t("common.state.not_available")
             ) : (
-              validatorFee
+              `${(
+                (stakingPoolInfo.fee.numerator /
+                  stakingPoolInfo.fee.denominator) *
+                100
+              ).toFixed(0)}%`
             )}
           </td>
           <td>
-            {validatorDelegators === undefined ? (
+            {stakingPoolInfo === undefined ? (
               <Spinner animation="border" size="sm" />
-            ) : validatorDelegators === null ? (
+            ) : stakingPoolInfo.delegatorsCount === null ? (
               t("common.state.not_available")
             ) : (
-              validatorDelegators
+              stakingPoolInfo.delegatorsCount
             )}
           </td>
           <StakeText as="td" className="text-right">

--- a/frontend/src/components/nodes/ValidatorRow.tsx
+++ b/frontend/src/components/nodes/ValidatorRow.tsx
@@ -60,13 +60,9 @@ const ValidatorRow: React.FC<Props> = React.memo(
     let totalStakeInPersnt = 0;
     let cumulativeStake = 0;
 
-    if (
-      node.stakingPoolInfo?.currentStake &&
-      totalStake &&
-      !totalStake.isZero()
-    ) {
+    if (node.currentStake && totalStake && !totalStake.isZero()) {
       totalStakeInPersnt =
-        new BN(node.stakingPoolInfo.currentStake)
+        new BN(node.currentStake)
           .mul(new BN(10000))
           .div(totalStake)
           .toNumber() / 100;
@@ -74,11 +70,7 @@ const ValidatorRow: React.FC<Props> = React.memo(
 
     const cumulativeStakeAmount =
       node.cumulativeStakeAmount && new BN(node.cumulativeStakeAmount);
-    if (
-      node.stakingPoolInfo?.currentStake &&
-      totalStake &&
-      cumulativeStakeAmount
-    ) {
+    if (node.currentStake && totalStake && cumulativeStakeAmount) {
       cumulativeStake =
         cumulativeStakeAmount.mul(new BN(10000)).div(totalStake).toNumber() /
         100;
@@ -105,6 +97,7 @@ const ValidatorRow: React.FC<Props> = React.memo(
           publicKey={node.public_key}
           stakingPoolInfo={node.stakingPoolInfo}
           proposedStakeForNextEpoch={node.proposedStake}
+          currentStake={node.currentStake}
           cumulativeStake={cumulativeStake}
           totalStakeInPersnt={totalStakeInPersnt}
           handleClick={switchRowActive}

--- a/frontend/src/components/nodes/ValidatorRow.tsx
+++ b/frontend/src/components/nodes/ValidatorRow.tsx
@@ -59,22 +59,14 @@ const ValidatorRow: React.FC<Props> = React.memo(
     ]);
     let totalStakeInPersnt = 0;
     let cumulativeStake = 0;
-    let validatorFee =
-      typeof node.fee === "undefined"
-        ? undefined
-        : node.fee === null
-        ? null
-        : `${((node.fee.numerator / node.fee.denominator) * 100).toFixed(0)}%`;
-    let validatorDelegators =
-      typeof node.delegatorsCount === "undefined"
-        ? undefined
-        : node.delegatorsCount === null
-        ? null
-        : node.delegatorsCount;
 
-    if (node.currentStake && totalStake) {
+    if (
+      node.stakingPoolInfo?.currentStake &&
+      totalStake &&
+      !totalStake.isZero()
+    ) {
       totalStakeInPersnt =
-        new BN(node.currentStake)
+        new BN(node.stakingPoolInfo.currentStake)
           .mul(new BN(10000))
           .div(totalStake)
           .toNumber() / 100;
@@ -82,7 +74,11 @@ const ValidatorRow: React.FC<Props> = React.memo(
 
     const cumulativeStakeAmount =
       node.cumulativeStakeAmount && new BN(node.cumulativeStakeAmount);
-    if (node.currentStake && totalStake && cumulativeStakeAmount) {
+    if (
+      node.stakingPoolInfo?.currentStake &&
+      totalStake &&
+      cumulativeStakeAmount
+    ) {
       cumulativeStake =
         cumulativeStakeAmount.mul(new BN(10000)).div(totalStake).toNumber() /
         100;
@@ -107,9 +103,7 @@ const ValidatorRow: React.FC<Props> = React.memo(
           country={node.poolDetails?.country}
           stakingStatus={node.stakingStatus}
           publicKey={node.public_key}
-          validatorFee={validatorFee}
-          validatorDelegators={validatorDelegators}
-          currentStake={node.currentStake}
+          stakingPoolInfo={node.stakingPoolInfo}
           proposedStakeForNextEpoch={node.proposedStake}
           cumulativeStake={cumulativeStake}
           totalStakeInPersnt={totalStakeInPersnt}

--- a/frontend/src/components/nodes/ValidatorsList.tsx
+++ b/frontend/src/components/nodes/ValidatorsList.tsx
@@ -16,6 +16,10 @@ interface Props {
   };
 }
 
+const getCurrentStake = (node: ValidationNodeInfo): string => {
+  return (node.stakingPoolInfo && node.stakingPoolInfo.currentStake) || "0";
+};
+
 const ValidatorsList: React.FC<Props> = React.memo(
   ({ validators, pages: { startPage, endPage, activePage, itemsPerPage } }) => {
     let validatorsList = validators.sort((a, b) => {
@@ -28,8 +32,10 @@ const ValidatorsList: React.FC<Props> = React.memo(
       const bInValidatingGroup =
         b.stakingStatus && validatingGroup.indexOf(b.stakingStatus) >= 0;
 
+      const aCurrentStake = getCurrentStake(a);
+      const bCurrentStake = getCurrentStake(b);
       if (aInValidatingGroup && bInValidatingGroup) {
-        return new BN(b.currentStake || 0).cmp(new BN(a.currentStake || 0));
+        return new BN(bCurrentStake).cmp(new BN(aCurrentStake));
       } else if (aInValidatingGroup) {
         return -1;
       } else if (bInValidatingGroup) {
@@ -37,11 +43,11 @@ const ValidatorsList: React.FC<Props> = React.memo(
       } else {
         const aStake = BN.max(
           new BN(b.proposedStake || 0),
-          new BN(b.currentStake || 0)
+          new BN(bCurrentStake)
         );
         const bStake = BN.max(
           new BN(a.proposedStake || 0),
-          new BN(a.currentStake || 0)
+          new BN(aCurrentStake)
         );
         return aStake.cmp(bStake);
       }
@@ -54,15 +60,16 @@ const ValidatorsList: React.FC<Props> = React.memo(
         i.stakingStatus && ["active", "leaving"].indexOf(i.stakingStatus) >= 0
     );
 
+    console.log("act", activeValidatorsList);
     const totalStake = activeValidatorsList.reduce(
-      (acc, node) => acc.add(new BN(node.currentStake || 0)),
+      (acc, node) => acc.add(new BN(getCurrentStake(node))),
       new BN(0)
     );
 
     activeValidatorsList.forEach((validator, index) => {
       let total = new BN(0);
       for (let i = 0; i <= index; i++) {
-        total = total.add(new BN(activeValidatorsList[i].currentStake || 0));
+        total = total.add(new BN(getCurrentStake(activeValidatorsList[i])));
         epochValidatorsStake.set(validator.account_id, total);
       }
     });

--- a/frontend/src/components/nodes/ValidatorsList.tsx
+++ b/frontend/src/components/nodes/ValidatorsList.tsx
@@ -17,7 +17,7 @@ interface Props {
 }
 
 const getCurrentStake = (node: ValidationNodeInfo): string => {
-  return (node.stakingPoolInfo && node.stakingPoolInfo.currentStake) || "0";
+  return node.currentStake || "0";
 };
 
 const ValidatorsList: React.FC<Props> = React.memo(
@@ -60,7 +60,6 @@ const ValidatorsList: React.FC<Props> = React.memo(
         i.stakingStatus && ["active", "leaving"].indexOf(i.stakingStatus) >= 0
     );
 
-    console.log("act", activeValidatorsList);
     const totalStake = activeValidatorsList.reduce(
       (acc, node) => acc.add(new BN(getCurrentStake(node))),
       new BN(0)

--- a/frontend/src/components/nodes/__test__/validators.tsx
+++ b/frontend/src/components/nodes/__test__/validators.tsx
@@ -18,7 +18,14 @@ export const VALIDATORS_LIST: ValidationNodeInfo[] = [
     public_key: "ed25519:3JBVXqenru2ErAM1kHQ8qfd29dCkURLd6JKrFgtmcDTZ",
     shards: [0],
     stakingStatus: "active",
-    currentStake: "42476926077593266003727024545752",
+    stakingPoolInfo: {
+      fee: {
+        numerator: 10,
+        denominator: 100,
+      },
+      delegatorsCount: 874,
+      currentStake: "42476926077593266003727024545752",
+    },
     proposedStake: "42585554199314238406961230826241",
     nodeInfo: {
       ipAddress: "44.226.195.207",
@@ -33,11 +40,6 @@ export const VALIDATORS_LIST: ValidationNodeInfo[] = [
       longitude: "-119.7143",
       city: "Boardman",
     },
-    fee: {
-      numerator: 10,
-      denominator: 100,
-    },
-    delegatorsCount: 874,
     cumulativeStakeAmount: "42476926077593266003727024545752",
   },
   // 'active' without poolDetails
@@ -57,7 +59,14 @@ export const VALIDATORS_LIST: ValidationNodeInfo[] = [
     public_key: "ed25519:Emk6wQJtpQZRJCvvPmmwP9GD2Pk37xxRpmb5uRvJpX62",
     shards: [0],
     stakingStatus: "active",
-    currentStake: "20814924218405478221870785686346",
+    stakingPoolInfo: {
+      fee: {
+        numerator: 10,
+        denominator: 100,
+      },
+      delegatorsCount: 436,
+      currentStake: "20814924218405478221870785686346",
+    },
     proposedStake: "20816469293003621239852045782324",
     nodeInfo: {
       ipAddress: "34.222.123.106",
@@ -72,11 +81,6 @@ export const VALIDATORS_LIST: ValidationNodeInfo[] = [
       longitude: "-119.7143",
       city: "Boardman",
     },
-    fee: {
-      numerator: 10,
-      denominator: 100,
-    },
-    delegatorsCount: 436,
     cumulativeStakeAmount: "63291850295998744225597810232098",
   },
   // 'active' with all data
@@ -96,7 +100,14 @@ export const VALIDATORS_LIST: ValidationNodeInfo[] = [
     public_key: "ed25519:2nPSBCzjqikgwrqUMcuEVReJhmkC91eqJGPGqH9sZc28",
     shards: [0],
     stakingStatus: "active",
-    currentStake: "17776328380244893436869022330562",
+    stakingPoolInfo: {
+      fee: {
+        numerator: 1,
+        denominator: 100,
+      },
+      delegatorsCount: 1774,
+      currentStake: "17776328380244893436869022330562",
+    },
     proposedStake: "17777040818619949427934165446355",
     nodeInfo: {
       ipAddress: "145.239.1.147",
@@ -111,11 +122,6 @@ export const VALIDATORS_LIST: ValidationNodeInfo[] = [
       longitude: "9.491",
       city: "",
     },
-    fee: {
-      numerator: 1,
-      denominator: 100,
-    },
-    delegatorsCount: 1774,
     poolDetails: {
       twitter: "@astrostakers",
       url: "astrostakers.com",
@@ -132,7 +138,14 @@ export const VALIDATORS_LIST: ValidationNodeInfo[] = [
     public_key: "ed25519:E4LAWdgLifBEoaWvhRNy5vpdAnUc3GsUHePeiAurZY5v",
     shards: [0],
     stakingStatus: "joining",
-    currentStake: "3735553291238507324807526403326",
+    stakingPoolInfo: {
+      fee: {
+        numerator: 3,
+        denominator: 100,
+      },
+      delegatorsCount: 148,
+      currentStake: "3735553291238507324807526403326",
+    },
     proposedStake: "3736122287791333873791529790832",
     nodeInfo: {
       ipAddress: "135.181.24.210",
@@ -147,11 +160,6 @@ export const VALIDATORS_LIST: ValidationNodeInfo[] = [
       longitude: "-79.3716",
       city: "",
     },
-    fee: {
-      numerator: 3,
-      denominator: 100,
-    },
-    delegatorsCount: 148,
     poolDetails: {
       email: "baziliknear@gmail.com",
       description: "pool commission 0% until 01.01.2021, then 1%",
@@ -162,7 +170,14 @@ export const VALIDATORS_LIST: ValidationNodeInfo[] = [
   {
     account_id: "cryptium.poolv1.near",
     public_key: "ed25519:5Y9hW8cKBb5RnsJBqttHHC5ujz5zcZZ5xnrJPwkCWmGQ",
-    currentStake: "",
+    stakingPoolInfo: {
+      fee: {
+        numerator: 5,
+        denominator: 100,
+      },
+      delegatorsCount: 129,
+      currentStake: null,
+    },
     proposedStake: "2656963060607021394774204108064",
     stakingStatus: "proposal",
     nodeInfo: {
@@ -178,11 +193,6 @@ export const VALIDATORS_LIST: ValidationNodeInfo[] = [
       longitude: "-79.3716",
       city: "",
     },
-    fee: {
-      numerator: 5,
-      denominator: 100,
-    },
-    delegatorsCount: 129,
     poolDetails: {
       country_code: "CH",
       description: "Secure and available validation from the Swiss Alps!",
@@ -194,12 +204,14 @@ export const VALIDATORS_LIST: ValidationNodeInfo[] = [
   // newcomer
   {
     account_id: "huobipool.poolv1.near",
-    fee: {
-      numerator: 10,
-      denominator: 100,
+    stakingPoolInfo: {
+      fee: {
+        numerator: 10,
+        denominator: 100,
+      },
+      delegatorsCount: 10,
+      currentStake: "1200162400050342684350218962960",
     },
-    delegatorsCount: 10,
-    currentStake: "1200162400050342684350218962960",
     stakingStatus: "newcomer",
   },
   // idle
@@ -218,23 +230,27 @@ export const VALIDATORS_LIST: ValidationNodeInfo[] = [
       longitude: "-119.7143",
       city: "Boardman",
     },
-    fee: {
-      numerator: 7,
-      denominator: 100,
+    stakingPoolInfo: {
+      fee: {
+        numerator: 7,
+        denominator: 100,
+      },
+      delegatorsCount: 9,
+      currentStake: "442471954465888931932802773752",
     },
-    delegatorsCount: 9,
-    currentStake: "442471954465888931932802773752",
     stakingStatus: "idle",
   },
   // idle with minimum data
   {
     account_id: "sphere.poolv1.near",
-    fee: {
-      numerator: 8,
-      denominator: 100,
+    stakingPoolInfo: {
+      fee: {
+        numerator: 8,
+        denominator: 100,
+      },
+      delegatorsCount: 1,
+      currentStake: "50000867090131772400000000",
     },
-    delegatorsCount: 1,
-    currentStake: "50000867090131772400000000",
     stakingStatus: "idle",
   },
   // leaving
@@ -254,7 +270,14 @@ export const VALIDATORS_LIST: ValidationNodeInfo[] = [
     public_key: "ed25519:5xz7EbcnPqabwoFezdJBxieK8S7XLsdHHuLwM4vLLhFt",
     shards: [0],
     stakingStatus: "leaving",
-    currentStake: "3632096312066963778697815591239",
+    stakingPoolInfo: {
+      fee: {
+        numerator: 1,
+        denominator: 100,
+      },
+      delegatorsCount: 512,
+      currentStake: "3632096312066963778697815591239",
+    },
     proposedStake: "3628588479796309298011827055582",
     nodeInfo: {
       ipAddress: "91.207.102.230",
@@ -269,11 +292,6 @@ export const VALIDATORS_LIST: ValidationNodeInfo[] = [
       longitude: "25",
       city: "",
     },
-    fee: {
-      numerator: 1,
-      denominator: 100,
-    },
-    delegatorsCount: 512,
     poolDetails: {
       country_code: "ro",
       email: "hello@01node.com",
@@ -290,6 +308,7 @@ export const VALIDATORS_TOTAL_STAKE = VALIDATORS_LIST.filter(
   (i: ValidationNodeInfo) =>
     i.stakingStatus && ["active", "leaving"].indexOf(i.stakingStatus) >= 0
 ).reduce(
-  (acc: BN, node: ValidationNodeInfo) => acc.add(new BN(node.currentStake!)),
+  (acc: BN, node: ValidationNodeInfo) =>
+    acc.add(new BN(node.stakingPoolInfo!.currentStake!)),
   new BN(0)
 ) as BN;

--- a/frontend/src/components/nodes/__test__/validators.tsx
+++ b/frontend/src/components/nodes/__test__/validators.tsx
@@ -24,8 +24,8 @@ export const VALIDATORS_LIST: ValidationNodeInfo[] = [
         denominator: 100,
       },
       delegatorsCount: 874,
-      currentStake: "42476926077593266003727024545752",
     },
+    currentStake: "42476926077593266003727024545752",
     proposedStake: "42585554199314238406961230826241",
     nodeInfo: {
       ipAddress: "44.226.195.207",
@@ -65,8 +65,8 @@ export const VALIDATORS_LIST: ValidationNodeInfo[] = [
         denominator: 100,
       },
       delegatorsCount: 436,
-      currentStake: "20814924218405478221870785686346",
     },
+    currentStake: "20814924218405478221870785686346",
     proposedStake: "20816469293003621239852045782324",
     nodeInfo: {
       ipAddress: "34.222.123.106",
@@ -106,8 +106,8 @@ export const VALIDATORS_LIST: ValidationNodeInfo[] = [
         denominator: 100,
       },
       delegatorsCount: 1774,
-      currentStake: "17776328380244893436869022330562",
     },
+    currentStake: "17776328380244893436869022330562",
     proposedStake: "17777040818619949427934165446355",
     nodeInfo: {
       ipAddress: "145.239.1.147",
@@ -144,8 +144,8 @@ export const VALIDATORS_LIST: ValidationNodeInfo[] = [
         denominator: 100,
       },
       delegatorsCount: 148,
-      currentStake: "3735553291238507324807526403326",
     },
+    currentStake: "3735553291238507324807526403326",
     proposedStake: "3736122287791333873791529790832",
     nodeInfo: {
       ipAddress: "135.181.24.210",
@@ -176,7 +176,6 @@ export const VALIDATORS_LIST: ValidationNodeInfo[] = [
         denominator: 100,
       },
       delegatorsCount: 129,
-      currentStake: null,
     },
     proposedStake: "2656963060607021394774204108064",
     stakingStatus: "proposal",
@@ -210,8 +209,8 @@ export const VALIDATORS_LIST: ValidationNodeInfo[] = [
         denominator: 100,
       },
       delegatorsCount: 10,
-      currentStake: "1200162400050342684350218962960",
     },
+    currentStake: "1200162400050342684350218962960",
     stakingStatus: "newcomer",
   },
   // idle
@@ -236,8 +235,8 @@ export const VALIDATORS_LIST: ValidationNodeInfo[] = [
         denominator: 100,
       },
       delegatorsCount: 9,
-      currentStake: "442471954465888931932802773752",
     },
+    currentStake: "442471954465888931932802773752",
     stakingStatus: "idle",
   },
   // idle with minimum data
@@ -249,8 +248,8 @@ export const VALIDATORS_LIST: ValidationNodeInfo[] = [
         denominator: 100,
       },
       delegatorsCount: 1,
-      currentStake: "50000867090131772400000000",
     },
+    currentStake: "50000867090131772400000000",
     stakingStatus: "idle",
   },
   // leaving
@@ -276,8 +275,8 @@ export const VALIDATORS_LIST: ValidationNodeInfo[] = [
         denominator: 100,
       },
       delegatorsCount: 512,
-      currentStake: "3632096312066963778697815591239",
     },
+    currentStake: "3632096312066963778697815591239",
     proposedStake: "3628588479796309298011827055582",
     nodeInfo: {
       ipAddress: "91.207.102.230",
@@ -308,7 +307,6 @@ export const VALIDATORS_TOTAL_STAKE = VALIDATORS_LIST.filter(
   (i: ValidationNodeInfo) =>
     i.stakingStatus && ["active", "leaving"].indexOf(i.stakingStatus) >= 0
 ).reduce(
-  (acc: BN, node: ValidationNodeInfo) =>
-    acc.add(new BN(node.stakingPoolInfo!.currentStake!)),
+  (acc: BN, node: ValidationNodeInfo) => acc.add(new BN(node.currentStake!)),
   new BN(0)
 ) as BN;

--- a/frontend/src/libraries/wamp/types.ts
+++ b/frontend/src/libraries/wamp/types.ts
@@ -39,6 +39,22 @@ export interface ValidationProgress {
   };
 }
 
+export type ValidationNodeInfo = {
+  account_id: string;
+  is_slashed?: boolean;
+  progress?: ValidationProgress;
+  public_key?: string;
+  proposedStake?: string;
+  cumulativeStakeAmount?: string;
+  stakingStatus?: StakingStatus;
+  networkHolder?: boolean;
+  shards?: number[];
+  nodeInfo?: NodeInfo;
+  stakingPoolInfo?: StakingPoolInfo;
+  currentStake?: string;
+  poolDetails?: PoolDetails;
+};
+
 export interface PoolDetails {
   country?: string;
   country_code?: string;
@@ -52,22 +68,6 @@ export interface PoolDetails {
 export type StakingPoolInfo = {
   fee: { numerator: number; denominator: number } | null;
   delegatorsCount: number | null;
-  currentStake: string | null;
-};
-
-export type ValidationNodeInfo = {
-  account_id: string;
-  is_slashed?: boolean;
-  progress?: ValidationProgress;
-  public_key?: string;
-  proposedStake?: string;
-  cumulativeStakeAmount?: string;
-  stakingStatus?: StakingStatus;
-  networkHolder?: boolean;
-  shards?: number[];
-  nodeInfo?: NodeInfo;
-  stakingPoolInfo?: StakingPoolInfo;
-  poolDetails?: PoolDetails;
 };
 
 export type NetworkStats = {

--- a/frontend/src/libraries/wamp/types.ts
+++ b/frontend/src/libraries/wamp/types.ts
@@ -38,19 +38,6 @@ export interface ValidationProgress {
     total: number;
   };
 }
-export interface BaseValidationNodeInfo {
-  account_id: string;
-  is_slashed?: boolean;
-  progress?: ValidationProgress;
-  public_key?: string;
-  currentStake?: string;
-  proposedStake?: string;
-  cumulativeStakeAmount?: string;
-  stakingStatus?: StakingStatus;
-  networkHolder?: boolean;
-  shards?: number[];
-  nodeInfo?: NodeInfo;
-}
 
 export interface PoolDetails {
   country?: string;
@@ -62,13 +49,26 @@ export interface PoolDetails {
   url?: string;
 }
 
-export interface StakingPoolInfo {
-  fee?: { numerator: number; denominator: number } | undefined;
-  delegatorsCount?: number;
-  poolDetails?: PoolDetails;
-}
+export type StakingPoolInfo = {
+  fee: { numerator: number; denominator: number } | null;
+  delegatorsCount: number | null;
+  currentStake: string | null;
+};
 
-export type ValidationNodeInfo = BaseValidationNodeInfo & StakingPoolInfo;
+export type ValidationNodeInfo = {
+  account_id: string;
+  is_slashed?: boolean;
+  progress?: ValidationProgress;
+  public_key?: string;
+  proposedStake?: string;
+  cumulativeStakeAmount?: string;
+  stakingStatus?: StakingStatus;
+  networkHolder?: boolean;
+  shards?: number[];
+  nodeInfo?: NodeInfo;
+  stakingPoolInfo?: StakingPoolInfo;
+  poolDetails?: PoolDetails;
+};
 
 export type NetworkStats = {
   currentValidatorsCount: number;


### PR DESCRIPTION
I managed to reproduced the [problem](https://github.com/near/near-explorer/pull/906#issuecomment-1084742726) (kudos to @frol) and fixed it.

The bug was created by migration to typescript.

I decided to make types more semantical - and separate `stakingPoolInfo` to a nested object, removing the need to have types like `Foo | undefined | null`.