### PR TITLE
fix: Chinese date time format

### DIFF
--- a/frontend/src/translations/zh-hans/common.json
+++ b/frontend/src/translations/zh-hans/common.json
@@ -71,7 +71,7 @@
       "no": "否"
     },
     "date_time": {
-      "date_time_format": "Modo, yyyy, aaah:mm:ss",
+      "date_time_format": "yyyy年M月d日, ah:mm:ss",
       "date_format": "Modo, yyyy",
       "time_format": "aaa h:mm:ss",
       "transaction_date_format": "dd/MM/yyyy h:mm"

--- a/frontend/src/translations/zh-hans/common.json
+++ b/frontend/src/translations/zh-hans/common.json
@@ -71,7 +71,7 @@
       "no": "否"
     },
     "date_time": {
-      "date_time_format": "yyyy年M月d日, ah:mm:ss",
+      "date_time_format": "PPP, ah:mm:ss",
       "date_format": "Modo, yyyy",
       "time_format": "aaa h:mm:ss",
       "transaction_date_format": "dd/MM/yyyy h:mm"

--- a/frontend/src/translations/zh-hant/common.json
+++ b/frontend/src/translations/zh-hant/common.json
@@ -71,7 +71,7 @@
       "no": "否"
     },
     "date_time": {
-      "date_time_format": "yyyy年M月d日, aaah:mm:ss",
+      "date_time_format": "yyyy年M月d日, ah:mm:ss",
       "date_format": "Modo, yyyy",
       "time_format": "aaa h:mm:ss",
       "transaction_date_format": "dd/MM/yyyy h:mm"

--- a/frontend/src/translations/zh-hant/common.json
+++ b/frontend/src/translations/zh-hant/common.json
@@ -71,7 +71,7 @@
       "no": "否"
     },
     "date_time": {
-      "date_time_format": "Modo, yyyy, aaah:mm:ss",
+      "date_time_format": "yyyy年M月d日, aaah:mm:ss",
       "date_format": "Modo, yyyy",
       "time_format": "aaa h:mm:ss",
       "transaction_date_format": "dd/MM/yyyy h:mm"

--- a/frontend/src/translations/zh-hant/common.json
+++ b/frontend/src/translations/zh-hant/common.json
@@ -71,7 +71,7 @@
       "no": "否"
     },
     "date_time": {
-      "date_time_format": "yyyy年M月d日, ah:mm:ss",
+      "date_time_format": "PPP, ah:mm:ss",
       "date_format": "Modo, yyyy",
       "time_format": "aaa h:mm:ss",
       "transaction_date_format": "dd/MM/yyyy h:mm"


### PR DESCRIPTION
Fixes: #1118

With this fix, the Chinese data format will be `2022年12月3日, 下午6:27:45`

<img width="251" alt="image" src="https://user-images.githubusercontent.com/46699230/205436668-9c50faee-edcc-4073-ab2a-2b1d277f645c.png">
