### PR TITLE
Refactor: charts refactor

### DIFF
--- a/backend/src/router/types.ts
+++ b/backend/src/router/types.ts
@@ -70,6 +70,10 @@ export type NetworkStats = {
   seatPrice?: string;
 };
 
+type TimestampDataSeries<T> = (T extends unknown[]
+  ? [number, ...T]
+  : [number, T])[];
+
 export type SubscriptionTopicTypes = {
   validators: ValidatorFullData[];
   latestBlock: {
@@ -87,15 +91,8 @@ export type SubscriptionTopicTypes = {
     totalSupply: string;
     accountCount: number;
   };
-  tokensSupply: {
-    totalSupply: string;
-    circulatingSupply: string;
-    timestamp: number;
-  }[];
-  transactionsHistory: {
-    count: number;
-    timestamp: number;
-  }[];
+  tokensSupply: TimestampDataSeries<[number, number]>;
+  transactionsHistory: TimestampDataSeries<number>;
   "network-stats": NetworkStats;
 };
 

--- a/backend/src/utils/bigint.ts
+++ b/backend/src/utils/bigint.ts
@@ -1,3 +1,5 @@
+import { nearNominationExponent } from "../common";
+
 export const BIMax = (...args: bigint[]) =>
   args.reduce((m, e) => (e > m ? e : m));
 export const BIMin = (...args: bigint[]) =>
@@ -10,3 +12,5 @@ export const millisecondsToNanoseconds = (ms: number): bigint => {
 export const nanosecondsToMilliseconds = (ns: bigint): number => {
   return Number(ns / BigInt(10 ** 6));
 };
+
+export const nearNomination = 10n ** BigInt(nearNominationExponent);

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -2,3 +2,4 @@ export * from "./utils/environment";
 export * from "./utils/promise";
 export * from "./utils/git";
 export * from "./utils/queries";
+export * from "./utils/near";

--- a/common/src/types/procedures.ts
+++ b/common/src/types/procedures.ts
@@ -13,8 +13,6 @@ export type AccountFungibleTokenHistoryElement =
 export type Block = NonNullable<TRPCQueryOutput<"block-info">>;
 export type BlockBase = TRPCQueryOutput<"blocks-list">[number];
 
-export type TransactionsHistory = TRPCSubscriptionOutput<"transactionsHistory">;
-
 export type ReceiptExecutionStatus = NonNullable<
   TRPCQueryOutput<"executed-receipts-list-by-block-hash">[number]["status"]
 >;

--- a/common/src/utils/near.ts
+++ b/common/src/utils/near.ts
@@ -1,0 +1,1 @@
+export const nearNominationExponent = 24;

--- a/frontend/src/components/dashboard/DashboardTransaction.tsx
+++ b/frontend/src/components/dashboard/DashboardTransaction.tsx
@@ -18,18 +18,8 @@ const TransactionCardNumber = styled(Row, {
   },
 });
 
-const TransactionCharts = styled(Row, {
-  "@media (max-width: 768px)": {
-    marginBottom: 178,
-  },
-});
-
 const DashboardTransaction: React.FC = React.memo(() => {
   const { t } = useTranslation();
-  const transactionHistorySub = useSubscription([
-    "transactionsHistory",
-    { amountOfDays: 14 },
-  ]);
   const recentTransactionsCountSub = useSubscription([
     "recentTransactionsCount",
   ]);
@@ -90,15 +80,7 @@ const DashboardTransaction: React.FC = React.memo(() => {
           />
         </Col>
       </TransactionCardNumber>
-      {transactionHistorySub.status === "success" ? (
-        <TransactionCharts>
-          <Col md="12">
-            <DashboardTransactionsHistoryChart
-              transactionHistory={transactionHistorySub.data}
-            />
-          </Col>
-        </TransactionCharts>
-      ) : null}
+      <DashboardTransactionsHistoryChart />
     </DashboardCard>
   );
 });

--- a/frontend/src/components/dashboard/DashboardTransactionsHistoryChart.tsx
+++ b/frontend/src/components/dashboard/DashboardTransactionsHistoryChart.tsx
@@ -1,129 +1,157 @@
 import * as React from "react";
 import ReactEcharts from "echarts-for-react";
 import * as echarts from "echarts";
-import moment from "moment";
 
 import PaginationSpinner from "../utils/PaginationSpinner";
 
 import { useTranslation } from "react-i18next";
-import { TransactionsHistory } from "../../types/common";
+import { TRPCSubscriptionOutput } from "../../types/common";
+import { styled } from "../../libraries/styles";
+import { Col, Row } from "react-bootstrap";
+import { useSubscription } from "../../hooks/use-subscription";
+
+const getOption = (
+  title: string,
+  transactionsTitle: string,
+  data: TRPCSubscriptionOutput<"transactionsHistory">
+) => {
+  return {
+    title: {
+      text: title,
+    },
+    tooltip: {
+      trigger: "axis",
+      position: "top",
+      backgroundColor: "#25272A",
+      formatter: (params: echarts.TooltipComponentFormatterCallbackParams) => {
+        const param = Array.isArray(params) ? params[0] : params;
+        const data = param.data as string[];
+        return `${echarts.time.format(data[0], "{MMM} {dd}", true)}<br />${
+          param.seriesName
+        }: ${data[1]}`;
+      },
+    },
+    grid: {
+      left: "5%",
+      bottom: "3%",
+      containLabel: true,
+      backgroundColor: "#F9F9F9",
+      show: true,
+      color: "white",
+      borderWidth: 0,
+    },
+    xAxis: [
+      {
+        type: "time",
+        boundaryGap: false,
+        axisLine: {
+          show: false,
+        },
+        axisLabel: {
+          color: "#9B9B9B",
+          formatter: "{MMM} {dd}",
+        },
+        offset: 3,
+        axisTick: {
+          show: false,
+        },
+      },
+    ],
+    yAxis: [
+      {
+        type: "value",
+        splitLine: {
+          lineStyle: {
+            color: "white",
+          },
+        },
+        splitNumber: 3,
+        axisLine: {
+          show: false,
+        },
+        axisLabel: {
+          color: "#9B9B9B",
+        },
+        offset: 3,
+        axisTick: {
+          show: false,
+        },
+      },
+    ],
+    series: [
+      {
+        name: transactionsTitle,
+        type: "line",
+        smooth: true,
+        lineStyle: {
+          color: "#00C1DE",
+          width: 2,
+        },
+        symbol: "circle",
+        itemStyle: {
+          color: "#25272A",
+        },
+        areaStyle: {
+          color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
+            {
+              offset: 0,
+              color: "rgba(0, 193, 222, 0.19)",
+            },
+            {
+              offset: 1,
+              color: "rgba(197, 247, 255, 0)",
+            },
+          ]),
+        },
+        data,
+      },
+    ],
+  };
+};
 
 const chartsStyle = {
   height: 232,
   marginVertical: 26,
 };
 
-type Props = {
-  transactionHistory: TransactionsHistory;
-};
+const TransactionCharts = styled(Row, {
+  "@media (max-width: 768px)": {
+    marginBottom: 178,
+  },
+});
 
-const DashboardTransactionHistoryChart: React.FC<Props> = React.memo(
-  ({ transactionHistory = [] }) => {
-    const { t } = useTranslation();
+const DashboardTransactionsHistoryChart: React.FC = React.memo(() => {
+  const transactionHistorySub = useSubscription([
+    "transactionsHistory",
+    { amountOfDays: 14 },
+  ]);
+  const { t, i18n } = useTranslation();
 
-    const option = React.useMemo(() => {
-      const format = t(
-        "component.dashboard.DashboardTransactionHistoryChart.date_format"
-      );
-      return {
-        title: {
-          text: t(
-            "component.dashboard.DashboardTransactionHistoryChart.14_day_history.title"
-          ),
-        },
-        tooltip: {
-          trigger: "axis",
-          position: "top",
-          backgroundColor: "#25272A",
-          formatter: `{b0}<br />${t(
-            "component.dashboard.DashboardTransactionHistoryChart.14_day_history.transactions"
-          )}: {c0}`,
-        },
-        grid: {
-          left: "5%",
-          bottom: "3%",
-          containLabel: true,
-          backgroundColor: "#F9F9F9",
-          show: true,
-          color: "white",
-          borderWidth: 0,
-        },
-        xAxis: [
-          {
-            type: "category",
-            boundaryGap: false,
-            data: transactionHistory.map(({ timestamp }) =>
-              moment(timestamp).format(format)
-            ),
-            axisLine: {
-              show: false,
-            },
-            axisLabel: {
-              color: "#9B9B9B",
-            },
-            offset: 3,
-            axisTick: {
-              show: false,
-            },
-          },
-        ],
-        yAxis: [
-          {
-            type: "value",
-            splitLine: {
-              lineStyle: {
-                color: "white",
-              },
-            },
-            splitNumber: 3,
-            axisLine: {
-              show: false,
-            },
-            axisLabel: {
-              color: "#9B9B9B",
-            },
-            offset: 3,
-            axisTick: {
-              show: false,
-            },
-          },
-        ],
-        series: [
-          {
-            name: "Txns",
-            type: "line",
-            smooth: true,
-            lineStyle: {
-              color: "#00C1DE",
-              width: 2,
-            },
-            symbol: "circle",
-            itemStyle: {
-              color: "#25272A",
-            },
-            areaStyle: {
-              color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
-                {
-                  offset: 0,
-                  color: "rgba(0, 193, 222, 0.19)",
-                },
-                {
-                  offset: 1,
-                  color: "rgba(197, 247, 255, 0)",
-                },
-              ]),
-            },
-            data: transactionHistory.map(({ count }) => count),
-          },
-        ],
-      };
-    }, [t, transactionHistory]);
-
-    if (transactionHistory.length === 0) {
-      return <PaginationSpinner />;
+  const option = React.useMemo(() => {
+    if (!transactionHistorySub.data) {
+      return;
     }
-    return <ReactEcharts option={option} style={chartsStyle} />;
-  }
-);
+    return getOption(
+      t(
+        "component.dashboard.DashboardTransactionHistoryChart.14_day_history.title"
+      ),
+      t(
+        "component.dashboard.DashboardTransactionHistoryChart.14_day_history.transactions"
+      ),
+      transactionHistorySub.data
+    );
+  }, [transactionHistorySub.data, i18n.language]);
+  return (
+    <TransactionCharts>
+      <Col md="12">
+        {option ? (
+          <ReactEcharts option={option} style={chartsStyle} />
+        ) : (
+          <PaginationSpinner />
+        )}
+      </Col>
+    </TransactionCharts>
+  );
+});
 
-export default DashboardTransactionHistoryChart;
+export default DashboardTransactionsHistoryChart;

--- a/frontend/src/components/stats/CirculatingSupplyStats.tsx
+++ b/frontend/src/components/stats/CirculatingSupplyStats.tsx
@@ -2,12 +2,135 @@ import { useTranslation } from "react-i18next";
 import ReactEcharts from "echarts-for-react";
 import * as echarts from "echarts";
 import * as React from "react";
-import JSBI from "jsbi";
 
 import { Props } from "./TransactionsByDate";
 import { useSubscription } from "../../hooks/use-subscription";
 import { styled } from "../../libraries/styles";
-import * as BI from "../../libraries/bigint";
+import { TRPCSubscriptionOutput } from "../../types/common";
+import PaginationSpinner from "../utils/PaginationSpinner";
+
+const getOption = (
+  totalTokenSupplyHeader: string,
+  circulatingTokenSupplyHeader: string,
+  data: TRPCSubscriptionOutput<"tokensSupply">
+) => {
+  return {
+    tooltip: {
+      trigger: "axis",
+      axisPointer: {
+        type: "cross",
+        label: {
+          backgroundColor: "#6a7985",
+        },
+      },
+    },
+    grid: {
+      left: "3%",
+      right: "4%",
+      bottom: "3%",
+      containLabel: true,
+      backgroundColor: "#F9F9F9",
+      show: true,
+      color: "white",
+    },
+    xAxis: [
+      {
+        type: "time",
+        boundaryGap: false,
+      },
+    ],
+    yAxis: [
+      {
+        type: "value",
+        splitLine: {
+          lineStyle: {
+            color: "white",
+          },
+        },
+        name: "NEAR",
+      },
+    ],
+    dataZoom: [
+      {
+        type: "inside",
+        start: 0,
+        end: 100,
+        filterMode: "filter",
+      },
+      {
+        start: 0,
+        end: 100,
+      },
+    ],
+    series: [
+      {
+        name: totalTokenSupplyHeader,
+        type: "line",
+        lineStyle: {
+          color: "#4d84d6",
+          width: 2,
+        },
+        symbol: "none",
+        itemStyle: {
+          color: "#4d84d6",
+        },
+        areaStyle: {
+          color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
+            {
+              offset: 0,
+              color: "rgb(21, 99, 214)",
+            },
+            {
+              offset: 0,
+              color: "rgb(197, 221, 255)",
+            },
+          ]),
+        },
+        emphasis: {
+          focus: "series",
+          itemStyle: {
+            color: "#25272A",
+          },
+        },
+        data: data.map(([timestamp, totalSupply]) => [timestamp, totalSupply]),
+      },
+      {
+        name: circulatingTokenSupplyHeader,
+        type: "line",
+        lineStyle: {
+          color: "#04a7bf",
+          width: 2,
+        },
+        symbol: "none",
+        itemStyle: {
+          color: "#04a7bf",
+        },
+        areaStyle: {
+          color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
+            {
+              offset: 0,
+              color: "rgb(4, 167, 191)",
+            },
+            {
+              offset: 0,
+              color: "rgb(201, 248, 255)",
+            },
+          ]),
+        },
+        emphasis: {
+          focus: "series",
+          itemStyle: {
+            color: "#25272A",
+          },
+        },
+        data: data.map(([timestamp, , circulatingSupply]) => [
+          timestamp,
+          circulatingSupply,
+        ]),
+      },
+    ],
+  };
+};
 
 const SupplyHeader = styled("div", {
   marginLeft: 30,
@@ -25,148 +148,19 @@ const SupplySubHeader = styled("div", {
 });
 
 const CirculatingSupplyStats: React.FC<Props> = React.memo(({ chartStyle }) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const tokensSupplySub = useSubscription(["tokensSupply"]);
-  const circulatingTokenSupply = React.useMemo(
-    () =>
-      (tokensSupplySub.data ?? []).map(({ circulatingSupply }) =>
-        JSBI.toNumber(
-          JSBI.divide(JSBI.BigInt(circulatingSupply), BI.nearNomination)
-        )
-      ),
-    [tokensSupplySub.data]
-  );
-  const totalTokenSupply = React.useMemo(
-    () =>
-      (tokensSupplySub.data ?? []).map(({ totalSupply }) =>
-        JSBI.toNumber(JSBI.divide(JSBI.BigInt(totalSupply), BI.nearNomination))
-      ),
-    [tokensSupplySub.data]
-  );
-  const supplyDates = React.useMemo(
-    () =>
-      (tokensSupplySub.data ?? []).map(({ timestamp }) =>
-        new Date(timestamp).toISOString().slice(0, 10)
-      ),
-    [tokensSupplySub.data]
-  );
 
-  const getOption = (seriesNameArray: Array<string>) => {
-    return {
-      tooltip: {
-        trigger: "axis",
-        axisPointer: {
-          type: "cross",
-          label: {
-            backgroundColor: "#6a7985",
-          },
-        },
-      },
-      grid: {
-        left: "3%",
-        right: "4%",
-        bottom: "3%",
-        containLabel: true,
-        backgroundColor: "#F9F9F9",
-        show: true,
-        color: "white",
-      },
-      xAxis: [
-        {
-          type: "category",
-          boundaryGap: false,
-          data: supplyDates,
-        },
-      ],
-      yAxis: [
-        {
-          type: "value",
-          splitLine: {
-            lineStyle: {
-              color: "white",
-            },
-          },
-          name: "NEAR",
-        },
-      ],
-      dataZoom: [
-        {
-          type: "inside",
-          start: 0,
-          end: 100,
-          filterMode: "filter",
-        },
-        {
-          start: 0,
-          end: 100,
-        },
-      ],
-      series: [
-        {
-          name: seriesNameArray[0],
-          type: "line",
-          lineStyle: {
-            color: "#4d84d6",
-            width: 2,
-          },
-          symbol: "circle",
-          itemStyle: {
-            color: "#4d84d6",
-          },
-          areaStyle: {
-            color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
-              {
-                offset: 0,
-                color: "rgb(21, 99, 214)",
-              },
-              {
-                offset: 0,
-                color: "rgb(197, 221, 255)",
-              },
-            ]),
-          },
-          emphasis: {
-            focus: "series",
-            itemStyle: {
-              color: "#25272A",
-            },
-          },
-          data: totalTokenSupply,
-        },
-        {
-          name: seriesNameArray[1],
-          type: "line",
-          lineStyle: {
-            color: "#04a7bf",
-            width: 2,
-          },
-          symbol: "circle",
-          itemStyle: {
-            color: "#04a7bf",
-          },
-          areaStyle: {
-            color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
-              {
-                offset: 0,
-                color: "rgb(4, 167, 191)",
-              },
-              {
-                offset: 0,
-                color: "rgb(201, 248, 255)",
-              },
-            ]),
-          },
-          emphasis: {
-            focus: "series",
-            itemStyle: {
-              color: "#25272A",
-            },
-          },
-          data: circulatingTokenSupply,
-        },
-      ],
-    };
-  };
+  const option = React.useMemo(() => {
+    if (!tokensSupplySub.data) {
+      return;
+    }
+    return getOption(
+      t("component.stats.CirculatingSupplyStats.tooltip.total_tokens_supply"),
+      t("component.stats.CirculatingSupplyStats.tooltip.circulating_supply"),
+      tokensSupplySub.data
+    );
+  }, [tokensSupplySub.data, i18n.language]);
 
   return (
     <>
@@ -178,20 +172,17 @@ const CirculatingSupplyStats: React.FC<Props> = React.memo(({ chartStyle }) => {
           "component.stats.CirculatingSupplyStats.tooltip.total_tokens_supply_explain"
         )}
       </SupplySubHeader>
-      <ReactEcharts
-        option={getOption([
-          `${t(
-            "component.stats.CirculatingSupplyStats.tooltip.total_tokens_supply"
-          )}`,
-          `${t(
-            "component.stats.CirculatingSupplyStats.tooltip.circulating_supply"
-          )}`,
-        ])}
-        style={{
-          ...chartStyle,
-          marginTop: "5px",
-        }}
-      />
+      {option ? (
+        <ReactEcharts
+          option={option}
+          style={{
+            ...chartStyle,
+            marginTop: "5px",
+          }}
+        />
+      ) : (
+        <PaginationSpinner />
+      )}
     </>
   );
 });

--- a/frontend/src/components/stats/TransactionsByDate.tsx
+++ b/frontend/src/components/stats/TransactionsByDate.tsx
@@ -3,10 +3,88 @@ import { Tabs, Tab } from "react-bootstrap";
 import ReactEcharts from "echarts-for-react";
 import * as echarts from "echarts";
 
-import { cumulativeSumArray } from "../../libraries/stats";
-
 import { useTranslation } from "react-i18next";
 import { useSubscription } from "../../hooks/use-subscription";
+import PaginationSpinner from "../utils/PaginationSpinner";
+
+const getOption = (
+  title: string,
+  seriesName: string,
+  data: [number, number][]
+) => {
+  return {
+    title: {
+      text: title,
+    },
+    tooltip: {
+      trigger: "axis",
+    },
+    grid: {
+      left: "3%",
+      right: "4%",
+      bottom: "3%",
+      containLabel: true,
+      backgroundColor: "#F9F9F9",
+      show: true,
+      color: "white",
+    },
+    xAxis: [
+      {
+        type: "time",
+        boundaryGap: false,
+      },
+    ],
+    yAxis: [
+      {
+        type: "value",
+        splitLine: {
+          lineStyle: {
+            color: "white",
+          },
+        },
+      },
+    ],
+    dataZoom: [
+      {
+        type: "inside",
+        start: 0,
+        end: 100,
+        filterMode: "filter",
+      },
+      {
+        start: 0,
+        end: 100,
+      },
+    ],
+    series: [
+      {
+        name: seriesName,
+        type: "line",
+        lineStyle: {
+          color: "#00C1DE",
+          width: 2,
+        },
+        symbol: "none",
+        itemStyle: {
+          color: "#25272A",
+        },
+        areaStyle: {
+          color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
+            {
+              offset: 0,
+              color: "rgb(0, 193, 222)",
+            },
+            {
+              offset: 1,
+              color: "rgb(197, 247, 255)",
+            },
+          ]),
+        },
+        data,
+      },
+    ],
+  };
+};
 
 export interface Props {
   chartStyle: object;
@@ -14,128 +92,60 @@ export interface Props {
 
 const TransactionsByDateChart: React.FC<Props> = React.memo(
   ({ chartStyle }) => {
-    const { t } = useTranslation();
+    const { t, i18n } = useTranslation();
     const transactionsHistorySub = useSubscription(["transactionsHistory"]);
-    const transactionsByDate = React.useMemo(
-      () => (transactionsHistorySub.data ?? []).map(({ count }) => count),
-      [transactionsHistorySub.data]
-    );
-    const transactionsByDateCumulative = React.useMemo(
-      () => cumulativeSumArray(transactionsByDate),
-      [transactionsByDate]
-    );
-    const transactionDates = React.useMemo(
-      () =>
-        (transactionsHistorySub.data ?? []).map(({ timestamp }) =>
-          new Date(timestamp).toISOString().slice(0, 10)
-        ),
-      [transactionsHistorySub.data]
-    );
 
-    const getOption = (
-      title: string,
-      seriesName: string,
-      data: Array<number>
-    ) => {
+    const options = React.useMemo(() => {
+      if (!transactionsHistorySub.data) {
+        return;
+      }
       return {
-        title: {
-          text: title,
-        },
-        tooltip: {
-          trigger: "axis",
-        },
-        grid: {
-          left: "3%",
-          right: "4%",
-          bottom: "3%",
-          containLabel: true,
-          backgroundColor: "#F9F9F9",
-          show: true,
-          color: "white",
-        },
-        xAxis: [
-          {
-            type: "category",
-            boundaryGap: false,
-            data: transactionDates,
-          },
-        ],
-        yAxis: [
-          {
-            type: "value",
-            splitLine: {
-              lineStyle: {
-                color: "white",
-              },
+        daily: getOption(
+          t("component.stats.TransactionsByDate.daily_number_of_transactions"),
+          t("component.stats.TransactionsByDate.transactions"),
+          transactionsHistorySub.data
+        ),
+        cumulative: getOption(
+          t("component.stats.TransactionsByDate.total_number_of_transactions"),
+          t("component.stats.TransactionsByDate.transactions"),
+          transactionsHistorySub.data.reduce<{
+            cumulativeData: number;
+            series: [number, number][];
+          }>(
+            (
+              { cumulativeData: prevCumulativeData, series },
+              [timestamp, data]
+            ) => {
+              const cumulativeData = prevCumulativeData + data;
+              return {
+                cumulativeData,
+                series: [...series, [timestamp, cumulativeData]],
+              };
             },
-          },
-        ],
-        dataZoom: [
-          {
-            type: "inside",
-            start: 0,
-            end: 100,
-            filterMode: "filter",
-          },
-          {
-            start: 0,
-            end: 100,
-          },
-        ],
-        series: [
-          {
-            name: seriesName,
-            type: "line",
-            lineStyle: {
-              color: "#00C1DE",
-              width: 2,
-            },
-            symbol: "circle",
-            itemStyle: {
-              color: "#25272A",
-            },
-            areaStyle: {
-              color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
-                {
-                  offset: 0,
-                  color: "rgb(0, 193, 222)",
-                },
-                {
-                  offset: 1,
-                  color: "rgb(197, 247, 255)",
-                },
-              ]),
-            },
-            data: data,
-          },
-        ],
+            {
+              cumulativeData: 0,
+              series: [],
+            }
+          ).series
+        ),
       };
-    };
+    }, [transactionsHistorySub.data, i18n.language]);
+
     return (
       <Tabs defaultActiveKey="daily" id="transactionByDate">
         <Tab eventKey="daily" title={t("common.stats.daily")}>
-          <ReactEcharts
-            option={getOption(
-              t(
-                "component.stats.TransactionsByDate.daily_number_of_transactions"
-              ),
-              t("component.stats.TransactionsByDate.transactions"),
-              transactionsByDate
-            )}
-            style={chartStyle}
-          />
+          {options ? (
+            <ReactEcharts option={options.daily} style={chartStyle} />
+          ) : (
+            <PaginationSpinner />
+          )}
         </Tab>
         <Tab eventKey="total" title={t("common.stats.total")}>
-          <ReactEcharts
-            option={getOption(
-              t(
-                "component.stats.TransactionsByDate.total_number_of_transactions"
-              ),
-              t("component.stats.TransactionsByDate.transactions"),
-              transactionsByDateCumulative
-            )}
-            style={chartStyle}
-          />
+          {options ? (
+            <ReactEcharts option={options.cumulative} style={chartStyle} />
+          ) : (
+            <PaginationSpinner />
+          )}
         </Tab>
       </Tabs>
     );

--- a/frontend/src/libraries/bigint.ts
+++ b/frontend/src/libraries/bigint.ts
@@ -1,4 +1,5 @@
 import JSBI from "jsbi";
+import { nearNominationExponent } from "../../../common/src/utils/near";
 
 export const zero = JSBI.BigInt(0);
 export const minusOne = JSBI.BigInt(-1);
@@ -25,8 +26,9 @@ export const cmp = (a: JSBI, b: JSBI) => {
   return -1;
 };
 
-export const nearNominationExponent = 24;
 export const nearNomination = JSBI.exponentiate(
   ten,
   JSBI.BigInt(nearNominationExponent)
 );
+
+export { nearNominationExponent };

--- a/frontend/src/translations/en/common.json
+++ b/frontend/src/translations/en/common.json
@@ -499,8 +499,7 @@
         "14_day_history": {
           "title": "14 Day History",
           "transactions": "Txns"
-        },
-        "date_format": "MMM D"
+        }
       }
     },
     "stats": {

--- a/frontend/src/translations/ru/common.json
+++ b/frontend/src/translations/ru/common.json
@@ -499,8 +499,7 @@
         "14_day_history": {
           "title": "История за 14 дней",
           "transactions": "Количество транзакций за 14 дней"
-        },
-        "date_format": "D MMM"
+        }
       }
     },
     "stats": {

--- a/frontend/src/translations/ua/common.json
+++ b/frontend/src/translations/ua/common.json
@@ -499,8 +499,7 @@
         "14_day_history": {
           "title": "Історія за 14 днів",
           "transactions": "Транзакції"
-        },
-        "date_format": "MMM D"
+        }
       }
     },
     "stats": {

--- a/frontend/src/translations/vi/common.json
+++ b/frontend/src/translations/vi/common.json
@@ -499,8 +499,7 @@
         "14_day_history": {
           "title": "Lịch sử 14 ngày",
           "transactions": "GD"
-        },
-        "date_format": "MMM D"
+        }
       }
     },
     "stats": {

--- a/frontend/src/translations/zh-hans/common.json
+++ b/frontend/src/translations/zh-hans/common.json
@@ -560,8 +560,7 @@
         "14_day_history": {
           "title": "过去14天历史",
           "transactions": "交易数"
-        },
-        "date_format": "MoDo"
+        }
       }
     },
     "utils": {


### PR DESCRIPTION
What's that about?
- sending less prop names over the wire in big (500+ items) arrays
- calculating bigints of those arrays once every hour on backend side rather than on frontend side on every render
- factoring out `getOption`s functions not to recreate them on every render
- leveraging `time` type of echarts
- spinners on proper places of loading charts