### PR TITLE
Refactor: PropsWithChildren

### DIFF
--- a/frontend/src/components/nodes/ValidatorMainRow.tsx
+++ b/frontend/src/components/nodes/ValidatorMainRow.tsx
@@ -55,7 +55,7 @@ const IconCellIcon = styled("img", {
   width: 16,
 });
 
-interface Props {
+type Props = React.PropsWithChildren<{
   isRowActive: boolean;
   accountId: string;
   index: number;
@@ -71,7 +71,7 @@ interface Props {
     cumulativePercent: number;
   } | null;
   handleClick: React.MouseEventHandler;
-}
+}>;
 
 const yoctoNearToNear = JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(24));
 

--- a/frontend/src/components/nodes/ValidatorMetadataRow.tsx
+++ b/frontend/src/components/nodes/ValidatorMetadataRow.tsx
@@ -33,9 +33,9 @@ const ValidatorNodesText = styled(Col, {
   color: "#3f4045",
 });
 
-type ElementProps = {
+type ElementProps = React.PropsWithChildren<{
   header: React.ReactNode;
-};
+}>;
 
 const ValidatorMetadataElement: React.FC<ElementProps> = React.memo(
   ({ children, header }) => {

--- a/frontend/src/components/utils/Content.tsx
+++ b/frontend/src/components/utils/Content.tsx
@@ -23,7 +23,7 @@ export const ContentHeader = styled(Row, {
   },
 });
 
-export interface Props {
+export type Props = React.PropsWithChildren<{
   title?: React.ReactNode;
   header?: React.ReactNode;
   overrideHeader?: React.FC<React.ComponentProps<typeof ContentHeader>>;
@@ -32,7 +32,7 @@ export interface Props {
   contentFluid?: boolean;
   icon?: React.ReactNode;
   className?: string;
-}
+}>;
 
 const Content: React.FC<Props> = React.memo(
   ({

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -149,10 +149,10 @@ const wrapRouterHandlerMaintainNetwork =
     );
   };
 
-type ContextProps = {
+type ContextProps = React.PropsWithChildren<{
   networkState: NetworkContextType;
   languageContext: LanguageContextType;
-};
+}>;
 
 const AppContextWrapper: React.FC<ContextProps> = React.memo((props) => (
   <LanguageContext.Provider value={props.languageContext}>


### PR DESCRIPTION
React 18 makes defining `children` strict in props.