### PR TITLE
Fix: empty receipts

### DIFF
--- a/frontend/src/components/transactions/ReceiptRow.tsx
+++ b/frontend/src/components/transactions/ReceiptRow.tsx
@@ -75,6 +75,15 @@ const ReceiptRowStatus = styled(Col, {
   fontWeight: 500,
 });
 
+const NotFoundReceipt = styled(Col, {
+  paddingTop: 8,
+  marginVertical: 8,
+  borderColor: "#999999",
+  borderWidth: 0,
+  borderTopWidth: 1,
+  borderStyle: "solid",
+});
+
 export interface Props {
   receipt: NestedReceiptWithOutcome;
   transactionHash: string;
@@ -223,16 +232,24 @@ const ReceiptRow: React.FC<Props> = React.memo(
           </ReceiptRowSection>
 
           {receipt.outcome.nestedReceipts.length > 0 &&
-            receipt.outcome.nestedReceipts.map((executedReceipt) => (
-              <ExecutedReceiptRow noGutters key={executedReceipt.id}>
-                <Col>
-                  <ReceiptRow
-                    transactionHash={transactionHash}
-                    receipt={executedReceipt}
-                  />
-                </Col>
-              </ExecutedReceiptRow>
-            ))}
+            receipt.outcome.nestedReceipts.map((executedReceipt) =>
+              "outcome" in executedReceipt ? (
+                <ExecutedReceiptRow noGutters key={executedReceipt.id}>
+                  <Col>
+                    <ReceiptRow
+                      transactionHash={transactionHash}
+                      receipt={executedReceipt}
+                    />
+                  </Col>
+                </ExecutedReceiptRow>
+              ) : (
+                <ExecutedReceiptRow noGutters key={executedReceipt.id}>
+                  <NotFoundReceipt>
+                    Receipt {executedReceipt.id} not found
+                  </NotFoundReceipt>
+                </ExecutedReceiptRow>
+              )
+            )}
         </Col>
       </ReceiptRowWrapper>
     );

--- a/frontend/src/components/transactions/TransactionDetails.tsx
+++ b/frontend/src/components/transactions/TransactionDetails.tsx
@@ -73,7 +73,7 @@ const flattenReceiptOutcomes = (
   receipt.outcome.nestedReceipts.reduce<NestedReceiptWithOutcome["outcome"][]>(
     (acc, subReceipt) => [
       ...acc,
-      ...(subReceipt.outcome.nestedReceipts
+      ...("outcome" in subReceipt && subReceipt.outcome.nestedReceipts
         ? flattenReceiptOutcomes(subReceipt)
         : []),
     ],


### PR DESCRIPTION
RPC doesn't respond the full tree of receipts for [some transactions](https://github.com/near/nearcore/issues/8321).
Until it is fixed we should at least show partial transaction.
I added a block with `Receipt <id> not found` stub.

Fixes https://github.com/near/near-explorer/issues/1136