### PR TITLE
Refactor: headless react-hot-toast

### DIFF
--- a/frontend/src/components/utils/ServiceStatus.tsx
+++ b/frontend/src/components/utils/ServiceStatus.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { OverlayTrigger, Tooltip } from "react-bootstrap";
-import toast from "react-hot-toast";
+import toast from "react-hot-toast/headless";
 
 import { HealthStatus } from "@explorer/common/types/procedures";
 import Timer from "@explorer/frontend/components/utils/Timer";

--- a/frontend/src/components/utils/ToastController.tsx
+++ b/frontend/src/components/utils/ToastController.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 
-import { useToaster, toast, ToastType } from "react-hot-toast";
+import {
+  useToaster,
+  toast,
+  ToastType,
+  resolveValue,
+} from "react-hot-toast/headless";
 
 import { styled } from "@explorer/frontend/libraries/styles";
 
@@ -77,7 +82,9 @@ export const ToastController: React.FC = () => {
                 fill="currentColor"
               />
             </svg>
-            <Message>{toastInstance.message}</Message>
+            <Message>
+              {resolveValue(toastInstance.message, toastInstance)}
+            </Message>
           </Toast>
         ))}
     </Wrapper>


### PR DESCRIPTION
We don't actually use original `react-hot-toast` styles, so we don't need headed version.