### PR TITLE
Refactor: transaction calculations on server

### DIFF
--- a/backend/src/procedure-handlers.ts
+++ b/backend/src/procedure-handlers.ts
@@ -1,7 +1,7 @@
 import { exec } from "child_process";
 import { promisify } from "util";
 
-import { KeysOfUnion, ProcedureTypes, RPC } from "./types";
+import { Action, KeysOfUnion, ProcedureTypes, RPC } from "./types";
 
 import * as stats from "./stats";
 import * as receipts from "./receipts";
@@ -27,13 +27,6 @@ export const procedureHandlers: {
 } = {
   "node-telemetry": async ([nodeInfo]) => {
     return await telemetry.sendTelemetry(nodeInfo);
-  },
-
-  "nearcore-tx": async ([transactionHash, accountId]) => {
-    return await sendJsonRpc("EXPERIMENTAL_tx_status", [
-      transactionHash,
-      accountId,
-    ]);
   },
 
   "nearcore-final-block": async () => {
@@ -109,7 +102,80 @@ export const procedureHandlers: {
   },
 
   "transaction-info": async ([transactionHash]) => {
-    return await transactions.getTransactionInfo(transactionHash);
+    const transactionBaseInfo = await transactions.getTransactionInfo(
+      transactionHash
+    );
+    if (!transactionBaseInfo) {
+      return null;
+    }
+    const transactionInfo = await sendJsonRpc("EXPERIMENTAL_tx_status", [
+      transactionBaseInfo.hash,
+      transactionBaseInfo.signerId,
+    ]);
+
+    const actions = transactionInfo.transaction.actions.map(
+      transactions.mapRpcActionToAction
+    );
+    const receipts = transactionInfo.receipts;
+    const receiptsOutcome = transactionInfo.receipts_outcome;
+    if (
+      receipts.length === 0 ||
+      receipts[0].receipt_id !== receiptsOutcome[0].id
+    ) {
+      receipts.unshift({
+        predecessor_id: transactionInfo.transaction.signer_id,
+        receipt: {
+          Action: {
+            signer_id: transactionInfo.transaction.signer_id,
+            signer_public_key: "",
+            gas_price: "0",
+            output_data_receivers: [],
+            input_data_ids: [],
+            actions: transactionInfo.transaction.actions,
+          },
+        },
+        receipt_id: receiptsOutcome[0].id,
+        receiver_id: transactionInfo.transaction.receiver_id,
+      });
+    }
+    const receiptOutcomesByIdMap = new Map<
+      string,
+      RPC.ExecutionOutcomeWithIdView
+    >();
+    receiptsOutcome.forEach((receipt) => {
+      receiptOutcomesByIdMap.set(receipt.id, receipt);
+    });
+
+    const receiptsByIdMap = new Map<
+      string,
+      Omit<RPC.ReceiptView, "actions"> & { actions: Action[] }
+    >();
+    receipts.forEach((receiptItem) => {
+      receiptsByIdMap.set(receiptItem.receipt_id, {
+        ...receiptItem,
+        actions:
+          "Action" in receiptItem.receipt
+            ? receiptItem.receipt.Action.actions.map(
+                transactions.mapRpcActionToAction
+              )
+            : [],
+      });
+    });
+
+    return {
+      ...transactionBaseInfo,
+      status: Object.keys(
+        transactionInfo.status
+      )[0] as KeysOfUnion<RPC.FinalExecutionStatus>,
+      actions,
+      receiptsOutcome,
+      receipt: transactions.collectNestedReceiptWithOutcome(
+        receiptsOutcome[0].id,
+        receiptsByIdMap,
+        receiptOutcomesByIdMap
+      ),
+      transactionOutcome: transactionInfo.transaction_outcome,
+    };
   },
 
   "transaction-execution-status": async ([hash, signerId]) => {

--- a/common/src/types/procedures.ts
+++ b/common/src/types/procedures.ts
@@ -152,6 +152,36 @@ export type TransactionBaseInfo = {
   actions: Action[];
 };
 
+export type TransactionOutcome = {
+  id: string;
+  outcome: RPC.ExecutionOutcomeView;
+  block_hash: string;
+};
+
+type ReceiptExecutionOutcome = {
+  tokens_burnt: string;
+  logs: string[];
+  outgoing_receipts?: NestedReceiptWithOutcome[];
+  status: RPC.ExecutionStatusView;
+  gas_burnt: number;
+};
+
+export type NestedReceiptWithOutcome = {
+  actions?: Action[];
+  block_hash: string;
+  outcome: ReceiptExecutionOutcome;
+  predecessor_id: string;
+  receipt_id: string;
+  receiver_id: string;
+};
+
+export type Transaction = TransactionBaseInfo & {
+  status: KeysOfUnion<RPC.FinalExecutionStatus>;
+  receiptsOutcome: RPC.ExecutionOutcomeWithIdView[];
+  transactionOutcome: TransactionOutcome;
+  receipt: NestedReceiptWithOutcome;
+};
+
 export type TransactionPagination = {
   endTimestamp: number;
   transactionIndex: number;
@@ -323,10 +353,6 @@ export type ProcedureTypes = {
     result: TransactionsByDateAmount[] | null;
   };
 
-  "nearcore-tx": {
-    args: [string, string];
-    result: RPC.FinalExecutionOutcomeWithReceiptView;
-  };
   "transaction-execution-status": {
     args: [string, string];
     result: KeysOfUnion<RPC.FinalExecutionStatus>;
@@ -349,7 +375,7 @@ export type ProcedureTypes = {
   };
   "transaction-info": {
     args: [string];
-    result: TransactionBaseInfo | null;
+    result: Transaction | null;
   };
   "nearcore-status": {
     args: [];

--- a/frontend/src/components/transactions/ReceiptRow.tsx
+++ b/frontend/src/components/transactions/ReceiptRow.tsx
@@ -13,8 +13,8 @@ import { Args } from "./ActionMessage";
 import ActionRow from "./ActionRow";
 
 import { useTranslation } from "react-i18next";
-import { NestedReceiptWithOutcome } from "../../pages/transactions/[hash]";
 import { styled } from "../../libraries/styles";
+import { NestedReceiptWithOutcome } from "../../types/common";
 
 const ReceiptRowWrapper = styled(Row, {
   paddingTop: 10,

--- a/frontend/src/components/transactions/TransactionDetails.tsx
+++ b/frontend/src/components/transactions/TransactionDetails.tsx
@@ -14,9 +14,8 @@ import TransactionExecutionStatus from "./TransactionExecutionStatus";
 
 import { useTranslation } from "react-i18next";
 import { useFinalBlockTimestampNanosecond } from "../../hooks/data";
-import { Transaction } from "../../pages/transactions/[hash]";
 import { styled } from "../../libraries/styles";
-import { RPC } from "../../types/common";
+import { RPC, Transaction } from "../../types/common";
 
 const HeaderRow = styled(Row);
 

--- a/frontend/src/components/transactions/TransactionOutcome.tsx
+++ b/frontend/src/components/transactions/TransactionOutcome.tsx
@@ -4,10 +4,10 @@ import { Row, Col } from "react-bootstrap";
 
 import Gas from "../utils/Gas";
 import Balance from "../utils/Balance";
-import { TransactionOutcome as TTransactionOutcome } from "../../pages/transactions/[hash]";
 
 import { useTranslation } from "react-i18next";
 import { styled } from "../../libraries/styles";
+import { TransactionOutcome } from "../../types/common";
 
 const TransactionOutcomeRow = styled(Row, {
   paddingTop: 10,
@@ -35,46 +35,52 @@ const TransactionOutcomeText = styled(Col, {
 });
 
 export interface Props {
-  transaction: TTransactionOutcome;
+  transaction: TransactionOutcome;
 }
 
-const TransactionOutcome: React.FC<Props> = React.memo(({ transaction }) => {
-  const { t } = useTranslation();
-  const gasBurnt = new BN(transaction.outcome?.gas_burnt ?? 0);
-  const tokensBurnt = new BN(transaction.outcome?.tokens_burnt ?? 0);
-  return (
-    <Row noGutters>
-      <Col>
-        <Row noGutters>
-          <TransactionOutcomeTitle main>
-            <b>
-              {t(
-                "common.transactions.execution.convert_transaction_to_receipt"
+const TransactionOutcomeView: React.FC<Props> = React.memo(
+  ({ transaction }) => {
+    const { t } = useTranslation();
+    const gasBurnt = new BN(transaction.outcome?.gas_burnt ?? 0);
+    const tokensBurnt = new BN(transaction.outcome?.tokens_burnt ?? 0);
+    return (
+      <Row noGutters>
+        <Col>
+          <Row noGutters>
+            <TransactionOutcomeTitle main>
+              <b>
+                {t(
+                  "common.transactions.execution.convert_transaction_to_receipt"
+                )}
+              </b>
+            </TransactionOutcomeTitle>
+          </Row>
+
+          <TransactionOutcomeRow noGutters className="mx-0 pl-4">
+            <TransactionOutcomeTitle>
+              {t("common.transactions.execution.gas_burned")}:
+            </TransactionOutcomeTitle>
+            <TransactionOutcomeText>
+              {gasBurnt ? <Gas gas={gasBurnt} /> : "..."}
+            </TransactionOutcomeText>
+          </TransactionOutcomeRow>
+
+          <TransactionOutcomeRow noGutters className="mx-0 pl-4">
+            <TransactionOutcomeTitle>
+              {t("common.transactions.execution.tokens_burned")}:
+            </TransactionOutcomeTitle>
+            <TransactionOutcomeText>
+              {tokensBurnt ? (
+                <Balance amount={tokensBurnt.toString()} />
+              ) : (
+                "..."
               )}
-            </b>
-          </TransactionOutcomeTitle>
-        </Row>
+            </TransactionOutcomeText>
+          </TransactionOutcomeRow>
+        </Col>
+      </Row>
+    );
+  }
+);
 
-        <TransactionOutcomeRow noGutters className="mx-0 pl-4">
-          <TransactionOutcomeTitle>
-            {t("common.transactions.execution.gas_burned")}:
-          </TransactionOutcomeTitle>
-          <TransactionOutcomeText>
-            {gasBurnt ? <Gas gas={gasBurnt} /> : "..."}
-          </TransactionOutcomeText>
-        </TransactionOutcomeRow>
-
-        <TransactionOutcomeRow noGutters className="mx-0 pl-4">
-          <TransactionOutcomeTitle>
-            {t("common.transactions.execution.tokens_burned")}:
-          </TransactionOutcomeTitle>
-          <TransactionOutcomeText>
-            {tokensBurnt ? <Balance amount={tokensBurnt.toString()} /> : "..."}
-          </TransactionOutcomeText>
-        </TransactionOutcomeRow>
-      </Col>
-    </Row>
-  );
-});
-
-export default TransactionOutcome;
+export default TransactionOutcomeView;

--- a/frontend/src/components/transactions/__tests__/common.tsx
+++ b/frontend/src/components/transactions/__tests__/common.tsx
@@ -1,5 +1,4 @@
-import { Receipt } from "../../../types/common";
-import { Transaction } from "../../../pages/transactions/[hash]";
+import { Receipt, Transaction } from "../../../types/common";
 
 export const TRANSACTIONS: Transaction[] = [
   // no action has deposit


### PR DESCRIPTION
It's quite hard to keep frontend server code simple with such a cumbersome calculations. It affects amount of data transferred on network as well.
I assume this code move may rise the stress on backend, we will be definitely able to see the effect after deployment.