### PR TITLE
Refactor: Introduce useFormatDistance hook

### DIFF
--- a/frontend/src/components/utils/Timer.tsx
+++ b/frontend/src/components/utils/Timer.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useEverySecond } from "../../hooks/use-every-second";
-import { useFormatDistanceToNow } from "../../hooks/use-format-distance-to-now";
+import { useFormatDistance } from "../../hooks/use-format-distance";
 
 interface Props {
   time?: number;
@@ -11,7 +11,7 @@ const Timer: React.FC<Props> = React.memo((props) => {
   useEverySecond(() => setCounter((c) => c + 1), [setCounter, props.time], {
     runOnMount: true,
   });
-  const formatDuration = useFormatDistanceToNow();
+  const formatDuration = useFormatDistance();
   return <span>{formatDuration(props.time || new Date())}</span>;
 });
 

--- a/frontend/src/hooks/use-format-distance.ts
+++ b/frontend/src/hooks/use-format-distance.ts
@@ -32,16 +32,19 @@ const formatDurationString = (
   );
 };
 
-export const useFormatDistanceToNow = () => {
+export const useFormatDistance = () => {
   const { locale } = React.useContext(LanguageContext);
   return React.useCallback(
-    (timestamp: number | Date) => {
+    (
+      timestampStart: number | Date,
+      timestampEnd: number | Date = new Date()
+    ) => {
       if (!locale) {
         return "";
       }
       const duration = intervalToDuration({
-        start: timestamp,
-        end: new Date(),
+        start: timestampStart,
+        end: timestampEnd,
       });
       return formatDurationString(duration, locale.durationFormatter);
     },


### PR DESCRIPTION
I decided to improve `useFormatDistanceToNow` hook and now it can calculate interval to a given timestamp. That’s because I need this in this PR #1048 