### PR TITLE
Feature: unify beta pages representation

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,6 +53,7 @@
     "lodash": "^4.17.21",
     "next": "^12.1.0",
     "rc-progress": "^3.1.4",
+    "rc-switch": "^4.0.0",
     "react": "^17.0.2",
     "react-bootstrap": "^1.6.4",
     "react-copy-to-clipboard": "^5.1.0",

--- a/frontend/src/components/beta/accounts/AccountActivityView.tsx
+++ b/frontend/src/components/beta/accounts/AccountActivityView.tsx
@@ -114,7 +114,7 @@ const getActionLink = (action: AccountActivityElementAction) => {
 };
 
 const getAccountLink = (account: string) => {
-  return `/beta/accounts/${account}`;
+  return `/accounts/${account}`;
 };
 
 const ActivityItemActionWrapper = styled("div", {

--- a/frontend/src/components/beta/common/AccountLink.tsx
+++ b/frontend/src/components/beta/common/AccountLink.tsx
@@ -13,7 +13,7 @@ export interface Props {
 
 const AccountLink: React.FC<Props> = React.memo(({ accountId }) => {
   return (
-    <Link href={`/beta/accounts/${accountId}`} passHref>
+    <Link href={`/accounts/${accountId}`} passHref>
       <AccountLinkWrapper>{shortenString(accountId)}</AccountLinkWrapper>
     </Link>
   );

--- a/frontend/src/components/utils/BetaSwitch.tsx
+++ b/frontend/src/components/utils/BetaSwitch.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { useBetaOptions } from "../../hooks/use-beta-options";
+import { styled } from "../../libraries/styles";
+import { Switch } from "./Switch";
+
+const Wrapper = styled("div", {
+  display: "flex",
+  alignItems: "center",
+  color: "#ccc",
+
+  "& > * + *": {
+    marginLeft: 8,
+  },
+
+  variants: {
+    enabled: {
+      true: {
+        color: "#0072ce",
+      },
+    },
+  },
+});
+
+export const BetaSwitch: React.FC = () => {
+  const [betaOptions, setBetaOptions] = useBetaOptions();
+  return (
+    <Wrapper enabled={betaOptions?.enabled}>
+      <span>Beta</span>
+      <Switch
+        checked={Boolean(betaOptions?.enabled)}
+        onChange={(enabled) => setBetaOptions((prev) => ({ ...prev, enabled }))}
+      />
+    </Wrapper>
+  );
+};

--- a/frontend/src/components/utils/Header.tsx
+++ b/frontend/src/components/utils/Header.tsx
@@ -16,6 +16,8 @@ import LanguageToggle from "./LanguageToggle";
 import { styled } from "../../libraries/styles";
 import { ServiceStatusView } from "./ServiceStatus";
 import { useNetworkContext } from "../../hooks/use-network-context";
+import { useBetaOptions } from "../../hooks/use-beta-options";
+import { BetaSwitch } from "./BetaSwitch";
 
 const HeaderContainer = styled(Container, {
   background: "#ffffff",
@@ -64,6 +66,7 @@ const Header: React.FC = React.memo(() => {
   const { t } = useTranslation();
   const router = useRouter();
   const { network } = useNetworkContext();
+  const [betaOptions] = useBetaOptions();
 
   return (
     <HeaderContainer fluid>
@@ -121,15 +124,20 @@ const Header: React.FC = React.memo(() => {
           md="auto"
         >
           <Row>
-            <Col md="3" className="align-self-center">
+            {betaOptions ? (
+              <Col md="3" className="align-self-center">
+                <BetaSwitch />
+              </Col>
+            ) : null}
+            <Col md={betaOptions ? 2 : 3} className="align-self-center">
               <LanguageToggle />
             </Col>
-            <Col md="4" className="align-self-center">
+            <Col md={betaOptions ? 3 : 4} className="align-self-center">
               <Link href="/" passHref>
                 <HeaderHome>{t("component.utils.Header.home")}</HeaderHome>
               </Link>
             </Col>
-            <Col md="5" className="align-self-center">
+            <Col md={betaOptions ? 4 : 5} className="align-self-center">
               <HeaderNavDropdown />
             </Col>
           </Row>

--- a/frontend/src/components/utils/MobileHeaderNavDropdown.tsx
+++ b/frontend/src/components/utils/MobileHeaderNavDropdown.tsx
@@ -11,6 +11,8 @@ import { useTranslation } from "react-i18next";
 import LanguageToggle from "./LanguageToggle";
 import { styled } from "../../libraries/styles";
 import { StyledComponent } from "@stitches/react/types/styled-component";
+import { BetaSwitch } from "./BetaSwitch";
+import { useBetaOptions } from "../../hooks/use-beta-options";
 
 const Icon = styled("svg", {
   width: 16,
@@ -157,6 +159,8 @@ const MobileNavDropdown: React.FC = React.memo(() => {
     return () => document.removeEventListener("click", closeMenu);
   }, [isMenuShown, closeMenu]);
 
+  const [betaOptions] = useBetaOptions();
+
   return (
     <>
       <MobileHeaderNav
@@ -206,6 +210,11 @@ const MobileNavDropdown: React.FC = React.memo(() => {
             <MobileNav>
               <LanguageToggle mobile />
             </MobileNav>
+            {betaOptions ? (
+              <MobileNav>
+                <BetaSwitch />
+              </MobileNav>
+            ) : null}
           </DropdownContent>
         ) : null}
       </MobileHeaderNav>

--- a/frontend/src/components/utils/Switch.tsx
+++ b/frontend/src/components/utils/Switch.tsx
@@ -1,0 +1,137 @@
+import React from "react";
+import RawSwitch from "rc-switch";
+import { keyframes, styled } from "../../libraries/styles";
+
+type Props = {
+  checked: boolean;
+  onChange: (nextChecked: boolean) => void;
+};
+
+const hoverOnKeyframes = keyframes({
+  "0%": {
+    transform: "scale(1)",
+  },
+  "50%": {
+    transform: "scale(1.25)",
+  },
+  "100%": {
+    transform: "scale(1)",
+  },
+});
+const switchKeyframes = keyframes({
+  "0%": {
+    transform: "scale(1.1)",
+  },
+  "100%": {
+    transform: "scale(1)",
+  },
+});
+
+const CONSTANTS = {
+  sizes: {
+    dot: 16,
+    padding: 3,
+    distance: 3,
+  },
+  colors: {
+    dot: "#fff",
+    background: {
+      on: "#0072ce",
+      off: "#ccc",
+    },
+    disabled: {
+      dot: "#9e9e9e",
+      background: "#ccc",
+    },
+  },
+};
+
+// Styles adapted from the demo: http://react-component.github.io/switch/demo/simple
+const StyledSwitch = styled(RawSwitch, {
+  position: "relative",
+  display: "inline-block",
+  boxSizing: "border-box",
+  width:
+    CONSTANTS.sizes.dot * 2 +
+    CONSTANTS.sizes.distance +
+    CONSTANTS.sizes.padding * 2,
+  height: CONSTANTS.sizes.dot + CONSTANTS.sizes.padding * 2,
+  lineHeight: CONSTANTS.sizes.dot + CONSTANTS.sizes.padding * 2,
+  padding: 0,
+  verticalAlign: "middle",
+  borderRadius: CONSTANTS.sizes.dot + CONSTANTS.sizes.padding * 2,
+  border: 0,
+  backgroundColor: CONSTANTS.colors.background.off,
+  cursor: "pointer",
+  transition: "all .3s cubic-bezier(0.35, 0, 0.25, 1)",
+  overflow: "hidden",
+
+  "&-inner": {
+    display: "none",
+  },
+
+  "&:after": {
+    position: "absolute",
+    width: CONSTANTS.sizes.dot,
+    height: CONSTANTS.sizes.dot,
+    left: CONSTANTS.sizes.padding,
+    top: CONSTANTS.sizes.padding,
+    borderRadius: "50% 50%",
+    backgroundColor: CONSTANTS.colors.dot,
+    content: " ",
+    cursor: "pointer",
+    boxShadow: "0 2px 5px rgba(0, 0, 0, 0.26)",
+    transform: "scale(1)",
+    transition: "left .3s cubic-bezier(0.35, 0, 0.25, 1)",
+    animationTimingFunction: "cubic-bezier(0.35, 0, 0.25, 1)",
+    animationDuration: ".3s",
+    animationName: switchKeyframes,
+  },
+
+  "&:hover:after": {
+    transform: "scale(1.1)",
+    animationName: hoverOnKeyframes,
+  },
+
+  "&:focus": {
+    boxShadow: "0 0 0 2px tint(#2db7f5, 80%)",
+    outline: "none",
+  },
+
+  "&-checked": {
+    backgroundColor: CONSTANTS.colors.background.on,
+
+    "&:after": {
+      left:
+        CONSTANTS.sizes.dot +
+        CONSTANTS.sizes.distance +
+        CONSTANTS.sizes.padding,
+    },
+  },
+
+  "&-disabled": {
+    cursor: "no-drop",
+    background: CONSTANTS.colors.disabled.background,
+
+    "&:after:": {
+      background: CONSTANTS.colors.disabled.dot,
+      animationName: "none",
+      cursor: "no-drop",
+    },
+
+    "&:hover:after": {
+      transform: "scale(1)",
+      animationName: "none",
+    },
+  },
+});
+
+export const Switch: React.FC<Props> = ({ checked, onChange }) => {
+  return (
+    <StyledSwitch
+      checked={checked}
+      onChange={onChange}
+      prefixCls={StyledSwitch.toString().slice(1)}
+    />
+  );
+};

--- a/frontend/src/hooks/use-account-page-options.ts
+++ b/frontend/src/hooks/use-account-page-options.ts
@@ -81,12 +81,7 @@ const getAccountTabParts = (options: AccountPageOptions) => {
 };
 
 export const buildAccountUrl = (options: AccountPageOptions) => {
-  return [
-    "/beta",
-    "accounts",
-    options.accountId,
-    ...getAccountTabParts(options),
-  ]
+  return ["accounts", options.accountId, ...getAccountTabParts(options)]
     .filter(Boolean)
     .join("/");
 };
@@ -94,7 +89,10 @@ export const buildAccountUrl = (options: AccountPageOptions) => {
 export const useAccountPageOptions = (): AccountPageOptions => {
   const router = useRouter();
   const pathElements = router.pathname.split("/").filter(Boolean);
-  if (pathElements[1] !== "accounts") {
+  const isRegularAccountPage = pathElements[0] === "accounts";
+  const isBetaAccountPage =
+    pathElements[0] === "beta" && pathElements[1] === "accounts";
+  if (!isRegularAccountPage && !isBetaAccountPage) {
     throw new Error(
       "useAccountPageOptions hook is used in non-account subpage!"
     );

--- a/frontend/src/hooks/use-beta-options.ts
+++ b/frontend/src/hooks/use-beta-options.ts
@@ -1,0 +1,20 @@
+import React from "react";
+import { BetaOptions, BETA_COOKIE_NAME } from "../libraries/beta";
+import { useCookie } from "./use-cookie";
+
+export const useBetaOptions = () => {
+  const [betaCookie, setBetaCookie] = useCookie<BetaOptions>(BETA_COOKIE_NAME);
+  const setBetaOptions = React.useCallback<
+    React.Dispatch<React.SetStateAction<BetaOptions>>
+  >(
+    (optionsOrUpdater) => {
+      if (typeof optionsOrUpdater === "function") {
+        setBetaCookie((prevCookie) => optionsOrUpdater(prevCookie));
+      } else {
+        setBetaCookie(optionsOrUpdater);
+      }
+    },
+    [setBetaCookie]
+  );
+  return [betaCookie, setBetaOptions] as const;
+};

--- a/frontend/src/hooks/use-beta.ts
+++ b/frontend/src/hooks/use-beta.ts
@@ -1,0 +1,3 @@
+import { useBetaOptions } from "./use-beta-options";
+
+export const useBeta = () => Boolean(useBetaOptions()[0]?.enabled);

--- a/frontend/src/hooks/use-watch-beta.ts
+++ b/frontend/src/hooks/use-watch-beta.ts
@@ -1,0 +1,15 @@
+import React from "react";
+import { useBetaOptions } from "./use-beta-options";
+import { useQueryParam } from "./use-query-param";
+
+export const useWatchBeta = () => {
+  const [enabledBeta, setEnableBeta] = useQueryParam("beta");
+  const [, setBetaOptions] = useBetaOptions();
+  React.useEffect(() => {
+    if (!enabledBeta) {
+      return;
+    }
+    setBetaOptions({ enabled: true });
+    setEnableBeta(undefined);
+  }, [enabledBeta, setBetaOptions, setEnableBeta]);
+};

--- a/frontend/src/libraries/beta.ts
+++ b/frontend/src/libraries/beta.ts
@@ -1,0 +1,16 @@
+import type { IncomingMessage } from "http";
+import { getCookiesFromReq } from "./cookie";
+
+export type BetaOptions =
+  | {
+      enabled: boolean;
+    }
+  | undefined;
+
+export const BETA_COOKIE_NAME = "NEAR_BETA_OPTIONS";
+
+const getBetaOptionsFromCookie = (cookie?: string): BetaOptions =>
+  typeof cookie === "string" && cookie ? JSON.parse(cookie) : undefined;
+
+export const getBetaOptionsFromReq = (req: IncomingMessage): BetaOptions =>
+  getBetaOptionsFromCookie(getCookiesFromReq(req).get(BETA_COOKIE_NAME));

--- a/frontend/src/libraries/styles.ts
+++ b/frontend/src/libraries/styles.ts
@@ -29,4 +29,4 @@ const stitches = createStitches({
   },
 });
 
-export const { styled, globalCss, getCssText, css } = stitches;
+export const { styled, globalCss, getCssText, css, keyframes } = stitches;

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -36,6 +36,7 @@ import { useI18n } from "../hooks/use-i18n";
 import { ToastController } from "../components/utils/ToastController";
 import { useCookie } from "../hooks/use-cookie";
 import { CookieContext, getCookiesFromString } from "../libraries/cookie";
+import { useWatchBeta } from "../hooks/use-watch-beta";
 
 const globalStyles = globalCss({
   body: {
@@ -183,6 +184,8 @@ const InnerApp: React.FC<AppPropsType> = React.memo(
       () => ({ language, setLanguage, locale }),
       [language, setLanguage, locale]
     );
+
+    useWatchBeta();
 
     return (
       <>

--- a/frontend/src/pages/beta/transactions/[hash].tsx
+++ b/frontend/src/pages/beta/transactions/[hash].tsx
@@ -14,20 +14,16 @@ import TransactionActionsList from "../../../components/beta/transactions/Transa
 import { trpc } from "../../../libraries/trpc";
 import { styled } from "../../../libraries/styles";
 
-type Props = {
-  hash: string;
-};
-
 const Wrapper = styled("div", {
   backgroundColor: "#fff",
   padding: "12px 6vw",
   fontFamily: "Manrope",
 });
 
-const TransactionPage: NextPage<Props> = React.memo((props) => {
+const TransactionPage: NextPage = React.memo(() => {
   const hash = useRouter().query.hash as string;
   useAnalyticsTrackOnMount("Explorer Beta | Individual Transaction Page", {
-    transaction_hash: props.hash,
+    transaction_hash: hash,
   });
 
   const transactionQuery = trpc.useQuery(["transaction.byHash", { hash }]);
@@ -42,7 +38,7 @@ const TransactionPage: NextPage<Props> = React.memo((props) => {
         rel="stylesheet"
       />
       <Wrapper>
-        <TransactionQueryView {...transactionQuery} hash={props.hash} />
+        <TransactionQueryView {...transactionQuery} hash={hash} />
       </Wrapper>
     </>
   );

--- a/frontend/src/pages/transactions/[hash].tsx
+++ b/frontend/src/pages/transactions/[hash].tsx
@@ -15,12 +15,14 @@ import { styled } from "../../libraries/styles";
 import * as React from "react";
 import { trpc } from "../../libraries/trpc";
 import { useRouter } from "next/router";
+import { default as BetaTransactionPage } from "../beta/transactions/[hash]";
+import { useBeta } from "../../hooks/use-beta";
 
 const TransactionIcon = styled(TransactionIconSvg, {
   width: 22,
 });
 
-const TransactionDetailsPage: NextPage = React.memo(() => {
+const TransactionDetailsPage = React.memo(() => {
   const hash = useRouter().query.hash as string;
   const { t } = useTranslation();
   useAnalyticsTrackOnMount("Explorer View Individual Transaction Page", {
@@ -82,4 +84,12 @@ const TransactionDetailsPage: NextPage = React.memo(() => {
   );
 });
 
-export default TransactionDetailsPage;
+const TransactionDetailsWithBeta: NextPage = () => {
+  const isBeta = useBeta();
+  if (isBeta) {
+    return <BetaTransactionPage />;
+  }
+  return <TransactionDetailsPage />;
+};
+
+export default TransactionDetailsWithBeta;

--- a/package-lock.json
+++ b/package-lock.json
@@ -139,6 +139,7 @@
         "lodash": "^4.17.21",
         "next": "^12.1.0",
         "rc-progress": "^3.1.4",
+        "rc-switch": "^4.0.0",
         "react": "^17.0.2",
         "react-bootstrap": "^1.6.4",
         "react-copy-to-clipboard": "^5.1.0",
@@ -2083,11 +2084,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
-      "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
+      "version": "7.20.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.6.tgz",
+      "integrity": "sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -15823,6 +15824,39 @@
         "react-dom": ">=16.9.0"
       }
     },
+    "node_modules/rc-switch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rc-switch/-/rc-switch-4.0.0.tgz",
+      "integrity": "sha512-IfrYC99vN0gKaTyjQdqYuADU0eH00SAFHg3jOp8HrmUpJruhV1SohJzrCbPqPraZeX/6X/QKkdLfkdnUub05WA==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "^2.2.1",
+        "rc-util": "^5.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-util": {
+      "version": "5.25.3",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.25.3.tgz",
+      "integrity": "sha512-+M+44T6UdM4iOd4QXRQKQjitOY26vC5pgFPNSo0XsY9OWzpHvy77BI55eL9Q9oDMUHzVuRNzzUkK1RI2W3n+ZQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "react-is": "^16.12.0",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-util/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
     "node_modules/react": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
@@ -16225,9 +16259,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.0",
@@ -16828,6 +16862,11 @@
       "bin": {
         "sha.js": "bin.js"
       }
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "node_modules/shebang-command": {
       "version": "1.2.0",
@@ -21194,11 +21233,11 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
-      "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
+      "version": "7.20.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.6.tgz",
+      "integrity": "sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==",
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       }
     },
     "@babel/template": {
@@ -30813,6 +30852,7 @@
         "next": "^12.1.0",
         "postcss": "^8.4.4",
         "rc-progress": "^3.1.4",
+        "rc-switch": "*",
         "react": "^17.0.2",
         "react-bootstrap": "^1.6.4",
         "react-copy-to-clipboard": "^5.1.0",
@@ -32257,6 +32297,33 @@
         "classnames": "^2.2.6"
       }
     },
+    "rc-switch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rc-switch/-/rc-switch-4.0.0.tgz",
+      "integrity": "sha512-IfrYC99vN0gKaTyjQdqYuADU0eH00SAFHg3jOp8HrmUpJruhV1SohJzrCbPqPraZeX/6X/QKkdLfkdnUub05WA==",
+      "requires": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "^2.2.1",
+        "rc-util": "^5.0.1"
+      }
+    },
+    "rc-util": {
+      "version": "5.25.3",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.25.3.tgz",
+      "integrity": "sha512-+M+44T6UdM4iOd4QXRQKQjitOY26vC5pgFPNSo0XsY9OWzpHvy77BI55eL9Q9oDMUHzVuRNzzUkK1RI2W3n+ZQ==",
+      "requires": {
+        "@babel/runtime": "^7.18.3",
+        "react-is": "^16.12.0",
+        "shallowequal": "^1.1.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
+    },
     "react": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
@@ -32548,9 +32615,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regenerator-transform": {
       "version": "0.15.0",
@@ -33054,6 +33121,11 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "shebang-command": {
       "version": "1.2.0",


### PR DESCRIPTION
What we do here is we get rid of `/beta` prefix as the main way to get into beta pages and introduce a cookie to keep the data about `beta` preferences.

Currently, you can add `?beta=anything` to turn on the beta switch (which is hidden by default) and you'll be able to opt-in/out for `beta` pages.