### PR TITLE
Support a new TelemetryInfo field: 'blob'

### DIFF
--- a/backend/src/database/models/readOnlyTelemetry/nodes.ts
+++ b/backend/src/database/models/readOnlyTelemetry/nodes.ts
@@ -40,6 +40,8 @@ export default interface Nodes {
   longitude: string | null;
 
   city: string | null;
+
+  blob: string | null;
 }
 
 export interface NodesInitializer {
@@ -79,4 +81,6 @@ export interface NodesInitializer {
   longitude?: string | null;
 
   city?: string | null;
+
+  blob?: string | null;
 }

--- a/backend/src/database/models/readOnlyTelemetry/nodes.ts
+++ b/backend/src/database/models/readOnlyTelemetry/nodes.ts
@@ -41,7 +41,7 @@ export default interface Nodes {
 
   city: string | null;
 
-  blob: string | null;
+  extra_info: string | null;
 }
 
 export interface NodesInitializer {
@@ -82,5 +82,5 @@ export interface NodesInitializer {
 
   city?: string | null;
 
-  blob?: string | null;
+  extra_info?: string | null;
 }

--- a/backend/src/router/telemetry.ts
+++ b/backend/src/router/telemetry.ts
@@ -41,6 +41,7 @@ export const router = trpc.router<Context>().mutation("upsert", {
         latitude: geo ? geo.ll[0].toString() : null,
         longitude: geo ? geo.ll[1].toString() : null,
         city: geo ? geo.city : null,
+        blob: nodeInfo.blob,
       })
       .onConflict((oc) =>
         oc.column("node_id").doUpdateSet({
@@ -60,6 +61,7 @@ export const router = trpc.router<Context>().mutation("upsert", {
           latitude: (eb) => eb.ref("excluded.latitude"),
           longitude: (eb) => eb.ref("excluded.longitude"),
           city: (eb) => eb.ref("excluded.city"),
+          blob: (eb) => eb.ref("excluded.blob"),
         })
       );
 

--- a/backend/src/router/telemetry.ts
+++ b/backend/src/router/telemetry.ts
@@ -41,7 +41,7 @@ export const router = trpc.router<Context>().mutation("upsert", {
         latitude: geo ? geo.ll[0].toString() : null,
         longitude: geo ? geo.ll[1].toString() : null,
         city: geo ? geo.city : null,
-        blob: nodeInfo.blob,
+        extra_info: nodeInfo.extra_info,
       })
       .onConflict((oc) =>
         oc.column("node_id").doUpdateSet({
@@ -61,7 +61,7 @@ export const router = trpc.router<Context>().mutation("upsert", {
           latitude: (eb) => eb.ref("excluded.latitude"),
           longitude: (eb) => eb.ref("excluded.longitude"),
           city: (eb) => eb.ref("excluded.city"),
-          blob: (eb) => eb.ref("excluded.blob"),
+          extra_info: (eb) => eb.ref("excluded.extra_info"),
         })
       );
 

--- a/backend/src/router/validators.ts
+++ b/backend/src/router/validators.ts
@@ -35,6 +35,6 @@ export const validators = {
       latest_block_hash: z.string(),
       status: z.string(),
     }),
-    blob: z.string(),
+    extra_info: z.string(),
   }),
 };

--- a/backend/src/router/validators.ts
+++ b/backend/src/router/validators.ts
@@ -35,5 +35,6 @@ export const validators = {
       latest_block_hash: z.string(),
       status: z.string(),
     }),
+    blob: z.string(),
   }),
 };

--- a/backend/src/utils/telemetry.ts
+++ b/backend/src/utils/telemetry.ts
@@ -26,6 +26,6 @@ export const setupTelemetryDb = async () => {
     .addColumn("latitude", "numeric(8, 6)")
     .addColumn("longitude", "numeric(9, 6)")
     .addColumn("city", "varchar(255)")
-    .addColumn("blob", "varchar(1048575)")
+    .addColumn("extra_info", "varchar(1048575)")
     .execute();
 };

--- a/backend/src/utils/telemetry.ts
+++ b/backend/src/utils/telemetry.ts
@@ -26,5 +26,6 @@ export const setupTelemetryDb = async () => {
     .addColumn("latitude", "numeric(8, 6)")
     .addColumn("longitude", "numeric(9, 6)")
     .addColumn("city", "varchar(255)")
+    .addColumn("blob", "varchar(1048575)")
     .execute();
 };


### PR DESCRIPTION
Support a new TelemetryInfo field: 'blob', which will be stored in the DB as a string. This field will let us easily extend TelemetryInfo without modifying explorer backend or the DB schema.