### PR TITLE
feat: Added support for API keys for NEAR RPC

### DIFF
--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -16,6 +16,7 @@ NEAR_EXPLORER_CONFIG__ACCOUNT_ID_SUFFIX__STAKING_POOL__LOCALNET
 export const config = merge(
   {
     archivalRpcUrl: "http://localhost:3030",
+    archivalRpcApiKey: "",
     networkName: "localnet" as NetworkName,
     accountIdSuffix: {
       lockup: "lockup.near",

--- a/backend/src/utils/near.ts
+++ b/backend/src/utils/near.ts
@@ -6,6 +6,9 @@ import { RPC } from "../types";
 
 const nearRpc = new nearApi.providers.JsonRpcProvider({
   url: config.archivalRpcUrl,
+  headers: config.archivalRpcApiKey
+    ? { "x-api-key": config.archivalRpcApiKey }
+    : undefined,
 });
 
 export const sendJsonRpc = <M extends keyof RPC.ResponseMapping>(


### PR DESCRIPTION
In order to migrate to Pagoda RPC-a-a-S we will need this small change. I tested it and it works great, so we will probably switch to using those NEAR RPCs instead of the private archival nodes.

This change is completely backward compatible.