### PR TITLE
fix: Vietnamese translation of transaction status `success`

### DIFF
--- a/frontend/src/translations/vi/common.json
+++ b/frontend/src/translations/vi/common.json
@@ -22,7 +22,7 @@
       "status": {
         "unknown": "Xử lý...",
         "failure": "Thất bại",
-        "success": "Thất bại"
+        "success": "Thành công"
       },
       "execution": {
         "convert_transaction_to_receipt": "Chuyển Giao Dịch Thành Biên Nhận",


### PR DESCRIPTION
### Problem

Due to the change in the PR: https://github.com/near/near-explorer/pull/1070/files#diff-66205e01d9991ccf3505fa0f9f55c265bc8d8dd63f2cc43a3744e13c3238754a, the translation of transaction status `success` is wrong for Vietnamese, which has been misleading Vietnamese users because all successful transactions are now `failure`. 

### Recommendation

To avoid such issue in the long run, for critical and impactful update to the translation JSON files, it would be recommended to request review from at least one contributor who knows well about the language. 

We can create a file (e.g. `translation.md`) that tracks the translators / owners for each language if needed.

```md
en: @alice
ru: @bob
zh-Hans: @charlie
vi: @dave
```

