### PR TITLE
Refactor: rename old transaction

### DIFF
--- a/common/src/types/procedures.ts
+++ b/common/src/types/procedures.ts
@@ -29,16 +29,13 @@ export type TransactionListResponse = TRPCQueryOutput<
 >;
 export type TransactionPreview = TransactionListResponse["items"][number];
 
-export type TransactionDetails = NonNullable<TRPCQueryOutput<"transaction">>;
+export type Transaction = NonNullable<TRPCQueryOutput<"transaction">>;
+export type TransactionStatus = Transaction["status"];
 
 export type Action = TransactionPreview["actions"][number];
-export type NestedReceiptWithOutcome = NonNullable<
-  TRPCQueryOutput<"transaction-info">
->["receipt"];
-export type Transaction = NonNullable<TRPCQueryOutput<"transaction-info">>;
-export type TransactionOutcome = NonNullable<
-  TRPCQueryOutput<"transaction-info">
->["transactionOutcome"];
+export type TransactionOld = NonNullable<TRPCQueryOutput<"transaction-info">>;
+export type NestedReceiptWithOutcome = TransactionOld["receipt"];
+export type TransactionOutcome = TransactionOld["transactionOutcome"];
 
 export type DeployInfo = TRPCQueryOutput<"utils.deployInfo">;
 

--- a/frontend/src/components/beta/transactions/TransactionHeader.tsx
+++ b/frontend/src/components/beta/transactions/TransactionHeader.tsx
@@ -7,11 +7,11 @@ import Moment from "../../../libraries/moment";
 import CopyToClipboard from "../../beta/common/CopyToClipboard";
 import { NearAmount } from "../../utils/NearAmount";
 import TransactionStatus from "./TransactionStatus";
-import { TransactionDetails } from "../../../types/common";
+import { Transaction } from "../../../types/common";
 import UtcLabel from "../common/UtcLabel";
 
 type Props = {
-  transaction: TransactionDetails;
+  transaction: Transaction;
 };
 
 const AVATAR_SIZE = 26;

--- a/frontend/src/components/beta/transactions/TransactionStatus.tsx
+++ b/frontend/src/components/beta/transactions/TransactionStatus.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
-import { TransactionDetails } from "../../../types/common";
+import { TransactionStatus } from "../../../types/common";
 import { styled } from "../../../libraries/styles";
 
 type Props = {
-  status: TransactionDetails["status"];
+  status: TransactionStatus;
 };
 
 const Label = styled("div", {
@@ -35,11 +35,11 @@ const Label = styled("div", {
   },
 });
 
-const TransactionStatus: React.FC<Props> = React.memo(({ status }) => {
+const TransactionStatusView: React.FC<Props> = React.memo(({ status }) => {
   const { t } = useTranslation();
   return (
     <Label type={status}>{t(`common.transactions.status.${status}`)}</Label>
   );
 });
 
-export default TransactionStatus;
+export default TransactionStatusView;

--- a/frontend/src/components/transactions/TransactionDetails.tsx
+++ b/frontend/src/components/transactions/TransactionDetails.tsx
@@ -15,7 +15,7 @@ import TransactionExecutionStatus from "./TransactionExecutionStatus";
 import { useTranslation } from "react-i18next";
 import { useSubscription } from "../../hooks/use-subscription";
 import { styled } from "../../libraries/styles";
-import { RPC, Transaction } from "../../types/common";
+import { RPC, TransactionOld } from "../../types/common";
 import * as BI from "../../libraries/bigint";
 
 const HeaderRow = styled(Row);
@@ -52,7 +52,7 @@ const TransactionStatusWrapper = styled("div", {
 });
 
 export interface Props {
-  transaction: Transaction;
+  transaction: TransactionOld;
 }
 
 export interface State {

--- a/frontend/src/components/transactions/TransactionExecutionStatus.tsx
+++ b/frontend/src/components/transactions/TransactionExecutionStatus.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import { Transaction } from "../../types/common";
+import { TransactionStatus } from "../../types/common";
 import { useTranslation } from "react-i18next";
 
 export interface Props {
-  status: Transaction["status"];
+  status: TransactionStatus;
 }
 const TransactionExecutionStatusComponent: React.FC<Props> = React.memo(
   ({ status }) => {

--- a/frontend/src/components/transactions/__tests__/common.tsx
+++ b/frontend/src/components/transactions/__tests__/common.tsx
@@ -1,6 +1,6 @@
-import { Receipt, Transaction } from "../../../types/common";
+import { Receipt, TransactionOld } from "../../../types/common";
 
-export const TRANSACTIONS: Transaction[] = [
+export const TRANSACTIONS: TransactionOld[] = [
   // no action has deposit
   {
     hash: "BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj",
@@ -406,7 +406,7 @@ export const TRANSACTIONS: Transaction[] = [
   },
 ];
 
-export const TRANSACTION_WITH_SUCCESSFUL_RECEIPT: Transaction = {
+export const TRANSACTION_WITH_SUCCESSFUL_RECEIPT: TransactionOld = {
   hash: "T1111111111111111111111111111111111111111111",
   signerId: "signer.test",
   receiverId: "receiver.test",
@@ -493,7 +493,7 @@ export const TRANSACTION_WITH_SUCCESSFUL_RECEIPT: Transaction = {
   },
 };
 
-export const TRANSACTION_WITH_MANY_RECEIPTS: Transaction = {
+export const TRANSACTION_WITH_MANY_RECEIPTS: TransactionOld = {
   hash: "T1111111111111111111111111111111111111111111",
   signerId: "signer.test",
   receiverId: "receiver.test",
@@ -676,7 +676,7 @@ export const TRANSACTION_WITH_MANY_RECEIPTS: Transaction = {
   },
 };
 
-export const TRANSACTION_WITH_FAILING_RECEIPT: Transaction = {
+export const TRANSACTION_WITH_FAILING_RECEIPT: TransactionOld = {
   hash: "T1111111111111111111111111111111111111111111",
   signerId: "signer.test",
   receiverId: "receiver.test",

--- a/frontend/src/pages/beta/transactions/[hash].tsx
+++ b/frontend/src/pages/beta/transactions/[hash].tsx
@@ -6,7 +6,7 @@ import * as ReactQuery from "react-query";
 import { useTranslation } from "react-i18next";
 import { NextPage } from "next";
 
-import { TransactionDetails } from "../../../types/common";
+import { Transaction } from "../../../types/common";
 import { useAnalyticsTrackOnMount } from "../../../hooks/analytics/use-analytics-track-on-mount";
 
 import TransactionHeader from "../../../components/beta/transactions/TransactionHeader";
@@ -47,7 +47,7 @@ const TransactionPage: NextPage<Props> = React.memo((props) => {
   );
 });
 
-type QueryProps = ReactQuery.UseQueryResult<TransactionDetails | null> & {
+type QueryProps = ReactQuery.UseQueryResult<Transaction | null> & {
   hash: string;
 };
 


### PR DESCRIPTION
Part of transaction router refactor: https://github.com/near/near-explorer/pull/1065
Renaming `Transaction` to remove confusion