### PR TITLE
Feature: receipt redirect page

### DIFF
--- a/backend/src/router/receipt/get-transaction-hash.ts
+++ b/backend/src/router/receipt/get-transaction-hash.ts
@@ -1,0 +1,26 @@
+import * as trpc from "@trpc/server";
+import { SelectQueryBuilder } from "kysely";
+import {
+  TableExpressionDatabase,
+  TableExpressionTables,
+} from "kysely/dist/cjs/parser/table-parser";
+import { z } from "zod";
+
+import { Context } from "../../context";
+import { indexerDatabase } from "../../database/databases";
+import { validators } from "../validators";
+
+export const router = trpc.router<Context>().query("getTransactionHash", {
+  input: z.strictObject({ id: validators.receiptId }),
+  resolve: async ({ input: { id } }) => {
+    const row = await indexerDatabase
+      .selectFrom("receipts")
+      .where("receipts.receipt_id", "=", id)
+      .select("originated_from_transaction_hash as transactionHash")
+      .executeTakeFirst();
+    if (!row) {
+      return null;
+    }
+    return row.transactionHash;
+  },
+});

--- a/backend/src/router/receipt/index.ts
+++ b/backend/src/router/receipt/index.ts
@@ -1,5 +1,9 @@
 import * as trpc from "@trpc/server";
 import { Context } from "../../context";
 import { router as listRouter } from "./list";
+import { router as getTransactionHashRouter } from "./get-transaction-hash";
 
-export const router = trpc.router<Context>().merge(listRouter);
+export const router = trpc
+  .router<Context>()
+  .merge(listRouter)
+  .merge(getTransactionHashRouter);

--- a/frontend/src/pages/receipts/[id].tsx
+++ b/frontend/src/pages/receipts/[id].tsx
@@ -1,0 +1,59 @@
+import * as React from "react";
+
+import { useTranslation } from "react-i18next";
+import { GetServerSideProps, NextPage } from "next";
+import Head from "next/head";
+import { useRouter } from "next/router";
+
+import Content from "../../components/utils/Content";
+import { getTrpcClient } from "../../libraries/trpc";
+import { getNearNetworkName } from "../../libraries/config";
+import { shortenString } from "../../libraries/formatting";
+
+const ReceiptRedirectPage: NextPage = React.memo(() => {
+  const receiptId = useRouter().query.id as string;
+  const { t } = useTranslation();
+  return (
+    <>
+      <Head>
+        <title>NEAR Explorer | Receipt</title>
+      </Head>
+      <Content
+        title={
+          <h1>
+            {t("common.receipts.receipt")}: {shortenString(receiptId)}
+          </h1>
+        }
+        border={false}
+      >
+        {t("page.transactions.error.transaction_fetching")}
+      </Content>
+    </>
+  );
+});
+
+export const getServerSideProps: GetServerSideProps<
+  {},
+  { id: string }
+> = async ({ req, query, params }) => {
+  const receiptId = params?.id ?? "";
+  if (!receiptId) {
+    return { props: {} };
+  }
+  const networkName = getNearNetworkName(query, req.headers.host);
+  const transactionHash = await getTrpcClient(networkName).query(
+    "receipt.getTransactionHash",
+    { id: receiptId }
+  );
+  if (!transactionHash) {
+    return { props: {} };
+  }
+  return {
+    redirect: {
+      permanent: true,
+      destination: `/transactions/${transactionHash}#${receiptId}`,
+    },
+  };
+};
+
+export default ReceiptRedirectPage;


### PR DESCRIPTION
Adding an ability to fetch page `https://explorer.near.org/receipts/<receipt_id>/` and get redirected to `https://explorer.near.org/transactions/<transaction_hash>#<receipt_id>/`.