### PR TITLE
Refactor: Extend receipt execution outcome type

### DIFF
--- a/frontend/src/components/transactions/__tests__/common.tsx
+++ b/frontend/src/components/transactions/__tests__/common.tsx
@@ -258,8 +258,15 @@ export const TRANSACTIONS: Transaction[] = [
         outgoing_receipts: [],
         status: {
           Failure: {
-            error_message: "Exceeded the prepaid gas.",
-            error_type: "ActionError::FunctionCallError",
+            ActionError: {
+              index: 0,
+              kind: {
+                FunctionCallError: {
+                  ExecutionError:
+                    "Smart contract panicked: ERR_INCORRECT_NONCE",
+                },
+              },
+            },
           },
         },
         gas_burnt: 222222,
@@ -278,8 +285,15 @@ export const TRANSACTIONS: Transaction[] = [
           receipt_ids: [],
           status: {
             Failure: {
-              error_message: "Exceeded the prepaid gas.",
-              error_type: "ActionError::FunctionCallError",
+              ActionError: {
+                index: 0,
+                kind: {
+                  FunctionCallError: {
+                    ExecutionError:
+                      "Smart contract panicked: ERR_INCORRECT_NONCE",
+                  },
+                },
+              },
             },
           },
           gas_burnt: 222222,


### PR DESCRIPTION
I decided to expand `Failure` param of `ExecutionStatusView` type and I use this [doc](https://docs.rs/near-primitives/0.12.0/near_primitives/errors/enum.TxExecutionError.html). I need this type [here](https://github.com/near/near-explorer/blob/54bdd2a940a2eebd875e577d01277f0175fbaeb0/frontend/src/components/beta/transactions/ReceiptDetails.tsx#L78) in this [PR](https://github.com/near/near-explorer/pull/977).