### PR TITLE
Feature: transaction history as procedure

### DIFF
--- a/backend/src/checks.ts
+++ b/backend/src/checks.ts
@@ -100,15 +100,8 @@ const recentTransactionsCountCheck: RegularCheckFn = {
 
 const transactionCountHistoryCheck: RegularCheckFn = {
   description: "transaction count history for 2 weeks",
-  fn: async (controller, state) => {
-    const history = await queryTransactionsCountHistoryForTwoWeeks();
-    state.transactionsCountHistoryForTwoWeeks = history;
-    void controller.publish("transaction-history", {
-      transactionsCountHistoryForTwoWeeks: history.map(({ date, total }) => ({
-        date: formatDate(date),
-        total,
-      })),
-    });
+  fn: async (_, state) => {
+    state.transactionsCountHistoryForTwoWeeks = await queryTransactionsCountHistoryForTwoWeeks();
   },
   interval: INTERVALS.checkTransactionCountHistory,
 };

--- a/backend/src/procedure-handlers.ts
+++ b/backend/src/procedure-handlers.ts
@@ -11,10 +11,13 @@ import * as accounts from "./accounts";
 import * as telemetry from "./telemetry";
 
 import { sendJsonRpc, sendJsonRpcQuery } from "./near";
+import { GlobalState } from "./checks";
+import { formatDate } from "./utils";
 
 export const procedureHandlers: {
   [P in keyof ProcedureTypes]: (
-    args: ProcedureTypes[P]["args"]
+    args: ProcedureTypes[P]["args"],
+    state: GlobalState
   ) => Promise<ProcedureTypes[P]["result"]>;
 } = {
   "node-telemetry": async ([nodeInfo]) => {
@@ -49,6 +52,13 @@ export const procedureHandlers: {
 
   "get-latest-circulating-supply": async () => {
     return await stats.getLatestCirculatingSupply();
+  },
+
+  "transaction-history": async (_, state) => {
+    return state.transactionsCountHistoryForTwoWeeks.map(({ date, total }) => ({
+      date: formatDate(date),
+      total,
+    }));
   },
 
   // stats part

--- a/backend/src/pubsub.ts
+++ b/backend/src/pubsub.ts
@@ -8,6 +8,7 @@ import {
   wampNearExplorerUrl,
   wampNearExplorerBackendSecret,
 } from "./config";
+import { GlobalState } from "./checks";
 import { SECOND } from "./consts";
 import { procedureHandlers } from "./procedure-handlers";
 
@@ -18,7 +19,7 @@ export type PubSubController = {
   ) => Promise<void>;
 };
 
-export const initPubSub = (): PubSubController => {
+export const initPubSub = (state: GlobalState): PubSubController => {
   console.log(
     `WAMP setup: connecting to ${wampNearExplorerUrl} with ticket ${wampNearExplorerBackendSecret}`
   );
@@ -54,10 +55,7 @@ export const initPubSub = (): PubSubController => {
     for (const [name, handler] of Object.entries(procedureHandlers)) {
       const uri = `com.nearprotocol.${nearNetworkName}.explorer.${name}`;
       try {
-        await session.register(
-          uri,
-          (handler as unknown) as autobahn.RegisterEndpoint
-        );
+        await session.register(uri, (args: any) => handler(args, state));
       } catch (error) {
         console.error(`Failed to register "${uri}" handler due to:`, error);
         wamp.close();

--- a/frontend/src/components/dashboard/DashboardTransaction.tsx
+++ b/frontend/src/components/dashboard/DashboardTransaction.tsx
@@ -9,12 +9,10 @@ import GasPrice from "../utils/GasPrice";
 import Link from "../utils/Link";
 
 import DashboardTransactionsHistoryChart from "./DashboardTransactionsHistoryChart";
-import {
-  useRecentTransactions,
-  useTransactionHistory,
-} from "../../hooks/subscriptions";
+import { useRecentTransactions } from "../../hooks/subscriptions";
 import { useLatestGasPrice } from "../../hooks/data";
 import { styled } from "../../libraries/styles";
+import { useFetch } from "../../hooks/use-fetch";
 
 const TransactionCardNumber = styled(Row, {
   "& > .col-12": {
@@ -30,8 +28,10 @@ const TransactionCharts = styled(Row, {
 
 const DashboardTransaction: React.FC = React.memo(() => {
   const { t } = useTranslation();
-  const transactionsCountHistoryForTwoWeeks = useTransactionHistory()
-    ?.transactionsCountHistoryForTwoWeeks;
+  const transactionsCountHistoryForTwoWeeks = useFetch(
+    "transaction-history",
+    []
+  );
   const recentTransactionsCount = useRecentTransactions()
     ?.recentTransactionsCount;
   const latestGasPrice = useLatestGasPrice();

--- a/frontend/src/components/dashboard/DashboardTransactionsHistoryChart.tsx
+++ b/frontend/src/components/dashboard/DashboardTransactionsHistoryChart.tsx
@@ -6,7 +6,7 @@ import moment from "moment";
 import PaginationSpinner from "../utils/PaginationSpinner";
 
 import { useTranslation } from "react-i18next";
-import { TransactionCountHistory } from "../../types/subscriptions";
+import { TransactionCountHistory } from "../../types/procedures";
 
 const chartsStyle = {
   height: 232,

--- a/frontend/src/hooks/subscriptions.ts
+++ b/frontend/src/hooks/subscriptions.ts
@@ -27,9 +27,6 @@ export const useChainBlockStats = () => useSubscription("chain-blocks-stats");
 export const useRecentTransactions = () =>
   useSubscription("recent-transactions");
 
-export const useTransactionHistory = () =>
-  useSubscription("transaction-history");
-
 export const useFinalityStatus = () => useSubscription("finality-status");
 
 export const useNetworkStats = () => useSubscription("network-stats");

--- a/frontend/src/types/procedures.ts
+++ b/frontend/src/types/procedures.ts
@@ -177,6 +177,11 @@ export type TelemetryRequest = {
   };
 };
 
+export type TransactionCountHistory = {
+  date: string;
+  total: number;
+};
+
 export type ProcedureTypes = {
   "account-info": {
     args: [string];
@@ -354,6 +359,11 @@ export type ProcedureTypes = {
   "node-telemetry": {
     args: [TelemetryRequest];
     result: void;
+  };
+
+  "transaction-history": {
+    args: [];
+    result: TransactionCountHistory[];
   };
 };
 

--- a/frontend/src/types/subscriptions.ts
+++ b/frontend/src/types/subscriptions.ts
@@ -1,8 +1,3 @@
-export type TransactionCountHistory = {
-  date: string;
-  total: number;
-};
-
 export type ValidatorTelemetry = {
   ipAddress: string;
   nodeId: string;
@@ -89,9 +84,6 @@ export type SubscriptionTopicTypes = {
   };
   "recent-transactions": {
     recentTransactionsCount: number;
-  };
-  "transaction-history": {
-    transactionsCountHistoryForTwoWeeks: TransactionCountHistory[];
   };
   "finality-status": {
     finalBlockTimestampNanosecond: string;


### PR DESCRIPTION
@frol 
As a follow-up to out chat - I changed transaction history fetch from subscription to procedure call so we can do it just once and not rely on 10 minute refresh to render it.