### PR TITLE
Refactor: genesis config subscription

### DIFF
--- a/backend/src/cron/index.ts
+++ b/backend/src/cron/index.ts
@@ -9,6 +9,7 @@ const regularTasks = [
   tasks.blockProductionSpeedCheck,
   tasks.recentTransactionsCountCheck,
   tasks.onlineNodesCountCheck,
+  tasks.genesisProtocolInfoFetch,
   tasks.transactionCountHistoryCheck,
   tasks.statsAggregationCheck,
   tasks.networkInfoCheck,
@@ -40,7 +41,9 @@ export const runTasks = (context: Context) => {
           String(error)
         );
       } finally {
-        setTimeoutBound();
+        if (timeout !== Infinity) {
+          setTimeoutBound();
+        }
       }
     };
     const setTimeoutBound = () => {

--- a/backend/src/database/queries.ts
+++ b/backend/src/database/queries.ts
@@ -757,19 +757,6 @@ export const queryCirculatingSupply = async () => {
     .execute();
 };
 
-export const queryFirstProducedBlockTimestamp = async () => {
-  return indexerDatabase
-    .selectFrom("blocks")
-    .select(
-      sql<Date>`to_timestamp(div(block_timestamp, 1000 * 1000 * 1000))::date`.as(
-        "first_produced_block_timestamp"
-      )
-    )
-    .orderBy("block_timestamp")
-    .limit(1)
-    .executeTakeFirstOrThrow();
-};
-
 export const queryBlocksList = async (limit: number = 15, cursor?: number) => {
   const selection = await indexerDatabase
     .selectFrom((eb) => {

--- a/backend/src/global-state.ts
+++ b/backend/src/global-state.ts
@@ -12,6 +12,10 @@ export type GlobalState = {
   stakingPoolInfos: CachedTimestampMap<ValidatorPoolInfo>;
   poolIds: string[];
   currentEpochState: CurrentEpochState | null;
+  genesis: {
+    minStakeRatio: [number, number];
+    accountCount: number;
+  } | null;
 };
 
 export const initGlobalState = (): GlobalState => ({
@@ -29,4 +33,5 @@ export const initGlobalState = (): GlobalState => ({
   },
   poolIds: [],
   currentEpochState: null,
+  genesis: null,
 });

--- a/backend/src/router/procedures.ts
+++ b/backend/src/router/procedures.ts
@@ -37,18 +37,6 @@ export const router = trpc
       return nearApi.sendJsonRpc("status", [null]);
     },
   })
-  // genesis configuration
-  .query("nearcore-genesis-protocol-configuration", {
-    resolve: async () => {
-      const networkProtocolConfig = await nearApi.sendJsonRpc(
-        "EXPERIMENTAL_protocol_config",
-        { finality: "final" }
-      );
-      return nearApi.sendJsonRpc("block", {
-        block_id: networkProtocolConfig.genesis_height,
-      });
-    },
-  })
   .query("get-latest-circulating-supply", {
     resolve: () => {
       return stats.getLatestCirculatingSupply();
@@ -265,11 +253,6 @@ export const router = trpc
     },
   })
   // blocks
-  .query("first-produced-block-timestamp", {
-    resolve: () => {
-      return stats.getFirstProducedBlockTimestamp();
-    },
-  })
   .query("blocks-list", {
     input: z.strictObject({
       limit: validators.limit,
@@ -323,11 +306,6 @@ export const router = trpc
     },
   })
   // genesis stats
-  .query("nearcore-genesis-accounts-count", {
-    resolve: () => {
-      return stats.getGenesisAccountsCount();
-    },
-  })
   .query("nearcore-total-fee-count", {
     input: z.tuple([z.number().min(1).max(7)]),
     resolve: ({ input: [daysCount] }) => {

--- a/backend/src/router/subscriptions.ts
+++ b/backend/src/router/subscriptions.ts
@@ -90,6 +90,12 @@ export const router = trpc
   .subscription("onlineNodesCount", {
     resolve: getSubscriptionResolve("onlineNodesCount"),
   })
+  .query("genesisConfig", {
+    resolve: getQueryResolve("genesisConfig"),
+  })
+  .subscription("genesisConfig", {
+    resolve: getSubscriptionResolve("genesisConfig"),
+  })
   .query("network-stats", {
     resolve: getQueryResolve("network-stats"),
   })

--- a/backend/src/router/types.ts
+++ b/backend/src/router/types.ts
@@ -67,9 +67,7 @@ export type NetworkStats = {
   epochStartHeight: number;
   epochProtocolVersion: number;
   totalStake: string;
-  seatPrice: string;
-  genesisTime: string;
-  genesisHeight: number;
+  seatPrice?: string;
 };
 
 export type SubscriptionTopicTypes = {
@@ -82,6 +80,13 @@ export type SubscriptionTopicTypes = {
   blockProductionSpeed: number;
   recentTransactionsCount: number;
   onlineNodesCount: number;
+  genesisConfig: {
+    height: number;
+    timestamp: number;
+    protocolVersion: number;
+    totalSupply: string;
+    accountCount: number;
+  };
   "network-stats": NetworkStats;
 };
 

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -1,7 +1,7 @@
 export * from "../../common/src/types";
 
 export type CurrentEpochState = {
-  seatPrice: string;
+  seatPrice?: string;
   totalStake: string;
   height: number;
 };


### PR DESCRIPTION
It seems like we can fetch genesis details just once and propagate them later.