### PR TITLE
Bigger interval for pool ids check

### DIFF
--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -82,6 +82,10 @@ export const INTERVALS = {
     "NEAR_REGULAR_PUBLISH_TRANSACTION_COUNT_FOR_TWO_WEEKS_INTERVAL",
     2.5 * SECOND
   ),
+  checkPoolIds: getEnvNumberWithDefault(
+    "NEAR_REGULAR_POOL_IDS_CHECK_INTERVAL",
+    10 * MINUTE
+  ),
 };
 
 const NETWORK_NAMES: Record<NetworkName, true> = {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -28,6 +28,7 @@ async function main(): Promise<void> {
       valueMap: new Map(),
       promisesMap: new Map(),
     },
+    poolIds: [],
   };
   for (const check of regularChecks) {
     if (check.shouldSkip?.()) {

--- a/backend/src/near.ts
+++ b/backend/src/near.ts
@@ -3,7 +3,7 @@ import * as nearApi from "near-api-js";
 import BN from "bn.js";
 
 import { nearArchivalRpcUrl } from "./config";
-import { queryStakingPoolAccountIds, queryOnlineNodesCount } from "./db-utils";
+import { queryOnlineNodesCount } from "./db-utils";
 import {
   NetworkStats,
   ValidationProgress,
@@ -171,16 +171,14 @@ type EpochData = {
   validators: ValidatorEpochData[];
 };
 
-const queryEpochData = async (): Promise<EpochData> => {
+const queryEpochData = async (poolIds: string[]): Promise<EpochData> => {
   const [
     networkProtocolConfig,
     epochStatus,
-    currentPools,
     onlineNodesCount,
   ] = await Promise.all([
     sendJsonRpc("EXPERIMENTAL_protocol_config", { finality: "final" }),
     sendJsonRpc("validators", [null]),
-    queryStakingPoolAccountIds(),
     queryOnlineNodesCount(),
   ]);
   const epochState = await getEpochState(epochStatus, networkProtocolConfig);
@@ -197,7 +195,7 @@ const queryEpochData = async (): Promise<EpochData> => {
       genesisHeight: networkProtocolConfig.genesis_height,
       onlineNodesCount,
     },
-    validators: mapValidators(epochStatus, currentPools),
+    validators: mapValidators(epochStatus, poolIds),
   };
 };
 


### PR DESCRIPTION
Addressing a problem of high CPU utilization of DB - I made a query to get pool ids way less frequent than before.