### PR TITLE
Fix: counting uptime for chunk-only producers

### DIFF
--- a/frontend/src/components/nodes/ValidatorProgressElement.tsx
+++ b/frontend/src/components/nodes/ValidatorProgressElement.tsx
@@ -23,6 +23,10 @@ interface Props {
 const ValidatorTelemetryRow: React.FC<Props> = React.memo(({ progress }) => {
   const { t } = useTranslation();
 
+  const productivityRatio =
+    (progress.blocks.produced + progress.chunks.produced) /
+    (progress.blocks.total + progress.chunks.total);
+
   return (
     <ValidatorNodesContentCell>
       <Row noGutters>
@@ -52,13 +56,7 @@ const ValidatorTelemetryRow: React.FC<Props> = React.memo(({ progress }) => {
               </Tooltip>
             }
           >
-            <span>
-              {(
-                (progress.blocks.produced / progress.blocks.total) *
-                100
-              ).toFixed(3)}
-              %
-            </span>
+            <span>{(productivityRatio * 100).toFixed(3)}%</span>
           </OverlayTrigger>
         </Uptime>
       </Row>


### PR DESCRIPTION
Uptime counting has used only produced/expected blocks ratio. It's a bug for chunk-only producers uptime indicating.

| Current problem  | Fixed problem  |
| ------------------| -------------- |
| <img width="500" src="https://user-images.githubusercontent.com/74172766/209623684-6a17a0a5-5bc4-4454-b186-b26f30c17b82.png">   | <img width="500" src="https://user-images.githubusercontent.com/74172766/209623799-b963258b-364b-473d-83a0-b63f586613a9.png">       |




