### PR TITLE
Store all fields from TelemetryInfo in the telemetry DB

### DIFF
--- a/backend/src/database/models/readOnlyTelemetry/nodes.ts
+++ b/backend/src/database/models/readOnlyTelemetry/nodes.ts
@@ -40,6 +40,24 @@ export default interface Nodes {
   longitude: string | null;
 
   city: string | null;
+
+  bandwidth_download: number | null;
+
+  bandwidth_upload: number | null;
+
+  cpu_usage: number | null;
+
+  memory_usage: number | null;
+
+  boot_time_seconds: Date | null;
+
+  block_production_tracking_delay: number | null;
+
+  min_block_production_delay: number | null;
+
+  max_block_production_delay: number | null;
+
+  max_block_wait_delay: number | null;
 }
 
 export interface NodesInitializer {

--- a/backend/src/database/models/readOnlyTelemetry/nodes.ts
+++ b/backend/src/database/models/readOnlyTelemetry/nodes.ts
@@ -41,23 +41,16 @@ export default interface Nodes {
 
   city: string | null;
 
-  bandwidth_download: number | null;
+  bandwidth_download?: number | null;
+  bandwidth_upload?: number | null;
+  cpu_usage?: number | null;
+  memory_usage?: number | null;
+  boot_time_seconds?: Date | null;
 
-  bandwidth_upload: number | null;
-
-  cpu_usage: number | null;
-
-  memory_usage: number | null;
-
-  boot_time_seconds: Date | null;
-
-  block_production_tracking_delay: number | null;
-
-  min_block_production_delay: number | null;
-
-  max_block_production_delay: number | null;
-
-  max_block_wait_delay: number | null;
+  block_production_tracking_delay?: number | null;
+  min_block_production_delay?: number | null;
+  max_block_production_delay?: number | null;
+  max_block_wait_delay?: number | null;
 }
 
 export interface NodesInitializer {
@@ -97,4 +90,15 @@ export interface NodesInitializer {
   longitude?: string | null;
 
   city?: string | null;
+
+  bandwidth_download?: number | null;
+  bandwidth_upload?: number | null;
+  cpu_usage?: number | null;
+  memory_usage?: number | null;
+  boot_time_seconds?: Date | null;
+
+  block_production_tracking_delay?: number | null;
+  min_block_production_delay?: number | null;
+  max_block_production_delay?: number | null;
+  max_block_wait_delay?: number | null;
 }

--- a/backend/src/router/telemetry.ts
+++ b/backend/src/router/telemetry.ts
@@ -41,6 +41,20 @@ export const router = trpc.router<Context>().mutation("upsert", {
         latitude: geo ? geo.ll[0].toString() : null,
         longitude: geo ? geo.ll[1].toString() : null,
         city: geo ? geo.city : null,
+
+        bandwidth_download: nodeInfo.system.bandwidth_download,
+        bandwidth_upload: nodeInfo.system.bandwidth_upload,
+        cpu_usage: nodeInfo.system.cpu_usage,
+        memory_usage: nodeInfo.system.memory_usage,
+        boot_time_seconds: nodeInfo.system.boot_time_seconds
+          ? new Date(nodeInfo.system.boot_time_seconds * 1000)
+          : null,
+
+        block_production_tracking_delay:
+          nodeInfo.chain.block_production_tracking_delay,
+        min_block_production_delay: nodeInfo.chain.min_block_production_delay,
+        max_block_production_delay: nodeInfo.chain.max_block_production_delay,
+        max_block_wait_delay: nodeInfo.chain.max_block_wait_delay,
       })
       .onConflict((oc) =>
         oc.column("node_id").doUpdateSet({
@@ -60,6 +74,20 @@ export const router = trpc.router<Context>().mutation("upsert", {
           latitude: (eb) => eb.ref("excluded.latitude"),
           longitude: (eb) => eb.ref("excluded.longitude"),
           city: (eb) => eb.ref("excluded.city"),
+
+          bandwidth_download: (eb) => eb.ref("excluded.bandwidth_download"),
+          bandwidth_upload: (eb) => eb.ref("excluded.bandwidth_upload"),
+          cpu_usage: (eb) => eb.ref("excluded.cpu_usage"),
+          memory_usage: (eb) => eb.ref("excluded.memory_usage"),
+          boot_time_seconds: (eb) => eb.ref("excluded.boot_time_seconds"),
+
+          block_production_tracking_delay: (eb) =>
+            eb.ref("excluded.block_production_tracking_delay"),
+          min_block_production_delay: (eb) =>
+            eb.ref("excluded.min_block_production_delay"),
+          max_block_production_delay: (eb) =>
+            eb.ref("excluded.max_block_production_delay"),
+          max_block_wait_delay: (eb) => eb.ref("excluded.max_block_wait_delay"),
         })
       );
 

--- a/backend/src/router/validators.ts
+++ b/backend/src/router/validators.ts
@@ -26,6 +26,13 @@ export const validators = {
       version: z.string(),
       build: z.string(),
     }),
+    system: z.object({
+      bandwidth_download: z.number(),
+      bandwidth_upload: z.number(),
+      cpu_usage: z.number(),
+      memory_usage: z.number(),
+      boot_time_seconds: z.number().optional(),
+    }),
     chain: z.object({
       node_id: z.string(),
       account_id: z.string().nullish(),
@@ -34,6 +41,11 @@ export const validators = {
       is_validator: z.boolean(),
       latest_block_hash: z.string(),
       status: z.string(),
+
+      block_production_tracking_delay: z.number().optional(),
+      min_block_production_delay: z.number().optional(),
+      max_block_production_delay: z.number().optional(),
+      max_block_wait_delay: z.number().optional(),
     }),
   }),
 };

--- a/backend/src/utils/telemetry.ts
+++ b/backend/src/utils/telemetry.ts
@@ -26,5 +26,16 @@ export const setupTelemetryDb = async () => {
     .addColumn("latitude", "numeric(8, 6)")
     .addColumn("longitude", "numeric(9, 6)")
     .addColumn("city", "varchar(255)")
+
+    .addColumn("bandwidth_download", "float4")
+    .addColumn("bandwidth_upload", "float4")
+    .addColumn("cpu_usage", "float4")
+    .addColumn("memory_usage", "int8")
+    .addColumn("boot_time_seconds", "timestamptz")
+
+    .addColumn("block_production_tracking_delay", "float4")
+    .addColumn("min_block_production_delay", "float4")
+    .addColumn("max_block_production_delay", "float4")
+    .addColumn("max_block_wait_delay", "float4")
     .execute();
 };

--- a/backend/src/utils/telemetry.ts
+++ b/backend/src/utils/telemetry.ts
@@ -1,7 +1,7 @@
 import { telemetryWriteDatabase } from "../database/databases";
 
 // Skip initializing Telemetry database if the backend is not configured to
-// save telemety data (it is absolutely fine for local development)
+// save telemetry data (it is absolutely fine for local development)
 export const setupTelemetryDb = async () => {
   if (!telemetryWriteDatabase) {
     return;


### PR DESCRIPTION
`block_production_tracking_delay` and similar fields are already populated by nodes in testnet, but not yet in mainnet.

The PR is not tested, please advise how to test it.