### PR TITLE
Refactor: cache locale

### DIFF
--- a/frontend/src/context/LanguageContext.tsx
+++ b/frontend/src/context/LanguageContext.tsx
@@ -1,12 +1,10 @@
 import * as React from "react";
 
-import { Locale } from "@explorer/frontend/libraries/date-locale";
 import { Language } from "@explorer/frontend/libraries/i18n";
 
 export type LanguageContextType = {
   language: Language;
   setLanguage: React.Dispatch<React.SetStateAction<Language>>;
-  locale?: Locale;
 };
 
 export const LanguageContext = React.createContext<LanguageContextType>({

--- a/frontend/src/hooks/use-date-format.ts
+++ b/frontend/src/hooks/use-date-format.ts
@@ -3,7 +3,7 @@ import React from "react";
 import { addMinutes, format, formatISO } from "date-fns";
 import { useTranslation } from "react-i18next";
 
-import { LanguageContext } from "@explorer/frontend/context/LanguageContext";
+import { useDateLocale } from "@explorer/frontend/hooks/use-date-locale";
 
 type Options = Omit<NonNullable<Parameters<typeof format>[2]>, "locale"> & {
   utc?: boolean;
@@ -11,7 +11,7 @@ type Options = Omit<NonNullable<Parameters<typeof format>[2]>, "locale"> & {
 
 export const useDateFormat = () => {
   const { i18n } = useTranslation();
-  const { locale } = React.useContext(LanguageContext);
+  const locale = useDateLocale();
   return React.useCallback(
     (
       date: Date | number,

--- a/frontend/src/hooks/use-date-locale.ts
+++ b/frontend/src/hooks/use-date-locale.ts
@@ -1,18 +1,25 @@
 import React from "react";
 
+import { LanguageContext } from "@explorer/frontend/context/LanguageContext";
 import {
-  Locale,
   getDateLocale,
+  getCachedDateLocale,
+  setCachedDateLocale,
 } from "@explorer/frontend/libraries/date-locale";
-import { Language } from "@explorer/frontend/libraries/i18n";
 
-export const useDateLocale = (
-  initialLocale: Locale | undefined,
-  language: Language
-) => {
-  const [locale, setLocale] = React.useState(initialLocale);
+export const useDateLocale = () => {
+  const { language } = React.useContext(LanguageContext);
+  const [locale, setLocale] = React.useState(getCachedDateLocale(language));
   React.useEffect(() => {
-    getDateLocale(language).then(setLocale);
-  }, [language]);
+    const cachedLocale = getCachedDateLocale(language);
+    if (cachedLocale) {
+      setLocale(cachedLocale);
+    } else {
+      getDateLocale(language).then((loadedLocale) => {
+        setCachedDateLocale(language, loadedLocale);
+        setLocale(loadedLocale);
+      });
+    }
+  }, [language, locale]);
   return locale;
 };

--- a/frontend/src/hooks/use-format-distance.ts
+++ b/frontend/src/hooks/use-format-distance.ts
@@ -2,7 +2,7 @@ import React from "react";
 
 import { intervalToDuration } from "date-fns";
 
-import { LanguageContext } from "@explorer/frontend/context/LanguageContext";
+import { useDateLocale } from "@explorer/frontend/hooks/use-date-locale";
 import { DurationFormatter } from "@explorer/frontend/libraries/locales/index";
 
 const durationKeys = [
@@ -35,7 +35,7 @@ const formatDurationString = (
 };
 
 export const useFormatDistance = () => {
-  const { locale } = React.useContext(LanguageContext);
+  const locale = useDateLocale();
   return React.useCallback(
     (
       timestampStart: number | Date,

--- a/frontend/src/libraries/date-locale.ts
+++ b/frontend/src/libraries/date-locale.ts
@@ -5,23 +5,39 @@ import { DurationFormatter } from "@explorer/frontend/libraries/locales/index";
 
 export type Locale = RawLocale & { durationFormatter: DurationFormatter };
 
-export const getDateLocale = async (
-  language: Language | "cimode"
-): Promise<Locale> => {
+type LanguageCi = Language | "cimode";
+
+const cachedLocales: Partial<Record<LanguageCi, Locale>> = {};
+
+const getDateLocaleModule = (
+  language: LanguageCi
+): Promise<{ locale: Locale }> => {
   switch (language) {
     case "en":
-      return (await import("./locales/en")).locale;
+      return import("./locales/en");
     case "ru":
-      return (await import("./locales/ru")).locale;
+      return import("./locales/ru");
     case "vi":
-      return (await import("./locales/vi")).locale;
+      return import("./locales/vi");
     case "zh-Hant":
-      return (await import("./locales/zh-Hant")).locale;
+      return import("./locales/zh-Hant");
     case "zh-Hans":
-      return (await import("./locales/zh-Hans")).locale;
+      return import("./locales/zh-Hans");
     case "uk":
-      return (await import("./locales/uk")).locale;
+      return import("./locales/uk");
     case "cimode":
-      return (await import("./locales/cimode")).locale;
+      return import("./locales/cimode");
   }
+};
+
+export const getCachedDateLocale = (language: LanguageCi): Locale | undefined =>
+  cachedLocales[language];
+
+export const setCachedDateLocale = (language: LanguageCi, locale: Locale) => {
+  cachedLocales[language] = locale;
+};
+
+export const getDateLocale = async (language: LanguageCi): Promise<Locale> => {
+  const { locale } = await getDateLocaleModule(language);
+  return locale;
 };

--- a/frontend/src/testing/env.ts
+++ b/frontend/src/testing/env.ts
@@ -1,8 +1,20 @@
-import i18next from "i18next";
+import i18next, { i18n } from "i18next";
 import JSDomEnvironment from "jest-environment-jsdom";
 import { initReactI18next } from "react-i18next";
 
-import { getDateLocale } from "@explorer/frontend/libraries/date-locale";
+import {
+  getCachedDateLocale,
+  getDateLocale,
+  Locale,
+  setCachedDateLocale,
+} from "@explorer/frontend/libraries/date-locale";
+
+/* eslint-disable vars-on-top, no-var */
+declare global {
+  var i18nInstance: i18n;
+  var locale: Locale;
+}
+/* eslint-enable vars-on-top, no-var */
 
 export default class extends JSDomEnvironment {
   async setup() {
@@ -14,6 +26,11 @@ export default class extends JSDomEnvironment {
     });
     // Will use this variables in renderElement
     this.global.i18nInstance = i18nInstance;
-    this.global.locale = await getDateLocale("cimode");
+    let locale = getCachedDateLocale("cimode");
+    if (!locale) {
+      locale = await getDateLocale("cimode");
+      setCachedDateLocale("cimode", locale);
+    }
+    this.global.locale = locale;
   }
 }

--- a/frontend/src/testing/utils.tsx
+++ b/frontend/src/testing/utils.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
-import { i18n } from "i18next";
 import fetch from "isomorphic-fetch";
+import { noop } from "lodash";
 import { setI18n } from "react-i18next";
 import * as ReactQuery from "react-query";
 import renderer, {
@@ -17,7 +17,8 @@ import {
   NetworkContext,
   NetworkContextType,
 } from "@explorer/frontend/context/NetworkContext";
-import { Locale } from "@explorer/frontend/libraries/date-locale";
+import { setCachedDateLocale } from "@explorer/frontend/libraries/date-locale";
+import { Language } from "@explorer/frontend/libraries/i18n";
 import { trpc } from "@explorer/frontend/libraries/trpc";
 
 const networkContext: NetworkContextType = {
@@ -29,14 +30,6 @@ const networkContext: NetworkContextType = {
     },
   },
 };
-
-// Variables were set in testing/env.ts
-/* eslint-disable vars-on-top, no-var */
-declare global {
-  var i18nInstance: i18n;
-  var locale: Locale;
-}
-/* eslint-enable vars-on-top, no-var */
 
 export const renderElement = (
   nextElement: React.ReactNode,
@@ -50,10 +43,10 @@ export const renderElement = (
     fetch,
   });
   const languageContext: LanguageContextType = {
-    language: "en",
-    setLanguage: () => {},
-    locale: global.locale,
+    language: "cimode" as Language,
+    setLanguage: noop,
   };
+  setCachedDateLocale("cimode", global.locale);
   renderer.act(() => {
     root = renderer.create(
       <trpc.Provider queryClient={queryClient} client={client}>


### PR DESCRIPTION
This is a step towards identical server-side and client-side rendering of dates.
I hope [there will be an easy way](https://github.com/vercel/next.js/discussions/46032) to implement it.