### PR TITLE
Fix: localhostnet -> localnet

### DIFF
--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -10,20 +10,20 @@ To override a config parameter you should use a specific environment variable, f
 - variable name should be CAPS_CASE'd target variable name;
 - going deep into object should be delimited with double underscore.
 
-For example, to override `config.accountIdSuffix.stakingPool.localhostnet` you should use variable
-NEAR_EXPLORER_CONFIG__ACCOUNT_ID_SUFFIX__STAKING_POOL__LOCALHOSTNET
+For example, to override `config.accountIdSuffix.stakingPool.localnet` you should use variable
+NEAR_EXPLORER_CONFIG__ACCOUNT_ID_SUFFIX__STAKING_POOL__LOCALNET
 */
 export const config = merge(
   {
     archivalRpcUrl: "http://localhost:3030",
-    networkName: "localhostnet" as NetworkName,
+    networkName: "localnet" as NetworkName,
     accountIdSuffix: {
       lockup: "lockup.near",
       stakingPool: {
         mainnet: ".poolv1.near",
         testnet: undefined,
         guildnet: undefined,
-        localhostnet: undefined,
+        localnet: undefined,
       } as Record<NetworkName, string | undefined>,
     },
 

--- a/common/src/types/common.ts
+++ b/common/src/types/common.ts
@@ -1,4 +1,4 @@
-export type NetworkName = "mainnet" | "testnet" | "guildnet" | "localhostnet";
+export type NetworkName = "mainnet" | "testnet" | "guildnet" | "localnet";
 
 // Workaround of Omit breaking discriminated unions
 // https://github.com/microsoft/TypeScript/issues/31501

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -13,7 +13,7 @@ const defaultBackendConfig: BackendConfig = {
     mainnet: "localhost",
     testnet: "localhost",
     guildnet: "localhost",
-    localhostnet: "localhost",
+    localnet: "localhost",
   },
   port: 10000,
   secure: false,

--- a/frontend/src/__mocks__/next/config.ts
+++ b/frontend/src/__mocks__/next/config.ts
@@ -2,7 +2,7 @@ import { NextConfig } from "next";
 import type { ExplorerConfig } from "../../libraries/config";
 
 const backendConfig = {
-  hosts: { localhostnet: "this-could-be-anything" },
+  hosts: { localnet: "this-could-be-anything" },
   port: 0,
   secure: false,
 };

--- a/frontend/src/components/utils/HeaderNetworkDropdown.tsx
+++ b/frontend/src/components/utils/HeaderNetworkDropdown.tsx
@@ -94,11 +94,11 @@ const NetworkIcon = styled("div", {
       guildnet: {
         background: "#0072ce",
       },
-      localhostnet: {},
+      localnet: {},
     },
   },
   defaultVariants: {
-    network: "localhostnet",
+    network: "localnet",
   },
 });
 

--- a/frontend/src/testing/utils.tsx
+++ b/frontend/src/testing/utils.tsx
@@ -11,9 +11,9 @@ import { setMomentLanguage } from "../libraries/language";
 import { trpc } from "../libraries/trpc";
 
 const networkContext: NetworkContext = {
-  networkName: "localhostnet",
+  networkName: "localnet",
   networks: {
-    localhostnet: {
+    localnet: {
       explorerLink: "http://explorer/",
       nearWalletProfilePrefix: "http://wallet/profile",
     },


### PR DESCRIPTION
I researched through other NEAR projects and found out nobody uses `localhostnet` except us but `localnet`.
This is the rename.