### PR TITLE
Refactor: no duplicate network

### DIFF
--- a/frontend.env
+++ b/frontend.env
@@ -1,14 +1,12 @@
 NEAR_EXPLORER_CONFIG__NETWORKS='
-[
-  {
-    "name": "mainnet",
+{
+  "mainnet": {
     "explorerLink": "http://localhost:3000/?network=mainnet",
     "nearWalletProfilePrefix": "https://wallet.near.org/profile"
   },
-  {
-    "name": "testnet",
+  "testnet": {
     "explorerLink": "http://localhost:3000/?network=testnet",
     "nearWalletProfilePrefix": "https://wallet.testnet.near.org/profile"
   }
-]
+}
 '

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -6,6 +6,7 @@ import {
 } from "./src/libraries/config";
 import { merge } from "lodash";
 import { getOverrides } from "./src/libraries/common";
+import { NetworkName } from "./src/types/common";
 
 const defaultBackendConfig: BackendConfig = {
   host: "localhost",
@@ -17,13 +18,7 @@ const config = merge(
   {
     backend: defaultBackendConfig,
     backendSsr: defaultBackendConfig,
-    networks: [
-      {
-        name: "localhostnet",
-        explorerLink: "http://localhost:3000",
-        nearWalletProfilePrefix: "https://wallet.near.org/profile",
-      },
-    ] as NearNetwork[],
+    networks: {} as Partial<Record<NetworkName, NearNetwork>>,
     googleAnalytics: undefined,
   },
   getOverrides("NEAR_EXPLORER_CONFIG")

--- a/frontend/src/__mocks__/next/config.ts
+++ b/frontend/src/__mocks__/next/config.ts
@@ -1,13 +1,5 @@
 import { NextConfig } from "next";
-import type { ExplorerConfig, NearNetwork } from "../../libraries/config";
-
-const nearNetworks: NearNetwork[] = [
-  {
-    name: "localhostnet",
-    explorerLink: "http://localhost:3000",
-    nearWalletProfilePrefix: "https://wallet.near.org/profile",
-  },
-];
+import type { ExplorerConfig } from "../../libraries/config";
 
 const backendConfig = {
   host: "this-could-be-anything",
@@ -16,7 +8,7 @@ const backendConfig = {
 };
 const config: ExplorerConfig & NextConfig = {
   publicRuntimeConfig: {
-    nearNetworks,
+    nearNetworks: {},
     backendConfig,
     googleAnalytics: "",
   },

--- a/frontend/src/components/accounts/AccountDetails.tsx
+++ b/frontend/src/components/accounts/AccountDetails.tsx
@@ -47,7 +47,7 @@ export interface Props {
 
 const AccountDetails: React.FC<Props> = React.memo(({ account }) => {
   const { t } = useTranslation();
-  const { currentNetwork } = useNetworkContext();
+  const { network } = useNetworkContext();
   const transactionCount = useFetch("account-transactions-count", [
     account.accountId,
   ]);
@@ -142,7 +142,8 @@ const AccountDetails: React.FC<Props> = React.memo(({ account }) => {
         )}
       </Row>
       {typeof account.nonStakedBalance !== "undefined" &&
-        typeof account.stakedBalance !== "undefined" && (
+        typeof account.stakedBalance !== "undefined" &&
+        network && (
           <Row noGutters>
             <Col xs="12" md="4">
               <CardCell
@@ -202,9 +203,7 @@ const AccountDetails: React.FC<Props> = React.memo(({ account }) => {
                 text={
                   <WalletLink
                     accountId={account.accountId}
-                    nearWalletProfilePrefix={
-                      currentNetwork.nearWalletProfilePrefix
-                    }
+                    nearWalletProfilePrefix={network.nearWalletProfilePrefix}
                   />
                 }
               />

--- a/frontend/src/components/utils/HeaderNetworkDropdown.tsx
+++ b/frontend/src/components/utils/HeaderNetworkDropdown.tsx
@@ -115,21 +115,21 @@ const IconRight = styled("img", {
 });
 
 const HeaderNetworkDropdown: React.FC = React.memo(() => {
-  const { currentNetwork, networks } = useNetworkContext();
+  const { networkName, networks } = useNetworkContext();
   return (
     <Dropdown>
       <HeaderNetwork variant="secondary">
-        <NetworkIcon network={currentNetwork.name} />
-        {currentNetwork.name}
+        <NetworkIcon network={networkName} />
+        {networkName}
         <IconRight src="/static/images/icon-network-right.svg" />
         <DropdownArrow src="/static/images/down-blue-arrow.svg" />
       </HeaderNetwork>
       <HeaderNetworkDropdownMenu>
-        {networks.map((network) => {
+        {networks.map(([name, network]) => {
           return (
             <HeaderDropdownItem
-              key={network.name}
-              title={network.name}
+              key={name}
+              title={name}
               link={network.explorerLink}
             />
           );

--- a/frontend/src/context/NetworkContext.tsx
+++ b/frontend/src/context/NetworkContext.tsx
@@ -1,9 +1,10 @@
 import * as React from "react";
 import { NearNetwork } from "../libraries/config";
+import { NetworkName } from "../types/common";
 
 export interface NetworkContext {
-  currentNetwork: NearNetwork;
-  networks: NearNetwork[];
+  networkName: NetworkName;
+  networks: Partial<Record<NetworkName, NearNetwork>>;
 }
 
 export const NetworkContext = React.createContext<NetworkContext | undefined>(

--- a/frontend/src/hooks/subscriptions.ts
+++ b/frontend/src/hooks/subscriptions.ts
@@ -7,12 +7,12 @@ import { useNetworkContext } from "./use-network-context";
 const useSubscription = <Topic extends SubscriptionTopicType>(
   topic: Topic
 ): SubscriptionTopicTypes[Topic] | undefined => {
-  const { currentNetwork } = useNetworkContext();
+  const { networkName } = useNetworkContext();
   const [value, setValue] = React.useState<
     SubscriptionTopicTypes[Topic] | undefined
   >();
-  React.useEffect(() => subscribe<Topic>(currentNetwork, topic, setValue), [
-    currentNetwork,
+  React.useEffect(() => subscribe<Topic>(networkName, topic, setValue), [
+    networkName,
     topic,
     setValue,
   ]);

--- a/frontend/src/hooks/use-fetcher.ts
+++ b/frontend/src/hooks/use-fetcher.ts
@@ -3,6 +3,6 @@ import { Fetcher, getFetcher } from "../libraries/transport";
 import { useNetworkContext } from "./use-network-context";
 
 export const useFetcher = (): Fetcher => {
-  const { currentNetwork } = useNetworkContext();
-  return React.useCallback(getFetcher(currentNetwork), [currentNetwork]);
+  const { networkName } = useNetworkContext();
+  return React.useCallback(getFetcher(networkName), [networkName]);
 };

--- a/frontend/src/hooks/use-network-context.ts
+++ b/frontend/src/hooks/use-network-context.ts
@@ -1,10 +1,24 @@
 import * as React from "react";
 import { NetworkContext } from "../context/NetworkContext";
+import { NearNetwork } from "../libraries/config";
+import { NetworkName } from "../types/common";
 
-export const useNetworkContext = (): NetworkContext => {
+export const useNetworkContext = (): {
+  networkName: NetworkName;
+  network?: NearNetwork;
+  networks: [NetworkName, NearNetwork][];
+} => {
   const networkContext = React.useContext(NetworkContext);
   if (!networkContext) {
     throw new Error("Expected to have NEAR network context");
   }
-  return networkContext;
+  const networks = Object.entries(networkContext.networks) as [
+    NetworkName,
+    NearNetwork
+  ][];
+  return {
+    network: networkContext.networks[networkContext.networkName],
+    networkName: networkContext.networkName,
+    networks,
+  };
 };

--- a/frontend/src/libraries/transport.ts
+++ b/frontend/src/libraries/transport.ts
@@ -1,4 +1,4 @@
-import { NearNetwork } from "./config";
+import { NetworkName } from "../types/common";
 import { subscribeTopic, getLastValue, unsubscribeTopic, fetch } from "./wamp";
 import {
   ProcedureType,
@@ -11,7 +11,7 @@ import {
 let subscriptions: Record<string, ((data: any) => void)[]> = {};
 
 export const subscribe = <T extends SubscriptionTopicType>(
-  nearNetwork: NearNetwork,
+  networkName: NetworkName,
   topic: T,
   handler: (data: SubscriptionTopicTypes[T]) => void
 ): (() => void) => {
@@ -19,10 +19,10 @@ export const subscribe = <T extends SubscriptionTopicType>(
     subscriptions[topic] = [];
   }
   subscriptions[topic].push(handler);
-  void subscribeTopic(topic, nearNetwork, (data) =>
+  void subscribeTopic(topic, networkName, (data) =>
     subscriptions[topic].forEach((handler) => handler(data))
   );
-  const lastValue = getLastValue(topic, nearNetwork);
+  const lastValue = getLastValue(topic, networkName);
   if (lastValue) {
     handler(lastValue);
   }
@@ -30,7 +30,7 @@ export const subscribe = <T extends SubscriptionTopicType>(
     subscriptions[topic] = subscriptions[topic].filter(
       (lookupHandler) => lookupHandler !== handler
     );
-    void unsubscribeTopic(topic, nearNetwork);
+    void unsubscribeTopic(topic, networkName);
   };
 };
 
@@ -39,7 +39,7 @@ export type Fetcher = <P extends ProcedureType>(
   args: ProcedureArgs<P>
 ) => Promise<ProcedureResult<P>>;
 
-export const getFetcher = (nearNetwork: NearNetwork): Fetcher => (
+export const getFetcher = (networkName: NetworkName): Fetcher => (
   procedure,
   args
-) => fetch(procedure, nearNetwork, args);
+) => fetch(procedure, networkName, args);

--- a/frontend/src/libraries/wamp.ts
+++ b/frontend/src/libraries/wamp.ts
@@ -1,5 +1,5 @@
 import autobahn from "autobahn";
-import { getConfig, NearNetwork } from "./config";
+import { getConfig } from "./config";
 import { getBackendUrl, wrapProcedure, wrapTopic } from "./common";
 import {
   SubscriptionTopicType,
@@ -7,6 +7,7 @@ import {
   ProcedureArgs,
   ProcedureResult,
   ProcedureType,
+  NetworkName,
 } from "../types/common";
 
 let sessionPromise: Promise<autobahn.Session> | undefined;
@@ -65,10 +66,10 @@ let subscriptionCache: Partial<
 
 export const subscribeTopic = async <T extends SubscriptionTopicType>(
   topic: T,
-  nearNetwork: NearNetwork,
+  networkName: NetworkName,
   handler: (data: SubscriptionTopicTypes[T]) => void
 ): Promise<void> => {
-  const wrappedTopic = wrapTopic(nearNetwork.name, topic);
+  const wrappedTopic = wrapTopic(networkName, topic);
   if (subscriptionCache[wrappedTopic]) {
     return;
   }
@@ -93,9 +94,9 @@ export const subscribeTopic = async <T extends SubscriptionTopicType>(
 
 export const unsubscribeTopic = async <T extends SubscriptionTopicType>(
   topic: T,
-  nearNetwork: NearNetwork
+  networkName: NetworkName
 ): Promise<void> => {
-  const wrappedTopic = wrapTopic(nearNetwork.name, topic);
+  const wrappedTopic = wrapTopic(networkName, topic);
   const cacheItem = subscriptionCache[wrappedTopic];
   if (!cacheItem) {
     return;
@@ -106,21 +107,21 @@ export const unsubscribeTopic = async <T extends SubscriptionTopicType>(
 
 export const getLastValue = <T extends SubscriptionTopicType>(
   topic: T,
-  nearNetwork: NearNetwork
+  networkName: NetworkName
 ): SubscriptionTopicTypes[T] | undefined => {
-  return subscriptionCache[wrapTopic(nearNetwork.name, topic)]?.lastValue as
+  return subscriptionCache[wrapTopic(networkName, topic)]?.lastValue as
     | SubscriptionTopicTypes[T]
     | undefined;
 };
 
 export const fetch = async <P extends ProcedureType>(
   procedure: P,
-  nearNetwork: NearNetwork,
+  networkName: NetworkName,
   args: ProcedureArgs<P>
 ): Promise<ProcedureResult<P>> => {
   const session = await getSession();
   const result = await session.call(
-    wrapProcedure(nearNetwork.name, procedure),
+    wrapProcedure(networkName, procedure),
     args
   );
   return result as ProcedureResult<P>;

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -6,7 +6,8 @@ import * as React from "react";
 import { exec } from "child_process";
 import { promisify } from "util";
 
-import { getConfig, getNearNetwork, NearNetwork } from "../libraries/config";
+import { getConfig, getNearNetworkName } from "../libraries/config";
+import { NetworkName } from "../types/common";
 
 import Header from "../components/utils/Header";
 import Footer from "../components/utils/Footer";
@@ -78,7 +79,7 @@ const {
 declare module "next/app" {
   type ExtraAppInitialProps = {
     language: Language;
-    currentNearNetwork: NearNetwork;
+    networkName: NetworkName;
     deployInfo: DeployInfoProps;
   };
 
@@ -116,8 +117,12 @@ const AppContextWrapper: React.FC<ContextProps> = React.memo((props) => {
 let extraAppInitialPropsCache: ExtraAppInitialProps;
 
 const App: AppType = React.memo(
-  ({ Component, currentNearNetwork, language, pageProps, deployInfo }) => {
-    extraAppInitialPropsCache = { language, deployInfo, currentNearNetwork };
+  ({ Component, networkName, language, pageProps, deployInfo }) => {
+    extraAppInitialPropsCache = {
+      language,
+      deployInfo,
+      networkName,
+    };
     const router = useRouter();
     React.useEffect(() => {
       router.replace = wrapRouterHandlerMaintainNetwork(router, router.replace);
@@ -135,10 +140,10 @@ const App: AppType = React.memo(
 
     const networkState = React.useMemo(
       () => ({
-        currentNetwork: currentNearNetwork,
+        networkName,
         networks: nearNetworks,
       }),
-      [currentNearNetwork, nearNetworks]
+      [networkName, nearNetworks]
     );
 
     return (
@@ -222,10 +227,7 @@ App.getInitialProps = async (appContext) => {
     }
     initialProps = {
       deployInfo,
-      currentNearNetwork: getNearNetwork(
-        appContext.ctx.query,
-        req.headers.host
-      ),
+      networkName: getNearNetworkName(appContext.ctx.query, req.headers.host),
       language,
     };
     setI18n(await initializeI18n(language));

--- a/frontend/src/pages/accounts/[id].tsx
+++ b/frontend/src/pages/accounts/[id].tsx
@@ -13,7 +13,7 @@ import { useTranslation } from "react-i18next";
 import { GetServerSideProps, NextPage } from "next";
 import { useAnalyticsTrackOnMount } from "../../hooks/analytics/use-analytics-track-on-mount";
 import { getFetcher } from "../../libraries/transport";
-import { getNearNetwork } from "../../libraries/config";
+import { getNearNetworkName } from "../../libraries/config";
 import { Account } from "../../types/common";
 import { styled } from "../../libraries/styles";
 import * as React from "react";
@@ -98,8 +98,8 @@ export const getServerSideProps: GetServerSideProps<
   };
 
   try {
-    const currentNetwork = getNearNetwork(query, req.headers.host);
-    const fetcher = getFetcher(currentNetwork);
+    const networkName = getNearNetworkName(query, req.headers.host);
+    const fetcher = getFetcher(networkName);
     const isAccountExist = await fetcher("is-account-indexed", [accountId]);
     if (isAccountExist) {
       try {

--- a/frontend/src/pages/api/circulating-supply-in-near.ts
+++ b/frontend/src/pages/api/circulating-supply-in-near.ts
@@ -1,17 +1,17 @@
 import { NextApiHandler } from "next";
 import { getFetcher } from "../../libraries/transport";
-import { getNearNetwork } from "../../libraries/config";
+import { getNearNetworkName } from "../../libraries/config";
 
 const handler: NextApiHandler = async (req, res) => {
   // This API is currently providing computed estimation based on the inflation, so we only have it for mainnet
-  const nearNetwork = getNearNetwork(req.query, req.headers.host);
-  if (nearNetwork.name !== "mainnet") {
+  const networkName = getNearNetworkName(req.query, req.headers.host);
+  if (networkName !== "mainnet") {
     res.status(404).end();
     return;
   }
 
   try {
-    const supply = await getFetcher(nearNetwork)(
+    const supply = await getFetcher(networkName)(
       "get-latest-circulating-supply",
       []
     );

--- a/frontend/src/pages/api/circulating-supply.ts
+++ b/frontend/src/pages/api/circulating-supply.ts
@@ -1,18 +1,18 @@
 import { NextApiHandler } from "next";
 import { getFetcher } from "../../libraries/transport";
-import { getNearNetwork } from "../../libraries/config";
+import { getNearNetworkName } from "../../libraries/config";
 
 const handler: NextApiHandler = async (req, res) => {
   // This API is currently providing computed estimation based on the inflation, so we only have it for mainnet
-  const nearNetwork = getNearNetwork(req.query, req.headers.host);
-  if (nearNetwork.name !== "mainnet") {
+  const networkName = getNearNetworkName(req.query, req.headers.host);
+  if (networkName !== "mainnet") {
     res.status(404).end();
     return;
   }
 
   try {
     res.send(
-      await getFetcher(nearNetwork)("get-latest-circulating-supply", [])
+      await getFetcher(networkName)("get-latest-circulating-supply", [])
     );
   } catch (error) {
     console.error(`Handler ${req.url} failed:`, error);

--- a/frontend/src/pages/api/fees-of-previous-7-days-utc.ts
+++ b/frontend/src/pages/api/fees-of-previous-7-days-utc.ts
@@ -1,15 +1,15 @@
 import moment from "moment";
 import { NextApiHandler } from "next";
-import { getNearNetwork } from "../../libraries/config";
+import { getNearNetworkName } from "../../libraries/config";
 import { getFetcher } from "../../libraries/transport";
 
 const handler: NextApiHandler = async (req, res) => {
   try {
-    const nearNetwork = getNearNetwork(req.query, req.headers.host);
+    const networkName = getNearNetworkName(req.query, req.headers.host);
     let resp = [];
     for (let i = 1; i <= 7; i++) {
       const feeCountPerDay = await getFetcher(
-        nearNetwork
+        networkName
       )("nearcore-total-fee-count", [i]);
       if (!feeCountPerDay) {
         return res.status(500).end();

--- a/frontend/src/pages/api/fees-of-previous-day-utc.ts
+++ b/frontend/src/pages/api/fees-of-previous-day-utc.ts
@@ -1,13 +1,13 @@
 import moment from "moment";
 import { NextApiHandler } from "next";
-import { getNearNetwork } from "../../libraries/config";
+import { getNearNetworkName } from "../../libraries/config";
 import { getFetcher } from "../../libraries/transport";
 
 const handler: NextApiHandler = async (req, res) => {
   try {
-    const nearNetwork = getNearNetwork(req.query, req.headers.host);
+    const networkName = getNearNetworkName(req.query, req.headers.host);
     const feeCountPerDay = await getFetcher(
-      nearNetwork
+      networkName
     )("nearcore-total-fee-count", [1]);
     if (!feeCountPerDay) {
       return res.status(500).end();

--- a/frontend/src/pages/api/metrics/indexer.ts
+++ b/frontend/src/pages/api/metrics/indexer.ts
@@ -1,12 +1,12 @@
 import { NextApiHandler } from "next";
 import json2Prom from "json-2-prom";
-import { getNearNetwork } from "../../../libraries/config";
+import { getNearNetworkName } from "../../../libraries/config";
 import { getFetcher } from "../../../libraries/transport";
 
 const handler: NextApiHandler = async (req, res) => {
   try {
-    const nearNetwork = getNearNetwork(req.query, req.headers.host);
-    const fetcher = getFetcher(nearNetwork);
+    const networkName = getNearNetworkName(req.query, req.headers.host);
+    const fetcher = getFetcher(networkName);
     const rpcFinalBlock = await fetcher("nearcore-final-block", []);
     const indexerFinalBlock = await fetcher("blocks-list", [1, null]);
 

--- a/frontend/src/pages/api/nodes.ts
+++ b/frontend/src/pages/api/nodes.ts
@@ -1,5 +1,5 @@
 import { NextApiHandler } from "next";
-import { getNearNetwork } from "../../libraries/config";
+import { getNearNetworkName } from "../../libraries/config";
 import { getFetcher } from "../../libraries/transport";
 
 const handler: NextApiHandler = async (req, res) => {
@@ -11,9 +11,9 @@ const handler: NextApiHandler = async (req, res) => {
 
     res.send({});
 
-    const nearNetwork = getNearNetwork(req.query, req.headers.host);
+    const networkName = getNearNetworkName(req.query, req.headers.host);
 
-    getFetcher(nearNetwork)("node-telemetry", [
+    getFetcher(networkName)("node-telemetry", [
       {
         ...req.body,
         ip_address: ip_address,

--- a/frontend/src/pages/api/status.ts
+++ b/frontend/src/pages/api/status.ts
@@ -1,11 +1,11 @@
 import { NextApiHandler } from "next";
-import { getNearNetwork } from "../../libraries/config";
+import { getNearNetworkName } from "../../libraries/config";
 import { getFetcher } from "../../libraries/transport";
 
 const handler: NextApiHandler = async (req, res) => {
   try {
-    const nearNetwork = getNearNetwork(req.query, req.headers.host);
-    await getFetcher(nearNetwork)("nearcore-status", []);
+    const networkName = getNearNetworkName(req.query, req.headers.host);
+    await getFetcher(networkName)("nearcore-status", []);
   } catch (error) {
     res.status(502).send(error);
     return;

--- a/frontend/src/pages/blocks/[hash].tsx
+++ b/frontend/src/pages/blocks/[hash].tsx
@@ -11,7 +11,7 @@ import Content from "../../components/utils/Content";
 import { useTranslation } from "react-i18next";
 import { GetServerSideProps, NextPage } from "next";
 import { useAnalyticsTrackOnMount } from "../../hooks/analytics/use-analytics-track-on-mount";
-import { getNearNetwork } from "../../libraries/config";
+import { getNearNetworkName } from "../../libraries/config";
 import { getFetcher } from "../../libraries/transport";
 import { Block } from "../../types/common";
 import { styled } from "../../libraries/styles";
@@ -87,8 +87,8 @@ export const getServerSideProps: GetServerSideProps<
 > = async ({ req, params, query }) => {
   const hash = params?.hash ?? "";
   try {
-    const nearNetwork = getNearNetwork(query, req.headers.host);
-    const fetcher = getFetcher(nearNetwork);
+    const networkName = getNearNetworkName(query, req.headers.host);
+    const fetcher = getFetcher(networkName);
     const block = await fetcher("block-info", [hash]);
     if (!block) {
       return {

--- a/frontend/src/pages/stats/index.tsx
+++ b/frontend/src/pages/stats/index.tsx
@@ -28,7 +28,7 @@ const chartStyle = {
 const Stats: NextPage = React.memo(() => {
   const { t } = useTranslation();
   useAnalyticsTrackOnMount("Explorer View Stats page");
-  const { currentNetwork } = useNetworkContext();
+  const { networkName } = useNetworkContext();
 
   return (
     <>
@@ -39,7 +39,7 @@ const Stats: NextPage = React.memo(() => {
         <div id="protocolConfiguration">
           <ProtocolConfigInfo />
         </div>
-        {currentNetwork.name === "mainnet" ? (
+        {networkName === "mainnet" ? (
           <div id="circulatingSupply">
             <CirculatingSupplyStats chartStyle={chartStyle} />
           </div>

--- a/frontend/src/pages/transactions/[hash].tsx
+++ b/frontend/src/pages/transactions/[hash].tsx
@@ -18,7 +18,7 @@ import {
   RPC,
 } from "../../types/common";
 import { getFetcher } from "../../libraries/transport";
-import { getNearNetwork } from "../../libraries/config";
+import { getNearNetworkName } from "../../libraries/config";
 import { styled } from "../../libraries/styles";
 import * as React from "react";
 
@@ -150,8 +150,8 @@ export const getServerSideProps: GetServerSideProps<
 > = async ({ req, params, query }) => {
   const hash = params?.hash ?? "";
   try {
-    const nearNetwork = getNearNetwork(query, req.headers.host);
-    const fetcher = getFetcher(nearNetwork);
+    const networkName = getNearNetworkName(query, req.headers.host);
+    const fetcher = getFetcher(networkName);
     const transactionBaseInfo = await fetcher("transaction-info", [hash]);
     if (!transactionBaseInfo) {
       throw new Error(`No hash ${hash} found`);

--- a/frontend/src/testing/utils.tsx
+++ b/frontend/src/testing/utils.tsx
@@ -8,12 +8,13 @@ import { NetworkContext } from "../context/NetworkContext";
 import { setMomentLanguage } from "../libraries/language";
 
 const networkContext: NetworkContext = {
-  currentNetwork: {
-    name: "testnet",
-    explorerLink: "http://explorer/",
-    nearWalletProfilePrefix: "http://wallet/profile",
+  networkName: "testnet",
+  networks: {
+    testnet: {
+      explorerLink: "http://explorer/",
+      nearWalletProfilePrefix: "http://wallet/profile",
+    },
   },
-  networks: [],
 };
 
 export const renderElement = (

--- a/render.yaml
+++ b/render.yaml
@@ -27,27 +27,23 @@ services:
         value: UA-100373569-14
       - key: NEAR_EXPLORER_CONFIG__NETWORKS
         value: |
-          [
-            {
-              "name": "mainnet",
+          {
+            "mainnet": {
               "explorerLink": "https://explorer.near.org/",
               "aliases": ["explorer.near.org", "explorer.mainnet.near.org", "explorer.nearprotocol.com", "explorer.mainnet.nearprotocol.com"],
-              "lockupAccountIdSuffix": "lockup.near",
               "nearWalletProfilePrefix": "https://wallet.near.org/profile"
             },
-            {
-              "name": "testnet",
+            "testnet": {
               "explorerLink": "https://explorer.testnet.near.org/",
               "aliases": ["explorer.testnet.near.org", "explorer.testnet.nearprotocol.com"],
               "nearWalletProfilePrefix": "https://wallet.testnet.near.org/profile"
             },
-            {
-              "name": "guildnet",
+            "guildnet": {
               "explorerLink": "https://explorer.guildnet.near.org/",
               "aliases": ["explorer.guildnet.near.org"],
               "nearWalletProfilePrefix": "https://wallet.openshards.io/profile"
             }
-          ]
+          }
 
   ## Explorer WAMP
   - type: web


### PR DESCRIPTION
We currently have two networks passed around - the one from the list and another one extracted from it by the key.
Let's not repeat ourselves and keep the list and the key separate, calculating the data if needed.