### PR TITLE
Chore: CI

### DIFF
--- a/.github/actions/install-cypress/action.yml
+++ b/.github/actions/install-cypress/action.yml
@@ -1,0 +1,22 @@
+name: Install cypress
+runs:
+  using: composite
+  steps:
+    - name: Get cypress version
+      id: getCypressVersion
+      shell: bash
+      run: |
+        version=`cat frontend/package.json | jq '.devDependencies.cypress'`
+        echo "::set-output name=version::$version"
+    - name: Cache cypress
+      uses: actions/cache@v3
+      id: cypress-cache
+      with:
+        path: ~/.cache/Cypress
+        key: cypress-${{ steps.getCypressVersion.outputs.version }}
+        restore-keys: |
+          cypress-${{ steps.getCypressVersion.outputs.version }}
+    - name: Install cypress
+      if: steps.cypress-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: npm explore cypress -- npm run postinstall

--- a/.github/actions/install-packages/action.yml
+++ b/.github/actions/install-packages/action.yml
@@ -1,0 +1,29 @@
+name: Install packages
+runs:
+  using: composite
+  steps:
+    - name: Cache npm packages
+      uses: actions/cache@v3
+      id: npm-cache
+      with:
+        path: ~/.npm
+        key: node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          node-${{ hashFiles('**/package-lock.json') }}
+          node-
+    - name: Cache node_modules
+      uses: actions/cache@v3
+      id: node-modules-cache
+      with:
+        path: |
+          ${{ github.workspace }}/node_modules
+          ${{ github.workspace }}/common/node_modules
+          ${{ github.workspace }}/frontend/node_modules
+          ${{ github.workspace }}/backend/node_modules
+        key: node-modules-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          node-modules-${{ hashFiles('**/package-lock.json') }}
+    - name: Install packages
+      if: steps.node-modules-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: npm install

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,0 +1,7 @@
+name: Setup node v16
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -1,4 +1,4 @@
-name: Run Tests
+name: CI
 on:
   pull_request:
   push:
@@ -6,84 +6,117 @@ on:
       - master
 
 jobs:
-  codestyle:
-    name: Code Style
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-18.04]
-        node: [16]
+  prettier:
+    name: Prettier
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: Install packages
-        run: npm install
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/install-packages
       - name: Run code formatting check
         run: npm run fmt:check
 
+  frontend-typecheck:
+    name: Frontend typecheck
+    needs: prettier
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/install-packages
+      - name: Run typecheck
+        run: npm run -w frontend typecheck
+
+  frontend-build:
+    name: Build frontend
+    needs: frontend-typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/install-packages
+      - name: Build frontend
+        run: npm run -w frontend build
+      - name: Upload frontend build
+        uses: actions/upload-artifact@v3
+        with:
+          name: frontend-dist
+          path: frontend/.next/
+
+  backend-typecheck:
+    name: Backend typecheck
+    needs: prettier
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/install-packages
+      - name: Run typecheck
+        run: npm run -w backend typecheck
+
+  backend-build:
+    name: Build backend
+    needs: backend-typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/install-packages
+      - name: Build backend
+        run: npm run -w backend build
+      - name: Upload backend build
+        uses: actions/upload-artifact@v3
+        with:
+          name: backend-dist
+          path: backend/build/
+
   frontend-test:
     name: Frontend unit testing
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-18.04]
-        node: [16]
+    needs: frontend-build
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: Install packages
-        run: npm install
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/install-packages
       - name: Run unit tests
         run: npm run -w frontend test
 
   e2e-test:
     name: e2e testing
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-18.04]
-        node: [16]
+    needs: [frontend-build, backend-build]
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: Install packages
-        run: npm install
-      - name: Build frontend
-        run: npm run -w frontend build
-      - name: Build backend
-        run: npm run -w backend build
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/install-packages
+      - uses: ./.github/actions/install-cypress
+      - name: Download frontend dist
+        uses: actions/download-artifact@v3
+        with:
+          name: frontend-dist
+          path: frontend/.next/
+      - name: Download backend dist
+        uses: actions/download-artifact@v3
+        with:
+          name: backend-dist
+          path: backend/build/
       - name: Run Cypress
         run: npm run test:ci
-        env:
-          CYPRESS_DASHBOARD_KEY: ${{ secrets.CYPRESS_DASHBOARD_KEY }}
-
-  backend-typecheck:
-    name: Backend typecheck
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-18.04]
-        node: [16]
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install packages
-        run: npm install
-      - name: Run typecheck
-        run: npm run -w backend typecheck
 
   backend-database-types-check:
     name: Backend database types check
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-18.04]
-        node: [16]
+    needs: backend-typecheck
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v1
-      - name: Install packages
-        run: npm install
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/install-packages
       - name: Copy original models
         run: cp -r backend/src/database/models backend/src/database/models-original
       - name: Generate types
         run: npm run -w backend db:generate-types
       - name: Run prettier on newly generated types
-        run: npm run fmt
+        run: npm run -w backend db:generated-types:fmt
       - name: Compare types
         run: diff -bur backend/src/database/models-original backend/src/database/models

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,8 @@
     "start:testnet": "dotenv -c -e ../testnet.env -- npm run start",
     "start:mainnet": "dotenv -c -e ../mainnet.env -- npm run start",
     "start:guildnet": "dotenv -c -e ../guildnet.env -- npm run start",
-    "db:generate-types": "dotenv -c -e ../mainnet.env -- ts-node kanel.ts"
+    "db:generate-types": "dotenv -c -e ../mainnet.env -- ts-node kanel.ts",
+    "db:generated-types:fmt": "prettier --write 'src/database/models/**/*.ts'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Changes:
- NPM modules [are now cached](https://github.com/near/near-explorer/pull/1040/files#diff-758cecc5b4ceca91212c11c4d1eb58944d37c114368b5cf6c7a122c2e7cbe889R1-R29) between jobs and runs, based on package-lock.json
- Cypress binary [is now cached](https://github.com/near/near-explorer/pull/1040/files#diff-758cecc5b4ceca91212c11c4d1eb58944d37c114368b5cf6c7a122c2e7cbe889R1-R29) between jobs and runs, based on cypress version
- Main CI description brevity increased
- Actions are now reused instead of verbosely repeat chunks of config
- Non-used matrix of OSes removed in favor of just one OS
- CI is now a graph instead of a bunch separate checks - CI fails fast
- DB types checks are active only on master