### PR TITLE
Fix: subscription error on no prefetched data

### DIFF
--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./utils/environment";
 export * from "./utils/promise";
 export * from "./utils/git";
+export * from "./utils/queries";

--- a/common/src/utils/queries.ts
+++ b/common/src/utils/queries.ts
@@ -1,0 +1,1 @@
+export const SSR_TIMEOUT = 3000;

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -19,7 +19,7 @@ import { NetworkContext } from "../context/NetworkContext";
 import { DeployInfo } from "../components/utils/DeployInfo";
 import { DeployInfo as DeployInfoProps } from "../types/common";
 
-import { getBranch, getShortCommitSha } from "../libraries/common";
+import { getBranch, getShortCommitSha, SSR_TIMEOUT } from "../libraries/common";
 import { getLanguage, LANGUAGE_COOKIE } from "../libraries/language";
 import { useAnalyticsInit } from "../hooks/analytics/use-analytics-init";
 import { createI18n, LANGUAGES } from "../libraries/i18n";
@@ -320,7 +320,7 @@ export default withTRPC<AppRouter>({
         },
       },
       links: getLinks(httpUrl, wsUrl),
-      ssrTimeout: 3000,
+      ssrTimeout: SSR_TIMEOUT,
     };
   },
   ssr: true,


### PR DESCRIPTION
I found a bug: whenever our subscription cached is not filled yet - we pass undefined to the client as the value which leads to an error on the page.