### PR TITLE
The index page now supports an optional 'q' query string param for searching

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Q: How to run the local development version of the frontend/backend?
 
 A: It is recommended to use `docker-compose` to run all the services and then stop the one that
 you want to develop locally (`docker-compose stop frontend`). (Follow the execution instructions
-written in the relevant README file of the subproject)
+written in the relevant README file of the subproject, such as
+[frontend/README.md](frontend/README.md) or [backend/README.md](backend/README.md).)
 
 Q: How to auto-format the source code on commit?
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -40,7 +40,7 @@ Project Root
 
 ## Run Frontend for Development
 
-Frontend required running backend to be run in the background to be usable.
+Frontend requires running backend to be run in the background to be usable.
 Follow the [backend instructions](../backend/README.md) and start frontend like this:
 
 ```

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -12,6 +12,7 @@ import { styled } from "../libraries/styles";
 import { DashboardCardWrapper } from "../components/utils/DashboardCard";
 import * as React from "react";
 import { NextPage } from "next";
+import { NextRouter, useRouter } from "next/router";
 
 const InnerContent = styled(Row, {
   margin: "71px 185px",
@@ -49,7 +50,19 @@ const DashboardContainer = styled(Container, {
   },
 });
 
+const getQuery: (router: NextRouter) => string = (router) => {
+  // Gets the optional `q` query string parameter.
+  const { q } = router.query;
+  if (q) {
+    return typeof q === "string" ? q : q[0];
+  }
+  return "";
+};
+
 const Dashboard: NextPage = React.memo(() => {
+  const router = useRouter();
+  const query = getQuery(router);
+  console.log({ query });
   const { t } = useTranslation();
   useAnalyticsTrackOnMount("Explorer View Landing Page");
 
@@ -66,7 +79,7 @@ const Dashboard: NextPage = React.memo(() => {
         <InnerContent noGutters>
           <Col xs="12" className="d-none d-md-block d-lg-block">
             <SearchRowWrapper noGutters>
-              <Search dashboard />
+              <Search dashboard query={query} />
             </SearchRowWrapper>
           </Col>
           <Col xs="12">


### PR DESCRIPTION
I love setting up Custom Search Engines in Chrome and Brave browsers, but it seemed impossible to do it for NEAR Explorer until this PR.

chrome://settings/searchEngines

Now, as you can see in this gif, I can set up `ex` (or any key word that I choose) to be a key word that allows me to conveniently search for NEAR accounts or transactions or blocks straight from my Chrome address bar.

![custom search engine](https://user-images.githubusercontent.com/2086493/186516692-33d167f3-d2fa-4066-915f-9609b0fb9cfa.gif)