### PR TITLE
Move react-i18next to next-i18next

### DIFF
--- a/frontend/i18n.d.ts
+++ b/frontend/i18n.d.ts
@@ -1,6 +1,6 @@
 import { I18nNamespace, ResourceType } from "@explorer/frontend/libraries/i18n";
 
-declare module "react-i18next" {
+declare module "i18next" {
   interface CustomTypeOptions {
     defaultNS: I18nNamespace;
     resources: ResourceType;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,6 +53,7 @@
     "json-2-prom": "1.0.3",
     "lodash": "^4.17.21",
     "next": "^12.1.0",
+    "next-i18next": "^12.1.0",
     "rc-progress": "^3.1.4",
     "rc-switch": "^4.0.0",
     "react": "^17.0.2",

--- a/frontend/src/components/accounts/AccountDetails.tsx
+++ b/frontend/src/components/accounts/AccountDetails.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
+import { Trans, useTranslation } from "next-i18next";
 import { Row, Col, Spinner } from "react-bootstrap";
-import { Trans, useTranslation } from "react-i18next";
 
 import { AccountOld } from "@explorer/common/types/procedures";
 import AccountLink from "@explorer/frontend/components/utils/AccountLink";

--- a/frontend/src/components/accounts/AccountRow.tsx
+++ b/frontend/src/components/accounts/AccountRow.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
+import { useTranslation } from "next-i18next";
 import { Row, Col } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import Balance from "@explorer/frontend/components/utils/Balance";
 import CopyToClipboard from "@explorer/frontend/components/utils/CopyToClipboard";

--- a/frontend/src/components/beta/accounts/AccountActivityBadge.tsx
+++ b/frontend/src/components/beta/accounts/AccountActivityBadge.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { AccountActivityAction } from "@explorer/common/types/procedures";
 import { styled } from "@explorer/frontend/libraries/styles";

--- a/frontend/src/components/beta/accounts/AccountFungibleTokenHistory.tsx
+++ b/frontend/src/components/beta/accounts/AccountFungibleTokenHistory.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 
 import JSBI from "jsbi";
+import { useTranslation } from "next-i18next";
 import { Spinner } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import {
   AccountFungibleToken,

--- a/frontend/src/components/beta/accounts/AccountHeader.tsx
+++ b/frontend/src/components/beta/accounts/AccountHeader.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import JSBI from "jsbi";
-import { Trans, useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "next-i18next";
 
 import { Account } from "@explorer/common/types/procedures";
 import ShortenValue from "@explorer/frontend/components/beta/common/ShortenValue";

--- a/frontend/src/components/beta/accounts/AccountTabs.tsx
+++ b/frontend/src/components/beta/accounts/AccountTabs.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { Account } from "@explorer/common/types/procedures";
 import AccountFungibleTokens from "@explorer/frontend/components/beta/accounts/AccountFungibleTokens";

--- a/frontend/src/components/beta/accounts/AccountTransactionsView.tsx
+++ b/frontend/src/components/beta/accounts/AccountTransactionsView.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 
 import JSBI from "jsbi";
+import { Trans } from "next-i18next";
 import { Spinner } from "react-bootstrap";
-import { Trans } from "react-i18next";
 
 import {
   TransactionListResponse,

--- a/frontend/src/components/beta/common/Timestamp.tsx
+++ b/frontend/src/components/beta/common/Timestamp.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import CopyToClipboard from "@explorer/frontend/components/utils/CopyToClipboard";
 import { useDateFormat } from "@explorer/frontend/hooks/use-date-format";

--- a/frontend/src/components/beta/transactions/ReceiptDetails.tsx
+++ b/frontend/src/components/beta/transactions/ReceiptDetails.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { TransactionReceipt } from "@explorer/common/types/procedures";
 import CodeArgs from "@explorer/frontend/components/beta/common/CodeArgs";

--- a/frontend/src/components/beta/transactions/ReceiptInfo.tsx
+++ b/frontend/src/components/beta/transactions/ReceiptInfo.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { TransactionReceipt } from "@explorer/common/types/procedures";
 import { Tabs } from "@explorer/frontend/components/beta/common/Tabs";

--- a/frontend/src/components/beta/transactions/ReceiptKind.tsx
+++ b/frontend/src/components/beta/transactions/ReceiptKind.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { Action } from "@explorer/common/types/procedures";
 import CodeArgs from "@explorer/frontend/components/beta/common/CodeArgs";

--- a/frontend/src/components/beta/transactions/TransactionActionsList.tsx
+++ b/frontend/src/components/beta/transactions/TransactionActionsList.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { Transaction } from "@explorer/common/types/procedures";
 import TransactionReceipt from "@explorer/frontend/components/beta/transactions/TransactionReceipt";

--- a/frontend/src/components/beta/transactions/TransactionHeader.tsx
+++ b/frontend/src/components/beta/transactions/TransactionHeader.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { Transaction } from "@explorer/common/types/procedures";
 import StringConditionalOverlay from "@explorer/frontend/components/beta/common/StringConditionalOverlay";

--- a/frontend/src/components/beta/transactions/TransactionStatus.tsx
+++ b/frontend/src/components/beta/transactions/TransactionStatus.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { TransactionStatus } from "@explorer/common/types/procedures";
 import { styled } from "@explorer/frontend/libraries/styles";

--- a/frontend/src/components/blocks/BlockDetails.tsx
+++ b/frontend/src/components/blocks/BlockDetails.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 
 import JSBI from "jsbi";
+import { useTranslation } from "next-i18next";
 import { Row, Col } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import { Block } from "@explorer/common/types/procedures";
 import AccountLink from "@explorer/frontend/components/utils/AccountLink";

--- a/frontend/src/components/blocks/Blocks.tsx
+++ b/frontend/src/components/blocks/Blocks.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { BlockBase } from "@explorer/common/types/procedures";
 import { id } from "@explorer/common/utils/utils";

--- a/frontend/src/components/blocks/BlocksRow.tsx
+++ b/frontend/src/components/blocks/BlocksRow.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
+import { useTranslation } from "next-i18next";
 import { Row, Col } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import { BlockBase } from "@explorer/common/types/procedures";
 import Link from "@explorer/frontend/components/utils/Link";

--- a/frontend/src/components/contracts/ContractDetails.tsx
+++ b/frontend/src/components/contracts/ContractDetails.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
+import { Trans, useTranslation } from "next-i18next";
 import { Row, Col } from "react-bootstrap";
-import { Trans, useTranslation } from "react-i18next";
 
 import CardCell, {
   CardCellTitleImage,

--- a/frontend/src/components/dashboard/DashboardBlock.tsx
+++ b/frontend/src/components/dashboard/DashboardBlock.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
+import { Trans, useTranslation } from "next-i18next";
 import { Col, Row } from "react-bootstrap";
-import { Trans, useTranslation } from "react-i18next";
 
 import CopyToClipboard from "@explorer/frontend/components/utils/CopyToClipboard";
 import DashboardCard from "@explorer/frontend/components/utils/DashboardCard";

--- a/frontend/src/components/dashboard/DashboardNode.tsx
+++ b/frontend/src/components/dashboard/DashboardNode.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
+import { useTranslation } from "next-i18next";
 import { Col, Row } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import DashboardCard from "@explorer/frontend/components/utils/DashboardCard";
 import LongCardCell, {

--- a/frontend/src/components/dashboard/DashboardTransaction.tsx
+++ b/frontend/src/components/dashboard/DashboardTransaction.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
+import { useTranslation } from "next-i18next";
 import { Col, Row } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import DashboardTransactionsHistoryChart from "@explorer/frontend/components/dashboard/DashboardTransactionsHistoryChart";
 import DashboardCard from "@explorer/frontend/components/utils/DashboardCard";

--- a/frontend/src/components/dashboard/DashboardTransactionsHistoryChart.tsx
+++ b/frontend/src/components/dashboard/DashboardTransactionsHistoryChart.tsx
@@ -2,8 +2,8 @@ import * as React from "react";
 
 import * as echarts from "echarts";
 import ReactEcharts from "echarts-for-react";
+import { useTranslation } from "next-i18next";
 import { Col, Row } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import { TRPCSubscriptionOutput } from "@explorer/common/types/trpc";
 import PaginationSpinner from "@explorer/frontend/components/utils/PaginationSpinner";

--- a/frontend/src/components/nodes/CumulativeStakeChart.tsx
+++ b/frontend/src/components/nodes/CumulativeStakeChart.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { styled } from "@explorer/frontend/libraries/styles";
 

--- a/frontend/src/components/nodes/NodeNav.tsx
+++ b/frontend/src/components/nodes/NodeNav.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
+import { useTranslation } from "next-i18next";
 import { Badge, Col, Row } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import Link from "@explorer/frontend/components/utils/Link";
 import { useNetworkStats } from "@explorer/frontend/hooks/subscriptions";

--- a/frontend/src/components/nodes/NodesCard.tsx
+++ b/frontend/src/components/nodes/NodesCard.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 
 import JSBI from "jsbi";
+import { useTranslation } from "next-i18next";
 import { OverlayTrigger, Tooltip } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import NearBadge from "@explorer/frontend/components/nodes/NearBadge";
 import {

--- a/frontend/src/components/nodes/NodesContentHeader.tsx
+++ b/frontend/src/components/nodes/NodesContentHeader.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
+import { useTranslation } from "next-i18next";
 import { Col, Row } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import NodeNav from "@explorer/frontend/components/nodes/NodeNav";
 import { styled } from "@explorer/frontend/libraries/styles";

--- a/frontend/src/components/nodes/NodesEpoch.tsx
+++ b/frontend/src/components/nodes/NodesEpoch.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
+import { useTranslation } from "next-i18next";
 import { Row, Col } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import ProgressBar from "@explorer/frontend/components/utils/ProgressBar";
 import { useDateFormat } from "@explorer/frontend/hooks/use-date-format";

--- a/frontend/src/components/nodes/ValidatingLabel.tsx
+++ b/frontend/src/components/nodes/ValidatingLabel.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
+import { TFunction, useTranslation } from "next-i18next";
 import { Badge, OverlayTrigger, Tooltip } from "react-bootstrap";
-import { TFunction, useTranslation } from "react-i18next";
 
 import { styled } from "@explorer/frontend/libraries/styles";
 
@@ -55,17 +55,16 @@ const ValidatingLabelWrapper = styled(Badge, {
   },
 });
 
-const TOOLTIP_TEXTS: Record<StakingStatus, (t: TFunction<"common">) => string> =
-  {
-    active: (t) => t("component.nodes.ValidatorMainRow.state.active.text"),
-    joining: (t) => t("component.nodes.ValidatorMainRow.state.joining.text"),
-    leaving: (t) => t("component.nodes.ValidatorMainRow.state.leaving.text"),
-    proposal: (t) => t("component.nodes.ValidatorMainRow.state.proposal.text"),
-    idle: (t) => t("component.nodes.ValidatorMainRow.state.idle.text"),
-    newcomer: (t) => t("component.nodes.ValidatorMainRow.state.newcomer.text"),
-    onHold: (t) => t("component.nodes.ValidatorMainRow.state.onHold.text"),
-  };
-const LABEL_TEXTS: Record<StakingStatus, (t: TFunction<"common">) => string> = {
+const TOOLTIP_TEXTS: Record<StakingStatus, (t: TFunction) => string> = {
+  active: (t) => t("component.nodes.ValidatorMainRow.state.active.text"),
+  joining: (t) => t("component.nodes.ValidatorMainRow.state.joining.text"),
+  leaving: (t) => t("component.nodes.ValidatorMainRow.state.leaving.text"),
+  proposal: (t) => t("component.nodes.ValidatorMainRow.state.proposal.text"),
+  idle: (t) => t("component.nodes.ValidatorMainRow.state.idle.text"),
+  newcomer: (t) => t("component.nodes.ValidatorMainRow.state.newcomer.text"),
+  onHold: (t) => t("component.nodes.ValidatorMainRow.state.onHold.text"),
+};
+const LABEL_TEXTS: Record<StakingStatus, (t: TFunction) => string> = {
   active: (t) => t("component.nodes.ValidatorMainRow.state.active.title"),
   joining: (t) => t("component.nodes.ValidatorMainRow.state.joining.title"),
   leaving: (t) => t("component.nodes.ValidatorMainRow.state.leaving.title"),

--- a/frontend/src/components/nodes/ValidatorMainRow.tsx
+++ b/frontend/src/components/nodes/ValidatorMainRow.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 
 import JSBI from "jsbi";
+import { useTranslation } from "next-i18next";
 import { Row, Col, Spinner } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import { ValidatorPoolInfo } from "@explorer/common/types/procedures";
 import CumulativeStakeChart from "@explorer/frontend/components/nodes/CumulativeStakeChart";

--- a/frontend/src/components/nodes/ValidatorMetadataRow.tsx
+++ b/frontend/src/components/nodes/ValidatorMetadataRow.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
+import { Trans, useTranslation } from "next-i18next";
 import { Col, Row } from "react-bootstrap";
-import { Trans, useTranslation } from "react-i18next";
 
 import { ValidatorDescription } from "@explorer/common/types/procedures";
 import { styled } from "@explorer/frontend/libraries/styles";

--- a/frontend/src/components/nodes/ValidatorProgressElement.tsx
+++ b/frontend/src/components/nodes/ValidatorProgressElement.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
+import { useTranslation } from "next-i18next";
 import { Col, Row, OverlayTrigger, Tooltip } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import { ValidationProgress } from "@explorer/common/types/procedures";
 import {

--- a/frontend/src/components/nodes/ValidatorRow.tsx
+++ b/frontend/src/components/nodes/ValidatorRow.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import JSBI from "jsbi";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { ValidatorFullData } from "@explorer/common/types/procedures";
 import { FRACTION_DIGITS } from "@explorer/frontend/components/nodes/CumulativeStakeChart";

--- a/frontend/src/components/nodes/ValidatorTelemetryElements.tsx
+++ b/frontend/src/components/nodes/ValidatorTelemetryElements.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
+import { Trans, useTranslation } from "next-i18next";
 import { Col, Row, Badge } from "react-bootstrap";
-import { Trans, useTranslation } from "react-i18next";
 
 import { ValidatorTelemetry } from "@explorer/common/types/procedures";
 import {

--- a/frontend/src/components/nodes/Validators.tsx
+++ b/frontend/src/components/nodes/Validators.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import ValidatorsList, {
   ITEMS_PER_PAGE,

--- a/frontend/src/components/receipts/ReceiptExecutionStatus.tsx
+++ b/frontend/src/components/receipts/ReceiptExecutionStatus.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { ReceiptExecutionStatus } from "@explorer/common/types/procedures";
 

--- a/frontend/src/components/receipts/Receipts.tsx
+++ b/frontend/src/components/receipts/Receipts.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { Receipt } from "@explorer/common/types/procedures";
 import ReceiptExecutionStatus from "@explorer/frontend/components/receipts/ReceiptExecutionStatus";

--- a/frontend/src/components/receipts/ReceiptsList.tsx
+++ b/frontend/src/components/receipts/ReceiptsList.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { Receipt } from "@explorer/common/types/procedures";
 import Receipts from "@explorer/frontend/components/receipts/Receipts";

--- a/frontend/src/components/stats/ActiveAccountsByDate.tsx
+++ b/frontend/src/components/stats/ActiveAccountsByDate.tsx
@@ -2,8 +2,8 @@ import * as React from "react";
 
 import * as echarts from "echarts";
 import ReactEcharts from "echarts-for-react";
+import { useTranslation } from "next-i18next";
 import { Tabs, Tab } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import { TRPCSubscriptionOutput } from "@explorer/common/types/trpc";
 import { Props } from "@explorer/frontend/components/stats/TransactionsByDate";

--- a/frontend/src/components/stats/ActiveAccountsList.tsx
+++ b/frontend/src/components/stats/ActiveAccountsList.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import ReactEcharts from "echarts-for-react";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { TRPCSubscriptionOutput } from "@explorer/common/types/trpc";
 import { Props } from "@explorer/frontend/components/stats/TransactionsByDate";

--- a/frontend/src/components/stats/ActiveContractsByDate.tsx
+++ b/frontend/src/components/stats/ActiveContractsByDate.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import * as echarts from "echarts";
 import ReactEcharts from "echarts-for-react";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { TRPCSubscriptionOutput } from "@explorer/common/types/trpc";
 import { Props } from "@explorer/frontend/components/stats/TransactionsByDate";

--- a/frontend/src/components/stats/ActiveContractsList.tsx
+++ b/frontend/src/components/stats/ActiveContractsList.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import ReactEcharts from "echarts-for-react";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { TRPCSubscriptionOutput } from "@explorer/common/types/trpc";
 import { Props } from "@explorer/frontend/components/stats/TransactionsByDate";

--- a/frontend/src/components/stats/CirculatingSupplyStats.tsx
+++ b/frontend/src/components/stats/CirculatingSupplyStats.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import * as echarts from "echarts";
 import ReactEcharts from "echarts-for-react";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { TRPCSubscriptionOutput } from "@explorer/common/types/trpc";
 import { Props } from "@explorer/frontend/components/stats/TransactionsByDate";

--- a/frontend/src/components/stats/GasUsedByDate.tsx
+++ b/frontend/src/components/stats/GasUsedByDate.tsx
@@ -3,8 +3,8 @@ import * as React from "react";
 import * as echarts from "echarts";
 import ReactEcharts from "echarts-for-react";
 import JSBI from "jsbi";
+import { useTranslation } from "next-i18next";
 import { Tabs, Tab } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import { TRPCSubscriptionOutput } from "@explorer/common/types/trpc";
 import { Props } from "@explorer/frontend/components/stats/TransactionsByDate";

--- a/frontend/src/components/stats/NewAccountsByDate.tsx
+++ b/frontend/src/components/stats/NewAccountsByDate.tsx
@@ -2,8 +2,8 @@ import * as React from "react";
 
 import * as echarts from "echarts";
 import ReactEcharts from "echarts-for-react";
+import { useTranslation } from "next-i18next";
 import { Tabs, Tab } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import { TRPCSubscriptionOutput } from "@explorer/common/types/trpc";
 import { Props } from "@explorer/frontend/components/stats/TransactionsByDate";

--- a/frontend/src/components/stats/NewContractsByDate.tsx
+++ b/frontend/src/components/stats/NewContractsByDate.tsx
@@ -2,8 +2,8 @@ import * as React from "react";
 
 import * as echarts from "echarts";
 import ReactEcharts from "echarts-for-react";
+import { useTranslation } from "next-i18next";
 import { Tabs, Tab } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import { TRPCSubscriptionOutput } from "@explorer/common/types/trpc";
 import { Props } from "@explorer/frontend/components/stats/TransactionsByDate";

--- a/frontend/src/components/stats/ProtocolConfigInfo.tsx
+++ b/frontend/src/components/stats/ProtocolConfigInfo.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 
 import JSBI from "jsbi";
+import { useTranslation } from "next-i18next";
 import { Spinner } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import NearBadge from "@explorer/frontend/components/nodes/NearBadge";
 import Balance, {

--- a/frontend/src/components/stats/TransactionsByDate.tsx
+++ b/frontend/src/components/stats/TransactionsByDate.tsx
@@ -2,8 +2,8 @@ import * as React from "react";
 
 import * as echarts from "echarts";
 import ReactEcharts from "echarts-for-react";
+import { useTranslation } from "next-i18next";
 import { Tabs, Tab } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import PaginationSpinner from "@explorer/frontend/components/utils/PaginationSpinner";
 import { useSubscription } from "@explorer/frontend/hooks/use-subscription";

--- a/frontend/src/components/transactions/ActionMessage.tsx
+++ b/frontend/src/components/transactions/ActionMessage.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import { hexy } from "hexy";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { Action } from "@explorer/common/types/procedures";
 import AccountLink from "@explorer/frontend/components/utils/AccountLink";

--- a/frontend/src/components/transactions/ActionRowBlock.tsx
+++ b/frontend/src/components/transactions/ActionRowBlock.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
+import { useTranslation } from "next-i18next";
 import { Row, Col } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import AccountLink from "@explorer/frontend/components/utils/AccountLink";
 import Timer from "@explorer/frontend/components/utils/Timer";

--- a/frontend/src/components/transactions/ReceiptRow.tsx
+++ b/frontend/src/components/transactions/ReceiptRow.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 
 import JSBI from "jsbi";
+import { useTranslation } from "next-i18next";
 import { Row, Col } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import { NestedReceiptWithOutcomeOld } from "@explorer/common/types/procedures";
 import { Args } from "@explorer/frontend/components/transactions/ActionMessage";

--- a/frontend/src/components/transactions/TransactionAction.tsx
+++ b/frontend/src/components/transactions/TransactionAction.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { TransactionPreview } from "@explorer/common/types/procedures";
 import ActionGroup from "@explorer/frontend/components/transactions/ActionGroup";

--- a/frontend/src/components/transactions/TransactionDetails.tsx
+++ b/frontend/src/components/transactions/TransactionDetails.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 
 import JSBI from "jsbi";
+import { useTranslation } from "next-i18next";
 import { Row, Col } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import {
   NestedReceiptWithOutcomeOld,

--- a/frontend/src/components/transactions/TransactionExecutionStatus.tsx
+++ b/frontend/src/components/transactions/TransactionExecutionStatus.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { TransactionStatus } from "@explorer/common/types/procedures";
 

--- a/frontend/src/components/transactions/TransactionOutcome.tsx
+++ b/frontend/src/components/transactions/TransactionOutcome.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 
 import JSBI from "jsbi";
+import { useTranslation } from "next-i18next";
 import { Row, Col } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import { TransactionOutcomeOld } from "@explorer/common/types/procedures";
 import Balance from "@explorer/frontend/components/utils/Balance";

--- a/frontend/src/components/transactions/Transactions.tsx
+++ b/frontend/src/components/transactions/Transactions.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 import * as ReactQuery from "react-query";
 
 import {

--- a/frontend/src/components/utils/CodePreview.tsx
+++ b/frontend/src/components/utils/CodePreview.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import Expandable from "@explorer/frontend/components/utils/Expandable";
 import { styled } from "@explorer/frontend/libraries/styles";

--- a/frontend/src/components/utils/ErrorMessage.tsx
+++ b/frontend/src/components/utils/ErrorMessage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { styled } from "@explorer/frontend/libraries/styles";
 

--- a/frontend/src/components/utils/Footer.tsx
+++ b/frontend/src/components/utils/Footer.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
+import { useTranslation } from "next-i18next";
 import { Container, Row, Col } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import { useAnalyticsTrack } from "@explorer/frontend/hooks/analytics/use-analytics-track";
 import { styled } from "@explorer/frontend/libraries/styles";

--- a/frontend/src/components/utils/Header.tsx
+++ b/frontend/src/components/utils/Header.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 
 import { useRouter } from "next/router";
+import { useTranslation } from "next-i18next";
 import { Container, Row, Col } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import { BetaSwitch } from "@explorer/frontend/components/utils/BetaSwitch";
 import HeaderNavDropdown from "@explorer/frontend/components/utils/HeaderNavDropdown";

--- a/frontend/src/components/utils/HeaderNavDropdown.tsx
+++ b/frontend/src/components/utils/HeaderNavDropdown.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 
 import { StyledComponent } from "@stitches/react/types/styled-component";
+import { useTranslation } from "next-i18next";
 import { Dropdown } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import Link from "@explorer/frontend/components/utils/Link";
 import { globalCss, styled } from "@explorer/frontend/libraries/styles";

--- a/frontend/src/components/utils/LanguageToggle.tsx
+++ b/frontend/src/components/utils/LanguageToggle.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { LanguageContext } from "@explorer/frontend/context/LanguageContext";
 import { Language, LANGUAGES } from "@explorer/frontend/libraries/i18n";

--- a/frontend/src/components/utils/ListHandler.tsx
+++ b/frontend/src/components/utils/ListHandler.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 import InfiniteScroll from "react-infinite-scroll-component";
 import * as ReactQuery from "react-query";
 

--- a/frontend/src/components/utils/MobileHeaderNavDropdown.tsx
+++ b/frontend/src/components/utils/MobileHeaderNavDropdown.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import { StyledComponent } from "@stitches/react/types/styled-component";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { BetaSwitch } from "@explorer/frontend/components/utils/BetaSwitch";
 import LanguageToggle from "@explorer/frontend/components/utils/LanguageToggle";

--- a/frontend/src/components/utils/Search.tsx
+++ b/frontend/src/components/utils/Search.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 
 import { useRouter } from "next/router";
+import { useTranslation } from "next-i18next";
 import { Button, FormControl, InputGroup, Row } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import { useAnalyticsTrack } from "@explorer/frontend/hooks/analytics/use-analytics-track";
 import { useQueryParam } from "@explorer/frontend/hooks/use-query-param";
@@ -247,7 +247,7 @@ const Search: React.FC<Props> = React.memo(({ dashboard }) => {
               <InputGroupText id="search">
                 <img
                   src="/static/images/icon-search.svg"
-                  alt={t("component.utils.Search.title")}
+                  alt={t("component.utils.Search.title")!}
                 />
               </InputGroupText>
             </InputGroup.Prepend>

--- a/frontend/src/components/utils/StorageSize.tsx
+++ b/frontend/src/components/utils/StorageSize.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 
+import { TFunction, useTranslation } from "next-i18next";
 import { OverlayTrigger, Tooltip } from "react-bootstrap";
-import { TFunction, useTranslation } from "react-i18next";
 
 import { formatWithCommas } from "@explorer/frontend/components/utils/Balance";
 
-const formatStoreSize = (value: number, t: TFunction<"common">): string => {
+const formatStoreSize = (value: number, t: TFunction): string => {
   let showStorage = value.toString();
   const kilo = 10 ** 3;
 

--- a/frontend/src/components/utils/Term.tsx
+++ b/frontend/src/components/utils/Term.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
+import { useTranslation } from "next-i18next";
 import { Modal } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import { useAnalyticsTrack } from "@explorer/frontend/hooks/analytics/use-analytics-track";
 import { styled } from "@explorer/frontend/libraries/styles";

--- a/frontend/src/components/utils/WalletLink.tsx
+++ b/frontend/src/components/utils/WalletLink.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { useAnalyticsTrack } from "@explorer/frontend/hooks/analytics/use-analytics-track";
 import { truncateAccountId } from "@explorer/frontend/libraries/formatting";

--- a/frontend/src/hooks/use-date-format.ts
+++ b/frontend/src/hooks/use-date-format.ts
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { addMinutes, format, formatISO } from "date-fns";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { useDateLocale } from "@explorer/frontend/hooks/use-date-locale";
 

--- a/frontend/src/pages/accounts/[...slug].tsx
+++ b/frontend/src/pages/accounts/[...slug].tsx
@@ -2,8 +2,8 @@ import * as React from "react";
 
 import { GetServerSideProps, NextPage } from "next";
 import Head from "next/head";
+import { useTranslation } from "next-i18next";
 import { Container, Spinner } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import { TRPCQueryResult } from "@explorer/common/types/trpc";
 import AccountDetails from "@explorer/frontend/components/accounts/AccountDetails";

--- a/frontend/src/pages/accounts/index.tsx
+++ b/frontend/src/pages/accounts/index.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { NextPage } from "next";
 import Head from "next/head";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import Accounts from "@explorer/frontend/components/accounts/Accounts";
 import Content from "@explorer/frontend/components/utils/Content";

--- a/frontend/src/pages/beta/accounts/[...slug].tsx
+++ b/frontend/src/pages/beta/accounts/[...slug].tsx
@@ -2,8 +2,8 @@ import * as React from "react";
 
 import { GetServerSideProps, NextPage } from "next";
 import Head from "next/head";
+import { useTranslation } from "next-i18next";
 import { Spinner } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import { TRPCQueryResult } from "@explorer/common/types/trpc";
 import AccountHeader from "@explorer/frontend/components/beta/accounts/AccountHeader";

--- a/frontend/src/pages/beta/transactions/[hash].tsx
+++ b/frontend/src/pages/beta/transactions/[hash].tsx
@@ -3,8 +3,8 @@ import * as React from "react";
 import { NextPage } from "next";
 import Head from "next/head";
 import { useRouter } from "next/router";
+import { useTranslation } from "next-i18next";
 import { Spinner } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 import * as ReactQuery from "react-query";
 
 import { Transaction } from "@explorer/common/types/procedures";

--- a/frontend/src/pages/blocks/[hash].tsx
+++ b/frontend/src/pages/blocks/[hash].tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { NextPage } from "next";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import BlockDetails from "@explorer/frontend/components/blocks/BlockDetails";
 import ReceiptsExecutedInBlock from "@explorer/frontend/components/receipts/ReceiptsExecutedInBlock";

--- a/frontend/src/pages/blocks/index.tsx
+++ b/frontend/src/pages/blocks/index.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { NextPage } from "next";
 import Head from "next/head";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import Blocks from "@explorer/frontend/components/blocks/Blocks";
 import Content from "@explorer/frontend/components/utils/Content";

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -2,8 +2,8 @@ import * as React from "react";
 
 import { GetServerSideProps, NextPage } from "next";
 import Head from "next/head";
+import { useTranslation } from "next-i18next";
 import { Container, Row, Col } from "react-bootstrap";
-import { useTranslation } from "react-i18next";
 
 import { TRPCQueryOutput } from "@explorer/common/types/trpc";
 import DashboardBlock from "@explorer/frontend/components/dashboard/DashboardBlock";

--- a/frontend/src/pages/receipts/[id].tsx
+++ b/frontend/src/pages/receipts/[id].tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { GetServerSideProps, NextPage } from "next";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import Content from "@explorer/frontend/components/utils/Content";
 import { getNearNetworkName } from "@explorer/frontend/libraries/config";

--- a/frontend/src/pages/stats/index.tsx
+++ b/frontend/src/pages/stats/index.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { NextPage } from "next";
 import Head from "next/head";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import ActiveAccountsByDate from "@explorer/frontend/components/stats/ActiveAccountsByDate";
 import ActiveAccountsList from "@explorer/frontend/components/stats/ActiveAccountsList";

--- a/frontend/src/pages/transactions/[hash].tsx
+++ b/frontend/src/pages/transactions/[hash].tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { NextPage } from "next";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import ActionsList from "@explorer/frontend/components/transactions/ActionsList";
 import ReceiptRow from "@explorer/frontend/components/transactions/ReceiptRow";

--- a/frontend/src/pages/transactions/index.tsx
+++ b/frontend/src/pages/transactions/index.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { NextPage } from "next";
 import Head from "next/head";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import Transactions, {
   getNextPageParam,

--- a/package-lock.json
+++ b/package-lock.json
@@ -138,6 +138,7 @@
         "json-2-prom": "1.0.3",
         "lodash": "^4.17.21",
         "next": "^12.1.0",
+        "next-i18next": "^12.1.0",
         "rc-progress": "^3.1.4",
         "rc-switch": "^4.0.0",
         "react": "^17.0.2",
@@ -4201,6 +4202,15 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
       }
     },
     "node_modules/@types/invariant": {
@@ -10797,6 +10807,14 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -11008,6 +11026,11 @@
       "dependencies": {
         "@babel/runtime": "^7.17.2"
       }
+    },
+    "node_modules/i18next-fs-backend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-1.2.0.tgz",
+      "integrity": "sha512-pUx3AcgXCbur0jpFA7U67Z2RJflAcIi698Y8VL+phdOqUchahxriV3Cs+M6UkPNQSS/zPEzWLfdJ8EgjB7HVxg=="
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -14241,6 +14264,51 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-i18next": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/next-i18next/-/next-i18next-12.1.0.tgz",
+      "integrity": "sha512-rhos/PVULmZPdC0jpec2MDBQMXdGZ3+Mbh/tZfrDtjgnVN3ucdq7k8BlwsJNww6FnqC8AC31n6dSYuqVzYsGsw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "dependencies": {
+        "@babel/runtime": "^7.18.9",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "core-js": "^3",
+        "hoist-non-react-statics": "^3.3.2",
+        "i18next": "^21.9.1",
+        "i18next-fs-backend": "^1.1.5",
+        "react-i18next": "^11.18.4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "next": ">= 10.0.0",
+        "react": ">= 16.8.0"
+      }
+    },
+    "node_modules/next-i18next/node_modules/core-js": {
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.28.0.tgz",
+      "integrity": "sha512-GiZn9D4Z/rSYvTeg1ljAIsEqFm0LaN9gVtwDCrKL80zHtS31p9BAjmTxVqTQDMpwlMolJZOFntUG2uwyj7DAqw==",
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -21953,6 +22021,7 @@
         "json-2-prom": "1.0.3",
         "lodash": "^4.17.21",
         "next": "^12.1.0",
+        "next-i18next": "^12.1.0",
         "postcss": "^8.4.4",
         "rc-progress": "^3.1.4",
         "rc-switch": "^4.0.0",
@@ -23386,6 +23455,15 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
       }
     },
     "@types/invariant": {
@@ -28691,6 +28769,14 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      }
+    },
     "hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -28847,6 +28933,11 @@
       "requires": {
         "@babel/runtime": "^7.17.2"
       }
+    },
+    "i18next-fs-backend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-1.2.0.tgz",
+      "integrity": "sha512-pUx3AcgXCbur0jpFA7U67Z2RJflAcIi698Y8VL+phdOqUchahxriV3Cs+M6UkPNQSS/zPEzWLfdJ8EgjB7HVxg=="
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -31330,6 +31421,27 @@
             "picocolors": "^1.0.0",
             "source-map-js": "^1.0.2"
           }
+        }
+      }
+    },
+    "next-i18next": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/next-i18next/-/next-i18next-12.1.0.tgz",
+      "integrity": "sha512-rhos/PVULmZPdC0jpec2MDBQMXdGZ3+Mbh/tZfrDtjgnVN3ucdq7k8BlwsJNww6FnqC8AC31n6dSYuqVzYsGsw==",
+      "requires": {
+        "@babel/runtime": "^7.18.9",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "core-js": "^3",
+        "hoist-non-react-statics": "^3.3.2",
+        "i18next": "^21.9.1",
+        "i18next-fs-backend": "^1.1.5",
+        "react-i18next": "^11.18.4"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.28.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.28.0.tgz",
+          "integrity": "sha512-GiZn9D4Z/rSYvTeg1ljAIsEqFm0LaN9gVtwDCrKL80zHtS31p9BAjmTxVqTQDMpwlMolJZOFntUG2uwyj7DAqw=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     ]
   },
   "dependencies": {
-    "@explorer/common": "*",
     "@explorer/backend": "*",
+    "@explorer/common": "*",
     "@explorer/frontend": "*",
     "dotenv-cli": "^5.0.0",
     "gleap": "^8.4.7",


### PR DESCRIPTION
We are going to migrate to `next-i18next` solution for incorporating translations soon, so I made files migration beforehand.