### PR TITLE
Refactor: link preparation to next 13

### DIFF
--- a/frontend/public/static/images/right-arrow.svg
+++ b/frontend/public/static/images/right-arrow.svg
@@ -1,3 +1,0 @@
-<svg width="8" height="14" viewBox="0 0 8 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M1 13L7 7L1 1" stroke="#0072CE" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/frontend/src/components/accounts/AccountRow.tsx
+++ b/frontend/src/components/accounts/AccountRow.tsx
@@ -39,10 +39,6 @@ const TransactionRowTimer = styled("div", {
   fontWeight: 300,
 });
 
-const LinkWrapper = styled("a", {
-  textDecoration: "none",
-});
-
 const AccountIcon = styled("img", {
   width: 15,
 });
@@ -60,61 +56,59 @@ const AccountRow: React.FC<Props> = React.memo(({ accountId }) => {
   const format = useDateFormat();
 
   return (
-    <Link href={`/accounts/${accountId}`} passHref>
-      <LinkWrapper>
-        <TransactionRow className="mx-0">
-          <Col md="auto" xs="1" className="pr-0">
-            <AccountIcon
-              src={
-                accountInfo?.deleted
-                  ? "/static/images/icon-t-acct-delete.svg"
-                  : "/static/images/icon-t-acct.svg"
-              }
-            />
-          </Col>
-          <TransactionRowTitle md="7" xs="11" className="pt-1">
-            {accountId}
-          </TransactionRowTitle>
-          <TransactionRowTransactionId
-            md="3"
-            xs="5"
-            className="ml-auto pt-1 text-right"
-          >
-            {accountInfo ? (
-              accountInfo.deleted ? (
+    <Link href={`/accounts/${accountId}`}>
+      <TransactionRow className="mx-0">
+        <Col md="auto" xs="1" className="pr-0">
+          <AccountIcon
+            src={
+              accountInfo?.deleted
+                ? "/static/images/icon-t-acct-delete.svg"
+                : "/static/images/icon-t-acct.svg"
+            }
+          />
+        </Col>
+        <TransactionRowTitle md="7" xs="11" className="pt-1">
+          {accountId}
+        </TransactionRowTitle>
+        <TransactionRowTransactionId
+          md="3"
+          xs="5"
+          className="ml-auto pt-1 text-right"
+        >
+          {accountInfo ? (
+            accountInfo.deleted ? (
+              <TransactionRowTimer>
+                {t("component.accounts.AccountRow.deleted_on")}{" "}
+                {format(accountInfo.deleted.timestamp, "PPP")}
+                <CopyToClipboard
+                  text={String(accountInfo.deleted.timestamp)}
+                  css={{ marginLeft: 8 }}
+                />
+              </TransactionRowTimer>
+            ) : (
+              <>
+                <Balance
+                  amount={accountInfo.details?.nonStakedBalance ?? "0"}
+                />
                 <TransactionRowTimer>
-                  {t("component.accounts.AccountRow.deleted_on")}{" "}
-                  {format(accountInfo.deleted.timestamp, "PPP")}
-                  <CopyToClipboard
-                    text={String(accountInfo.deleted.timestamp)}
-                    css={{ marginLeft: 8 }}
-                  />
+                  {t("component.accounts.AccountRow.created_on")}{" "}
+                  {accountInfo.created ? (
+                    <>
+                      {format(accountInfo.created.timestamp, "PPP")}
+                      <CopyToClipboard
+                        text={String(accountInfo.created.timestamp)}
+                        css={{ marginLeft: 8 }}
+                      />
+                    </>
+                  ) : (
+                    "Genesis"
+                  )}
                 </TransactionRowTimer>
-              ) : (
-                <>
-                  <Balance
-                    amount={accountInfo.details?.nonStakedBalance ?? "0"}
-                  />
-                  <TransactionRowTimer>
-                    {t("component.accounts.AccountRow.created_on")}{" "}
-                    {accountInfo.created ? (
-                      <>
-                        {format(accountInfo.created.timestamp, "PPP")}
-                        <CopyToClipboard
-                          text={String(accountInfo.created.timestamp)}
-                          css={{ marginLeft: 8 }}
-                        />
-                      </>
-                    ) : (
-                      "Genesis"
-                    )}
-                  </TransactionRowTimer>
-                </>
-              )
-            ) : null}
-          </TransactionRowTransactionId>
-        </TransactionRow>
-      </LinkWrapper>
+              </>
+            )
+          ) : null}
+        </TransactionRowTransactionId>
+      </TransactionRow>
     </Link>
   );
 });

--- a/frontend/src/components/accounts/__tests__/__snapshots__/AccountDetails.test.tsx.snap
+++ b/frontend/src/components/accounts/__tests__/__snapshots__/AccountDetails.test.tsx.snap
@@ -140,18 +140,14 @@ exports[`<AccountDetails /> renders with account created at genesis (legacy) 1`]
             <div
               className="c-CardCellText-eLcwWo ml-auto align-self-center col-md-12 col-auto"
             >
-              <span
+              <a
+                className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                href="/accounts/gjturigjgkjnfidsjffjsa.lockup.near"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
-                <a
-                  className="c-AccountLinkWrapper-dbzzBd"
-                  href="/accounts/gjturigjgkjnfidsjffjsa.lockup.near"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  gjtur…ockup.near
-                </a>
-              </span>
+                gjtur…ockup.near
+              </a>
             </div>
           </div>
         </div>
@@ -479,18 +475,14 @@ exports[`<AccountDetails /> renders with account created at genesis 1`] = `
             <div
               className="c-CardCellText-eLcwWo ml-auto align-self-center col-md-12 col-auto"
             >
-              <span
+              <a
+                className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                href="/accounts/gjturigjgkjnfidsjffjsa.lockup.near"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
-                <a
-                  className="c-AccountLinkWrapper-dbzzBd"
-                  href="/accounts/gjturigjgkjnfidsjffjsa.lockup.near"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  gjtur…ockup.near
-                </a>
-              </span>
+                gjtur…ockup.near
+              </a>
             </div>
           </div>
         </div>
@@ -818,18 +810,14 @@ exports[`<AccountDetails /> renders with account deletion at 1`] = `
             <div
               className="c-CardCellText-eLcwWo ml-auto align-self-center col-md-12 col-auto"
             >
-              <span
+              <a
+                className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                href="/accounts/gjturigjgkjnfidsjffjsa.lockup.near"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
-                <a
-                  className="c-AccountLinkWrapper-dbzzBd"
-                  href="/accounts/gjturigjgkjnfidsjffjsa.lockup.near"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  gjtur…ockup.near
-                </a>
-              </span>
+                gjtur…ockup.near
+              </a>
             </div>
           </div>
         </div>
@@ -1063,20 +1051,17 @@ exports[`<AccountDetails /> renders with account deletion at 1`] = `
               className="c-CardCellText-eLcwWo ml-auto align-self-center col-md-12 col-auto"
             >
               3RAqiv3SzjmtMT3ncqU96q1efRm67YT6gxtS7hhPvADp
-              <span
+              <a
+                className="c-Anchor-hIXuvg"
+                href="/transactions/3RAqiv3SzjmtMT3ncqU96q1efRm67YT6gxtS7hhPvADp"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
-                <a
-                  href="/transactions/3RAqiv3SzjmtMT3ncqU96q1efRm67YT6gxtS7hhPvADp"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  <img
-                    className="c-TransactionLinkIcon-fCEEVh"
-                    src="/static/images/icon-m-copy.svg"
-                  />
-                </a>
-              </span>
+                <img
+                  className="c-TransactionLinkIcon-fCEEVh"
+                  src="/static/images/icon-m-copy.svg"
+                />
+              </a>
             </div>
           </div>
         </div>
@@ -1226,18 +1211,14 @@ exports[`<AccountDetails /> renders with lockup account 1`] = `
             <div
               className="c-CardCellText-eLcwWo ml-auto align-self-center col-md-12 col-auto"
             >
-              <span
+              <a
+                className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                href="/accounts/gjturigjgkjnfidsjffjsa.lockup.near"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
-                <a
-                  className="c-AccountLinkWrapper-dbzzBd"
-                  href="/accounts/gjturigjgkjnfidsjffjsa.lockup.near"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  gjtur…ockup.near
-                </a>
-              </span>
+                gjtur…ockup.near
+              </a>
             </div>
           </div>
         </div>
@@ -1471,20 +1452,17 @@ exports[`<AccountDetails /> renders with lockup account 1`] = `
               className="c-CardCellText-eLcwWo ml-auto align-self-center col-md-12 col-auto"
             >
               EVvWW1S9BFaEjY1JBNSdstb7ZTtTFjQ6cygkbw1KY4tL
-              <span
+              <a
+                className="c-Anchor-hIXuvg"
+                href="/transactions/EVvWW1S9BFaEjY1JBNSdstb7ZTtTFjQ6cygkbw1KY4tL"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
-                <a
-                  href="/transactions/EVvWW1S9BFaEjY1JBNSdstb7ZTtTFjQ6cygkbw1KY4tL"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  <img
-                    className="c-TransactionLinkIcon-fCEEVh"
-                    src="/static/images/icon-m-copy.svg"
-                  />
-                </a>
-              </span>
+                <img
+                  className="c-TransactionLinkIcon-fCEEVh"
+                  src="/static/images/icon-m-copy.svg"
+                />
+              </a>
             </div>
           </div>
         </div>
@@ -1828,20 +1806,17 @@ exports[`<AccountDetails /> renders without lockup account 1`] = `
               className="c-CardCellText-eLcwWo ml-auto align-self-center col-md-12 col-auto"
             >
               EVvWW1S9BFlkjkmnjmkb7ZTtTFjQ6cygkbw1KY4tL
-              <span
+              <a
+                className="c-Anchor-hIXuvg"
+                href="/transactions/EVvWW1S9BFlkjkmnjmkb7ZTtTFjQ6cygkbw1KY4tL"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
-                <a
-                  href="/transactions/EVvWW1S9BFlkjkmnjmkb7ZTtTFjQ6cygkbw1KY4tL"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  <img
-                    className="c-TransactionLinkIcon-fCEEVh"
-                    src="/static/images/icon-m-copy.svg"
-                  />
-                </a>
-              </span>
+                <img
+                  className="c-TransactionLinkIcon-fCEEVh"
+                  src="/static/images/icon-m-copy.svg"
+                />
+              </a>
             </div>
           </div>
         </div>

--- a/frontend/src/components/accounts/__tests__/__snapshots__/AccountRow.test.tsx.snap
+++ b/frontend/src/components/accounts/__tests__/__snapshots__/AccountRow.test.tsx.snap
@@ -1,69 +1,61 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<AccountRow /> renders with long name 1`] = `
-<span
+<a
+  className="c-Anchor-hIXuvg"
+  href="/accounts/b7df2090560a225dc4934aed43db03a6c674c2d4.lockup.near"
   onClick={[Function]}
+  onMouseEnter={[Function]}
 >
-  <a
-    className="c-LinkWrapper-cIdiJW"
-    href="/accounts/b7df2090560a225dc4934aed43db03a6c674c2d4.lockup.near"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
+  <div
+    className="c-TransactionRow-keHKEY mx-0 row"
   >
     <div
-      className="c-TransactionRow-keHKEY mx-0 row"
+      className="pr-0 col-md-auto col-1"
     >
-      <div
-        className="pr-0 col-md-auto col-1"
-      >
-        <img
-          className="c-AccountIcon-exgREZ"
-          src="/static/images/icon-t-acct.svg"
-        />
-      </div>
-      <div
-        className="c-TransactionRowTitle-bvTgKA pt-1 col-md-7 col-11"
-      >
-        b7df2090560a225dc4934aed43db03a6c674c2d4.lockup.near
-      </div>
-      <div
-        className="c-TransactionRowTransactionId-lbSlCc ml-auto pt-1 text-right col-md-3 col-5"
+      <img
+        className="c-AccountIcon-exgREZ"
+        src="/static/images/icon-t-acct.svg"
       />
     </div>
-  </a>
-</span>
+    <div
+      className="c-TransactionRowTitle-bvTgKA pt-1 col-md-7 col-11"
+    >
+      b7df2090560a225dc4934aed43db03a6c674c2d4.lockup.near
+    </div>
+    <div
+      className="c-TransactionRowTransactionId-lbSlCc ml-auto pt-1 text-right col-md-3 col-5"
+    />
+  </div>
+</a>
 `;
 
 exports[`<AccountRow /> renders with short name 1`] = `
-<span
+<a
+  className="c-Anchor-hIXuvg"
+  href="/accounts/account"
   onClick={[Function]}
+  onMouseEnter={[Function]}
 >
-  <a
-    className="c-LinkWrapper-cIdiJW"
-    href="/accounts/account"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
+  <div
+    className="c-TransactionRow-keHKEY mx-0 row"
   >
     <div
-      className="c-TransactionRow-keHKEY mx-0 row"
+      className="pr-0 col-md-auto col-1"
     >
-      <div
-        className="pr-0 col-md-auto col-1"
-      >
-        <img
-          className="c-AccountIcon-exgREZ"
-          src="/static/images/icon-t-acct.svg"
-        />
-      </div>
-      <div
-        className="c-TransactionRowTitle-bvTgKA pt-1 col-md-7 col-11"
-      >
-        account
-      </div>
-      <div
-        className="c-TransactionRowTransactionId-lbSlCc ml-auto pt-1 text-right col-md-3 col-5"
+      <img
+        className="c-AccountIcon-exgREZ"
+        src="/static/images/icon-t-acct.svg"
       />
     </div>
-  </a>
-</span>
+    <div
+      className="c-TransactionRowTitle-bvTgKA pt-1 col-md-7 col-11"
+    >
+      account
+    </div>
+    <div
+      className="c-TransactionRowTransactionId-lbSlCc ml-auto pt-1 text-right col-md-3 col-5"
+    />
+  </div>
+</a>
 `;

--- a/frontend/src/components/beta/accounts/AccountFungibleTokenHistory.tsx
+++ b/frontend/src/components/beta/accounts/AccountFungibleTokenHistory.tsx
@@ -63,18 +63,6 @@ const TableElement = styled("td", {
   paddingRight: 12,
 });
 
-const Link = styled(LinkWrapper, {
-  cursor: "pointer",
-
-  variants: {
-    disabled: {
-      true: {
-        cursor: "inherit",
-      },
-    },
-  },
-});
-
 type ItemProps = {
   item: AccountFungibleTokenHistoryElement;
   balance: string;
@@ -87,17 +75,15 @@ const AccountFungibleTokenHistoryElementView: React.FC<ItemProps> = React.memo(
     const format = useDateFormat();
     return (
       <TableRow>
-        <Link
+        <LinkWrapper
           href={
             item.counterparty
               ? buildAccountUrl({
                   accountId: item.counterparty,
                   tab: "fungible-tokens",
                 })
-              : ""
+              : undefined
           }
-          shallow
-          disabled={!item.counterparty}
         >
           <TableElement>
             {item.counterparty
@@ -106,7 +92,7 @@ const AccountFungibleTokenHistoryElementView: React.FC<ItemProps> = React.memo(
               ? "MINT"
               : "BURN"}
           </TableElement>
-        </Link>
+        </LinkWrapper>
         <TableElement>
           <TokenAmount
             token={{
@@ -120,12 +106,11 @@ const AccountFungibleTokenHistoryElementView: React.FC<ItemProps> = React.memo(
         <TableElement>
           <TokenAmount token={{ ...token, balance }} noSymbol />
         </TableElement>
-        <Link
+        <LinkWrapper
           href={`/transactions/${item.transactionHash}#${item.receiptId}`}
-          shallow
         >
           <TableElement>{shortenString(item.receiptId)}</TableElement>
-        </Link>
+        </LinkWrapper>
         <TableElement>
           {format(item.timestamp, t("common.date_time.date_format"))}
           <CopyToClipboard

--- a/frontend/src/components/beta/accounts/AccountFungibleTokens.tsx
+++ b/frontend/src/components/beta/accounts/AccountFungibleTokens.tsx
@@ -31,13 +31,7 @@ const Tokens = styled("div", {
   flexDirection: "column",
 });
 
-const TokenLink = styled(LinkWrapper, {
-  "& + &": {
-    marginTop: 12,
-  },
-});
-
-const Token = styled("div", {
+const Token = styled(LinkWrapper, {
   cursor: "pointer",
   display: "flex",
   justifyContent: "space-between",
@@ -61,6 +55,10 @@ const Token = styled("div", {
         border: "1px solid #1E93FF",
       },
     },
+  },
+
+  "& + &": {
+    marginTop: 12,
   },
 });
 
@@ -104,34 +102,32 @@ type ItemProps = {
 
 const AccountFungibleTokenView: React.FC<ItemProps> = React.memo(
   ({ token, options, selected }) => (
-    <TokenLink
+    <Token
+      selected={selected}
       href={buildAccountUrl({ ...options, token: token.authorAccountId })}
-      shallow
     >
-      <Token selected={selected}>
-        <TokenHeader>
-          <TokenLogo>
-            {token.icon ? (
-              <Image src={token.icon} layout="fill" />
-            ) : (
-              <TokenEmptyLogo />
-            )}
-          </TokenLogo>
-          {shortenString(token.name).length === token.name.length ? (
-            <TokenName>{token.name}</TokenName>
+      <TokenHeader>
+        <TokenLogo>
+          {token.icon ? (
+            <Image src={token.icon} layout="fill" />
           ) : (
-            <OverlayTrigger
-              overlay={<Tooltip id="token-name">{token.name}</Tooltip>}
-            >
-              <TokenName>{shortenString(token.name)}</TokenName>
-            </OverlayTrigger>
+            <TokenEmptyLogo />
           )}
-        </TokenHeader>
-        <TokenAmountWrapper>
-          <TokenAmount token={token} />
-        </TokenAmountWrapper>
-      </Token>
-    </TokenLink>
+        </TokenLogo>
+        {shortenString(token.name).length === token.name.length ? (
+          <TokenName>{token.name}</TokenName>
+        ) : (
+          <OverlayTrigger
+            overlay={<Tooltip id="token-name">{token.name}</Tooltip>}
+          >
+            <TokenName>{shortenString(token.name)}</TokenName>
+          </OverlayTrigger>
+        )}
+      </TokenHeader>
+      <TokenAmountWrapper>
+        <TokenAmount token={token} />
+      </TokenAmountWrapper>
+    </Token>
   )
 );
 

--- a/frontend/src/components/beta/common/AccountLink.tsx
+++ b/frontend/src/components/beta/common/AccountLink.tsx
@@ -4,7 +4,7 @@ import Link from "@explorer/frontend/components/utils/Link";
 import { shortenString } from "@explorer/frontend/libraries/formatting";
 import { styled } from "@explorer/frontend/libraries/styles";
 
-const AccountLinkWrapper = styled("a", {
+const AccountLinkWrapper = styled(Link, {
   whiteSpace: "nowrap",
 });
 
@@ -13,9 +13,9 @@ export interface Props {
 }
 
 const AccountLink: React.FC<Props> = React.memo(({ accountId }) => (
-  <Link href={`/accounts/${accountId}`} passHref>
-    <AccountLinkWrapper>{shortenString(accountId)}</AccountLinkWrapper>
-  </Link>
+  <AccountLinkWrapper href={`/accounts/${accountId}`}>
+    {shortenString(accountId)}
+  </AccountLinkWrapper>
 ));
 
 export default AccountLink;

--- a/frontend/src/components/beta/common/BlockLink.tsx
+++ b/frontend/src/components/beta/common/BlockLink.tsx
@@ -8,15 +8,12 @@ export interface Props {
   blockHeight: number;
 }
 
-const LinkWrapper = styled("a", {
+const LinkWrapper = styled(Link, {
   whiteSpace: "nowrap",
-  cursor: "pointer",
 });
 
 const BlockLink: React.FC<Props> = React.memo(({ blockHash, blockHeight }) => (
-  <Link href="/blocks/[hash]" as={`/blocks/${blockHash}`}>
-    <LinkWrapper>{`#${blockHeight}`}</LinkWrapper>
-  </Link>
+  <LinkWrapper href={`/blocks/${blockHash}`}>{`#${blockHeight}`}</LinkWrapper>
 ));
 
 export default BlockLink;

--- a/frontend/src/components/beta/common/Tabs.tsx
+++ b/frontend/src/components/beta/common/Tabs.tsx
@@ -113,13 +113,7 @@ export const Tabs = React.memo(<T extends string>(props: Props<T>) => {
               ref={(element) => (labelsRecordRef.current[id] = element)}
               disabled={Boolean(disabled)}
             >
-              {href ? (
-                <LinkWrapper href={href} shallow>
-                  {label}
-                </LinkWrapper>
-              ) : (
-                label
-              )}
+              {href ? <LinkWrapper href={href}>{label}</LinkWrapper> : label}
             </TabHeader>
           );
         })}

--- a/frontend/src/components/beta/common/TransactionLink.tsx
+++ b/frontend/src/components/beta/common/TransactionLink.tsx
@@ -5,7 +5,7 @@ import Link from "@explorer/frontend/components/utils/Link";
 import { shortenString } from "@explorer/frontend/libraries/formatting";
 import { styled } from "@explorer/frontend/libraries/styles";
 
-const TransactionLinkWrapper = styled("a", {
+const TransactionLinkWrapper = styled(Link, {
   whiteSpace: "nowrap",
 });
 
@@ -15,9 +15,9 @@ export interface Props {
 
 const TransactionLink: React.FC<Props> = React.memo(({ hash }) => (
   <>
-    <Link href={`/transactions/${hash}`} passHref>
-      <TransactionLinkWrapper>{shortenString(hash)}</TransactionLinkWrapper>
-    </Link>
+    <TransactionLinkWrapper href={`/transactions/${hash}`}>
+      {shortenString(hash)}
+    </TransactionLinkWrapper>
     <CopyToClipboard
       text={hash}
       css={{

--- a/frontend/src/components/blocks/BlocksRow.tsx
+++ b/frontend/src/components/blocks/BlocksRow.tsx
@@ -49,10 +49,6 @@ const TransactionRowTimerStatus = styled("span", {
   fontWeight: 500,
 });
 
-const LinkWrapper = styled("a", {
-  textDecoration: "none",
-});
-
 const BlockIcon = styled("img", {
   width: 20,
 });
@@ -69,52 +65,50 @@ const BlocksRow: React.FC<Props> = React.memo(({ block }) => {
   const { t } = useTranslation();
   const latestBlockSub = useSubscription(["latestBlock"]);
   return (
-    <Link href={`/blocks/${block.hash}`} passHref>
-      <LinkWrapper>
-        <TransactionRow className="mx-0">
-          <Col md="auto" xs="1" className="pr-0" />
-          <Col md="auto" xs="1" className="pr-0">
-            <BlockIcon src="/static/images/icon-m-block.svg" />
-          </Col>
-          <Col md="7" xs="6">
-            <Row>
-              <TransactionRowTitle>#{block.height}</TransactionRowTitle>
-            </Row>
-            <Row>
-              <TransactionRowText>
-                <Row>
-                  <Col md="auto">
-                    <TransactionIcon src="/static/images/icon-m-transaction.svg" />
-                    {` ${block.transactionsCount}`}
-                  </Col>
-                </Row>
-              </TransactionRowText>
-            </Row>
-          </Col>
-          <Col md="3" xs="4" className="ml-auto text-right">
-            <Row>
-              <TransactionRowTransactionId>
-                {block.hash !== undefined
-                  ? `${block.hash.substring(0, 7)}...`
-                  : null}
-              </TransactionRowTransactionId>
-            </Row>
-            <Row>
-              <TransactionRowTimer>
-                <TransactionRowTimerStatus>
-                  {latestBlockSub.status !== "success"
-                    ? t("common.blocks.status.checking_finality")
-                    : block.timestamp < latestBlockSub.data.timestamp
-                    ? t("common.blocks.status.finalized")
-                    : t("common.blocks.status.finalizing")}
-                </TransactionRowTimerStatus>
-                &nbsp;&nbsp;
-                <Timer time={block.timestamp} />
-              </TransactionRowTimer>
-            </Row>
-          </Col>
-        </TransactionRow>
-      </LinkWrapper>
+    <Link href={`/blocks/${block.hash}`}>
+      <TransactionRow className="mx-0">
+        <Col md="auto" xs="1" className="pr-0" />
+        <Col md="auto" xs="1" className="pr-0">
+          <BlockIcon src="/static/images/icon-m-block.svg" />
+        </Col>
+        <Col md="7" xs="6">
+          <Row>
+            <TransactionRowTitle>#{block.height}</TransactionRowTitle>
+          </Row>
+          <Row>
+            <TransactionRowText>
+              <Row>
+                <Col md="auto">
+                  <TransactionIcon src="/static/images/icon-m-transaction.svg" />
+                  {` ${block.transactionsCount}`}
+                </Col>
+              </Row>
+            </TransactionRowText>
+          </Row>
+        </Col>
+        <Col md="3" xs="4" className="ml-auto text-right">
+          <Row>
+            <TransactionRowTransactionId>
+              {block.hash !== undefined
+                ? `${block.hash.substring(0, 7)}...`
+                : null}
+            </TransactionRowTransactionId>
+          </Row>
+          <Row>
+            <TransactionRowTimer>
+              <TransactionRowTimerStatus>
+                {latestBlockSub.status !== "success"
+                  ? t("common.blocks.status.checking_finality")
+                  : block.timestamp < latestBlockSub.data.timestamp
+                  ? t("common.blocks.status.finalized")
+                  : t("common.blocks.status.finalizing")}
+              </TransactionRowTimerStatus>
+              &nbsp;&nbsp;
+              <Timer time={block.timestamp} />
+            </TransactionRowTimer>
+          </Row>
+        </Col>
+      </TransactionRow>
     </Link>
   );
 });

--- a/frontend/src/components/blocks/__tests__/__snapshots__/BlockDetails.test.tsx.snap
+++ b/frontend/src/components/blocks/__tests__/__snapshots__/BlockDetails.test.tsx.snap
@@ -140,18 +140,14 @@ exports[`<BlockDetails /> renders 1`] = `
               <div
                 className="c-CardCellText-eLcwWo ml-auto align-self-center col-md-12 col-auto"
               >
-                <span
+                <a
+                  className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                  href="/accounts/near.near"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
-                  <a
-                    className="c-AccountLinkWrapper-dbzzBd"
-                    href="/accounts/near.near"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                  >
-                    near.near
-                  </a>
-                </span>
+                  near.near
+                </a>
               </div>
             </div>
           </div>
@@ -374,17 +370,14 @@ exports[`<BlockDetails /> renders 1`] = `
               <div
                 className="c-CardCellText-eLcwWo ml-auto align-self-center col-md-12 col-auto"
               >
-                <span
+                <a
+                  className="c-Anchor-hIXuvg"
+                  href="/blocks/EVvWW1S9BFaEjY1JBNSdstb7Zjghjlyguiygfhgu"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
-                  <a
-                    href="/blocks/EVvWW1S9BFaEjY1JBNSdstb7Zjghjlyguiygfhgu"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                  >
-                    EVvWW1S9BFaEjY1JBNSdstb7Zjghjlyguiygfhgu
-                  </a>
-                </span>
+                  EVvWW1S9BFaEjY1JBNSdstb7Zjghjlyguiygfhgu
+                </a>
               </div>
             </div>
           </div>

--- a/frontend/src/components/blocks/__tests__/__snapshots__/BlocksRow.test.tsx.snap
+++ b/frontend/src/components/blocks/__tests__/__snapshots__/BlocksRow.test.tsx.snap
@@ -1,95 +1,91 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<BlocksRow /> renders 1`] = `
-<span
+<a
+  className="c-Anchor-hIXuvg"
+  href="/blocks/EVvWW1S9BFaEjY1JBNSdstb7ZTtTFjQ6cygkbw1KY4tL"
   onClick={[Function]}
+  onMouseEnter={[Function]}
 >
-  <a
-    className="c-LinkWrapper-cIdiJW"
-    href="/blocks/EVvWW1S9BFaEjY1JBNSdstb7ZTtTFjQ6cygkbw1KY4tL"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
+  <div
+    className="c-TransactionRow-keHKEY mx-0 row"
   >
     <div
-      className="c-TransactionRow-keHKEY mx-0 row"
+      className="pr-0 col-md-auto col-1"
+    />
+    <div
+      className="pr-0 col-md-auto col-1"
+    >
+      <img
+        className="c-BlockIcon-dPulhb"
+        src="/static/images/icon-m-block.svg"
+      />
+    </div>
+    <div
+      className="col-md-7 col-6"
     >
       <div
-        className="pr-0 col-md-auto col-1"
-      />
-      <div
-        className="pr-0 col-md-auto col-1"
+        className="row"
       >
-        <img
-          className="c-BlockIcon-dPulhb"
-          src="/static/images/icon-m-block.svg"
-        />
+        <div
+          className="c-TransactionRowTitle-bvTgKA col"
+        >
+          #
+          12345
+        </div>
       </div>
       <div
-        className="col-md-7 col-6"
+        className="row"
       >
         <div
-          className="row"
+          className="c-TransactionRowText-kkbyDv col"
         >
           <div
-            className="c-TransactionRowTitle-bvTgKA col"
-          >
-            #
-            12345
-          </div>
-        </div>
-        <div
-          className="row"
-        >
-          <div
-            className="c-TransactionRowText-kkbyDv col"
+            className="row"
           >
             <div
-              className="row"
+              className="col-md-auto"
             >
-              <div
-                className="col-md-auto"
-              >
-                <img
-                  className="c-TransactionIcon-hDGfVG"
-                  src="/static/images/icon-m-transaction.svg"
-                />
-                 3
-              </div>
+              <img
+                className="c-TransactionIcon-hDGfVG"
+                src="/static/images/icon-m-transaction.svg"
+              />
+               3
             </div>
           </div>
         </div>
       </div>
+    </div>
+    <div
+      className="ml-auto text-right col-md-3 col-4"
+    >
       <div
-        className="ml-auto text-right col-md-3 col-4"
+        className="row"
       >
         <div
-          className="row"
+          className="c-TransactionRowTransactionId-lbSlCc col"
         >
-          <div
-            className="c-TransactionRowTransactionId-lbSlCc col"
-          >
-            EVvWW1S...
-          </div>
+          EVvWW1S...
         </div>
+      </div>
+      <div
+        className="row"
+      >
         <div
-          className="row"
+          className="c-TransactionRowTimer-iiZTaa col"
         >
-          <div
-            className="c-TransactionRowTimer-iiZTaa col"
+          <span
+            className="c-TransactionRowTimerStatus-cJbzxd"
           >
-            <span
-              className="c-TransactionRowTimerStatus-cJbzxd"
-            >
-              common.blocks.status.checking_finality
-            </span>
-              
-            <span>
-              0s
-            </span>
-          </div>
+            common.blocks.status.checking_finality
+          </span>
+            
+          <span>
+            0s
+          </span>
         </div>
       </div>
     </div>
-  </a>
-</span>
+  </div>
+</a>
 `;

--- a/frontend/src/components/dashboard/DashboardBlock.tsx
+++ b/frontend/src/components/dashboard/DashboardBlock.tsx
@@ -32,8 +32,8 @@ const DashboardBlock: React.FC = React.memo(() => {
       iconPath="/static/images/icon-blocks.svg"
       title={t("common.blocks.blocks")}
       headerRight={
-        <Link href="/blocks">
-          <a>{t("button.view_all")}</a>
+        <Link href="/blocks" css={{ color: "#007bff" }}>
+          {t("button.view_all")}
         </Link>
       }
     >

--- a/frontend/src/components/dashboard/DashboardNode.tsx
+++ b/frontend/src/components/dashboard/DashboardNode.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "next-i18next";
 import { Col, Row } from "react-bootstrap";
 
 import DashboardCard from "@explorer/frontend/components/utils/DashboardCard";
+import LinkWrapper from "@explorer/frontend/components/utils/Link";
 import LongCardCell from "@explorer/frontend/components/utils/LongCardCell";
 import Term from "@explorer/frontend/components/utils/Term";
 import { useSubscription } from "@explorer/frontend/hooks/use-subscription";
@@ -58,11 +59,12 @@ const DashboardNode: React.FC = React.memo(() => {
               />
             }
             subscription={networkStatsSub}
-            href="/nodes/validators"
             textCss={{ color: "#00c08b" }}
           >
             {(networkStats) => (
-              <>{networkStats.currentValidatorsCount.toLocaleString()}</>
+              <LinkWrapper href="/nodes/validators">
+                {networkStats.currentValidatorsCount.toLocaleString()}
+              </LinkWrapper>
             )}
           </LongCardCell>
         </Col>

--- a/frontend/src/components/dashboard/DashboardTransaction.tsx
+++ b/frontend/src/components/dashboard/DashboardTransaction.tsx
@@ -31,8 +31,8 @@ const DashboardTransaction: React.FC = React.memo(() => {
       iconPath="/static/images/icon-transactions.svg"
       title={t("common.transactions.transactions")}
       headerRight={
-        <Link href="/transactions">
-          <a>{t("button.view_all")}</a>
+        <Link href="/transactions" css={{ color: "#007bff" }}>
+          {t("button.view_all")}
         </Link>
       }
     >

--- a/frontend/src/components/nodes/NodeNav.tsx
+++ b/frontend/src/components/nodes/NodeNav.tsx
@@ -32,7 +32,7 @@ const NodeAmountLabel = styled(Badge, {
   color: "#ffffff",
 });
 
-const NodeLink = styled("a", {
+const NodeLink = styled(Link, {
   color: "inherit",
   "&:hover": {
     color: "inherit",
@@ -46,14 +46,12 @@ const NodeNav: React.FC = React.memo(() => {
   return (
     <Row>
       <NodeSelector xs="auto" selected className="pt-2 pb-2">
-        <Link href="/nodes/validators" passHref>
-          <NodeLink>
-            {t("component.nodes.NodeNav.validating")}{" "}
-            <NodeAmountLabel pill>
-              {networkStats ? networkStats.currentValidatorsCount : "--"}
-            </NodeAmountLabel>
-          </NodeLink>
-        </Link>
+        <NodeLink href="/nodes/validators">
+          {t("component.nodes.NodeNav.validating")}{" "}
+          <NodeAmountLabel pill>
+            {networkStats ? networkStats.currentValidatorsCount : "--"}
+          </NodeAmountLabel>
+        </NodeLink>
       </NodeSelector>
     </Row>
   );

--- a/frontend/src/components/transactions/__tests__/__snapshots__/ActionMessage.test.tsx.snap
+++ b/frontend/src/components/transactions/__tests__/__snapshots__/ActionMessage.test.tsx.snap
@@ -3,18 +3,14 @@
 exports[`<ActionMessage /> renders AddKey with permission FullAccess 1`] = `
 Array [
   "component.transactions.ActionMessage.AddKey.new_key_added",
-  <span
+  <a
+    className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+    href="/accounts/receiver.test"
     onClick={[Function]}
+    onMouseEnter={[Function]}
   >
-    <a
-      className="c-AccountLinkWrapper-dbzzBd"
-      href="/accounts/receiver.test"
-      onClick={[Function]}
-      onMouseEnter={[Function]}
-    >
-      receiver.test
-    </a>
-  </span>,
+    receiver.test
+  </a>,
   ": ed25519:BgXFiJS...",
   <p>
     component.transactions.ActionMessage.AddKey.fullAccessPermission
@@ -25,18 +21,14 @@ Array [
 exports[`<ActionMessage /> renders AddKey with permission function call to call any method 1`] = `
 Array [
   "component.transactions.ActionMessage.AddKey.access_key_added_for_contract",
-  <span
+  <a
+    className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+    href="/accounts/stake"
     onClick={[Function]}
+    onMouseEnter={[Function]}
   >
-    <a
-      className="c-AccountLinkWrapper-dbzzBd"
-      href="/accounts/stake"
-      onClick={[Function]}
-      onMouseEnter={[Function]}
-    >
-      stake
-    </a>
-  </span>,
+    stake
+  </a>,
   ": ed25519:BgXFiJS...",
   <p>
     component.transactions.ActionMessage.AddKey.with_permission_call_method_and_nounce
@@ -47,18 +39,14 @@ Array [
 exports[`<ActionMessage /> renders AddKey with permission function call to call specific methods 1`] = `
 Array [
   "component.transactions.ActionMessage.AddKey.access_key_added_for_contract",
-  <span
+  <a
+    className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+    href="/accounts/stake"
     onClick={[Function]}
+    onMouseEnter={[Function]}
   >
-    <a
-      className="c-AccountLinkWrapper-dbzzBd"
-      href="/accounts/stake"
-      onClick={[Function]}
-      onMouseEnter={[Function]}
-    >
-      stake
-    </a>
-  </span>,
+    stake
+  </a>,
   ": ed25519:BgXFiJS...",
   <p>
     component.transactions.ActionMessage.AddKey.with_permission_call_method_and_nounce
@@ -69,49 +57,37 @@ Array [
 exports[`<ActionMessage /> renders CreateAccount 1`] = `
 Array [
   "component.transactions.ActionMessage.CreateAccount.new_account_created",
-  <span
+  <a
+    className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+    href="/accounts/receiver.test"
     onClick={[Function]}
+    onMouseEnter={[Function]}
   >
-    <a
-      className="c-AccountLinkWrapper-dbzzBd"
-      href="/accounts/receiver.test"
-      onClick={[Function]}
-      onMouseEnter={[Function]}
-    >
-      receiver.test
-    </a>
-  </span>,
+    receiver.test
+  </a>,
 ]
 `;
 
 exports[`<ActionMessage /> renders DeleteAccount 1`] = `
 Array [
   "component.transactions.ActionMessage.DeleteAccount.delete_account",
-  <span
+  <a
+    className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+    href="/accounts/receiver.test"
     onClick={[Function]}
+    onMouseEnter={[Function]}
   >
-    <a
-      className="c-AccountLinkWrapper-dbzzBd"
-      href="/accounts/receiver.test"
-      onClick={[Function]}
-      onMouseEnter={[Function]}
-    >
-      receiver.test
-    </a>
-  </span>,
+    receiver.test
+  </a>,
   "component.transactions.ActionMessage.DeleteAccount.and_transfer_fund_to",
-  <span
+  <a
+    className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+    href="/accounts/near"
     onClick={[Function]}
+    onMouseEnter={[Function]}
   >
-    <a
-      className="c-AccountLinkWrapper-dbzzBd"
-      href="/accounts/near"
-      onClick={[Function]}
-      onMouseEnter={[Function]}
-    >
-      near
-    </a>
-  </span>,
+    near
+  </a>,
 ]
 `;
 
@@ -120,54 +96,42 @@ exports[`<ActionMessage /> renders DeleteKey 1`] = `"component.transactions.Acti
 exports[`<ActionMessage /> renders DeployContract 1`] = `
 Array [
   "component.transactions.ActionMessage.DeployContract.contract_deployed",
-  <span
+  <a
+    className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+    href="/accounts/receiver.test"
     onClick={[Function]}
+    onMouseEnter={[Function]}
   >
-    <a
-      className="c-AccountLinkWrapper-dbzzBd"
-      href="/accounts/receiver.test"
-      onClick={[Function]}
-      onMouseEnter={[Function]}
-    >
-      receiver.test
-    </a>
-  </span>,
+    receiver.test
+  </a>,
 ]
 `;
 
 exports[`<ActionMessage /> renders FunctionCall 1`] = `
 Array [
   "component.transactions.ActionMessage.FunctionCall.called_method",
-  <span
+  <a
+    className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+    href="/accounts/receiver.test"
     onClick={[Function]}
+    onMouseEnter={[Function]}
   >
-    <a
-      className="c-AccountLinkWrapper-dbzzBd"
-      href="/accounts/receiver.test"
-      onClick={[Function]}
-      onMouseEnter={[Function]}
-    >
-      receiver.test
-    </a>
-  </span>,
+    receiver.test
+  </a>,
 ]
 `;
 
 exports[`<ActionMessage /> renders FunctionCall with details 1`] = `
 Array [
   "component.transactions.ActionMessage.FunctionCall.called_method",
-  <span
+  <a
+    className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+    href="/accounts/receiver2.test"
     onClick={[Function]}
+    onMouseEnter={[Function]}
   >
-    <a
-      className="c-AccountLinkWrapper-dbzzBd"
-      href="/accounts/receiver2.test"
-      onClick={[Function]}
-      onMouseEnter={[Function]}
-    >
-      receiver2.test
-    </a>
-  </span>,
+    receiver2.test
+  </a>,
   <dl>
     <dt>
       component.transactions.ActionMessage.FunctionCall.arguments
@@ -230,17 +194,13 @@ Array [
     Ⓝ
   </span>,
   "component.transactions.ActionMessage.Transfer.to",
-  <span
+  <a
+    className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+    href="/accounts/receiver.test"
     onClick={[Function]}
+    onMouseEnter={[Function]}
   >
-    <a
-      className="c-AccountLinkWrapper-dbzzBd"
-      href="/accounts/receiver.test"
-      onClick={[Function]}
-      onMouseEnter={[Function]}
-    >
-      receiver.test
-    </a>
-  </span>,
+    receiver.test
+  </a>,
 ]
 `;

--- a/frontend/src/components/transactions/__tests__/__snapshots__/ActionRow.test.tsx.snap
+++ b/frontend/src/components/transactions/__tests__/__snapshots__/ActionRow.test.tsx.snap
@@ -29,18 +29,14 @@ exports[`<ActionRow /> renders compact for receipt 1`] = `
             className="c-ActionRowTitle-cYlxUq col"
           >
             component.transactions.ActionMessage.FunctionCall.called_method
-            <span
+            <a
+              className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+              href="/accounts/5ce78003b590264df3f259983f3c3e0917fc10ea.lockup.near"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
-              <a
-                className="c-AccountLinkWrapper-dbzzBd"
-                href="/accounts/5ce78003b590264df3f259983f3c3e0917fc10ea.lockup.near"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                5ce78…ockup.near
-              </a>
-            </span>
+              5ce78…ockup.near
+            </a>
           </div>
         </div>
       </div>
@@ -78,18 +74,14 @@ exports[`<ActionRow /> renders compact for transaction 1`] = `
             className="c-ActionRowTitle-cYlxUq col"
           >
             component.transactions.ActionMessage.AddKey.new_key_added
-            <span
+            <a
+              className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+              href="/accounts/receiver.test"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
-              <a
-                className="c-AccountLinkWrapper-dbzzBd"
-                href="/accounts/receiver.test"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                receiver.test
-              </a>
-            </span>
+              receiver.test
+            </a>
             : ed25519:8LXEySy...
             <p>
               component.transactions.ActionMessage.AddKey.fullAccessPermission
@@ -104,18 +96,14 @@ exports[`<ActionRow /> renders compact for transaction 1`] = `
           >
             component.transactions.ActionRowBlock.by
              
-            <span
+            <a
+              className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+              href="/accounts/signer.test"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
-              <a
-                className="c-AccountLinkWrapper-dbzzBd"
-                href="/accounts/signer.test"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                signer.test
-              </a>
-            </span>
+              signer.test
+            </a>
           </div>
         </div>
       </div>
@@ -128,17 +116,14 @@ exports[`<ActionRow /> renders compact for transaction 1`] = `
           <div
             className="c-ActionRowTransaction-lbSlCc col"
           >
-            <span
+            <a
+              className="c-Anchor-hIXuvg"
+              href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
-              <a
-                href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                BvJeW6g...
-              </a>
-            </span>
+              BvJeW6g...
+            </a>
           </div>
         </div>
         <div
@@ -194,18 +179,14 @@ exports[`<ActionRow /> renders functioncall with detail 1`] = `
             className="c-ActionRowTitle-cYlxUq col"
           >
             component.transactions.ActionMessage.FunctionCall.called_method
-            <span
+            <a
+              className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+              href="/accounts/receiver.test"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
-              <a
-                className="c-AccountLinkWrapper-dbzzBd"
-                href="/accounts/receiver.test"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                receiver.test
-              </a>
-            </span>
+              receiver.test
+            </a>
             <dl>
               <dt>
                 component.transactions.ActionMessage.FunctionCall.arguments
@@ -243,18 +224,14 @@ exports[`<ActionRow /> renders functioncall with detail 1`] = `
           >
             component.transactions.ActionRowBlock.by
              
-            <span
+            <a
+              className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+              href="/accounts/signer.test"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
-              <a
-                className="c-AccountLinkWrapper-dbzzBd"
-                href="/accounts/signer.test"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                signer.test
-              </a>
-            </span>
+              signer.test
+            </a>
           </div>
         </div>
       </div>
@@ -321,18 +298,14 @@ exports[`<ActionRow /> renders sparsely ActionRow for receipt 1`] = `
             className="c-ActionRowTitle-cYlxUq col"
           >
             component.transactions.ActionMessage.FunctionCall.called_method
-            <span
+            <a
+              className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+              href="/accounts/app.nearcrowd.near"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
-              <a
-                className="c-AccountLinkWrapper-dbzzBd"
-                href="/accounts/app.nearcrowd.near"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                app.nearcrowd.near
-              </a>
-            </span>
+              app.nearcrowd.near
+            </a>
           </div>
         </div>
         <div
@@ -343,18 +316,14 @@ exports[`<ActionRow /> renders sparsely ActionRow for receipt 1`] = `
           >
             component.transactions.ActionRowBlock.by
              
-            <span
+            <a
+              className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+              href="/accounts/elonmusk_tesla.near"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
-              <a
-                className="c-AccountLinkWrapper-dbzzBd"
-                href="/accounts/elonmusk_tesla.near"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                elonmusk_tesla.near
-              </a>
-            </span>
+              elonmusk_tesla.near
+            </a>
           </div>
         </div>
       </div>
@@ -367,17 +336,14 @@ exports[`<ActionRow /> renders sparsely ActionRow for receipt 1`] = `
           <div
             className="c-ActionRowTransaction-lbSlCc col"
           >
-            <span
+            <a
+              className="c-Anchor-hIXuvg"
+              href="/transactions/2WDYbcuRyyRXJvrXkfFej9Vrv3s3GNTxVQAqKFTiEtGh#7uADRkZL3b8HRbCRe3ML6yRyVZ46HHp1pEJKbxewq5Hg"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
-              <a
-                href="/transactions/2WDYbcuRyyRXJvrXkfFej9Vrv3s3GNTxVQAqKFTiEtGh#7uADRkZL3b8HRbCRe3ML6yRyVZ46HHp1pEJKbxewq5Hg"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                7uADRkZ...
-              </a>
-            </span>
+              7uADRkZ...
+            </a>
           </div>
         </div>
         <div
@@ -433,18 +399,14 @@ exports[`<ActionRow /> renders sparsely ActionRow for transaction by default 1`]
             className="c-ActionRowTitle-cYlxUq col"
           >
             component.transactions.ActionMessage.CreateAccount.new_account_created
-            <span
+            <a
+              className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+              href="/accounts/receiver.test"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
-              <a
-                className="c-AccountLinkWrapper-dbzzBd"
-                href="/accounts/receiver.test"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                receiver.test
-              </a>
-            </span>
+              receiver.test
+            </a>
           </div>
         </div>
         <div
@@ -455,18 +417,14 @@ exports[`<ActionRow /> renders sparsely ActionRow for transaction by default 1`]
           >
             component.transactions.ActionRowBlock.by
              
-            <span
+            <a
+              className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+              href="/accounts/signer.test"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
-              <a
-                className="c-AccountLinkWrapper-dbzzBd"
-                href="/accounts/signer.test"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                signer.test
-              </a>
-            </span>
+              signer.test
+            </a>
           </div>
         </div>
       </div>
@@ -479,17 +437,14 @@ exports[`<ActionRow /> renders sparsely ActionRow for transaction by default 1`]
           <div
             className="c-ActionRowTransaction-lbSlCc col"
           >
-            <span
+            <a
+              className="c-Anchor-hIXuvg"
+              href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
-              <a
-                href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                BvJeW6g...
-              </a>
-            </span>
+              BvJeW6g...
+            </a>
           </div>
         </div>
         <div
@@ -545,18 +500,14 @@ exports[`<ActionRow /> renders sparsely ActionRow for transaction with status 1`
             className="c-ActionRowTitle-cYlxUq col"
           >
             component.transactions.ActionMessage.CreateAccount.new_account_created
-            <span
+            <a
+              className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+              href="/accounts/receiver.test"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
-              <a
-                className="c-AccountLinkWrapper-dbzzBd"
-                href="/accounts/receiver.test"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                receiver.test
-              </a>
-            </span>
+              receiver.test
+            </a>
           </div>
         </div>
         <div
@@ -567,18 +518,14 @@ exports[`<ActionRow /> renders sparsely ActionRow for transaction with status 1`
           >
             component.transactions.ActionRowBlock.by
              
-            <span
+            <a
+              className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+              href="/accounts/signer.test"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
-              <a
-                className="c-AccountLinkWrapper-dbzzBd"
-                href="/accounts/signer.test"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                signer.test
-              </a>
-            </span>
+              signer.test
+            </a>
           </div>
         </div>
       </div>
@@ -591,17 +538,14 @@ exports[`<ActionRow /> renders sparsely ActionRow for transaction with status 1`
           <div
             className="c-ActionRowTransaction-lbSlCc col"
           >
-            <span
+            <a
+              className="c-Anchor-hIXuvg"
+              href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
-              <a
-                href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                BvJeW6g...
-              </a>
-            </span>
+              BvJeW6g...
+            </a>
           </div>
         </div>
         <div

--- a/frontend/src/components/transactions/__tests__/__snapshots__/ActionsList.test.tsx.snap
+++ b/frontend/src/components/transactions/__tests__/__snapshots__/ActionsList.test.tsx.snap
@@ -54,18 +54,14 @@ exports[`<ActionsList /> renders compact for Receipts 1`] = `
             className="c-ActionRowTitle-cYlxUq col"
           >
             component.transactions.ActionMessage.FunctionCall.called_method
-            <span
+            <a
+              className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+              href="/accounts/app.nearcrowd.near"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
-              <a
-                className="c-AccountLinkWrapper-dbzzBd"
-                href="/accounts/app.nearcrowd.near"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                app.nearcrowd.near
-              </a>
-            </span>
+              app.nearcrowd.near
+            </a>
           </div>
         </div>
         <div
@@ -76,18 +72,14 @@ exports[`<ActionsList /> renders compact for Receipts 1`] = `
           >
             component.transactions.ActionRowBlock.by
              
-            <span
+            <a
+              className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+              href="/accounts/elonmusk_tesla.near"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
-              <a
-                className="c-AccountLinkWrapper-dbzzBd"
-                href="/accounts/elonmusk_tesla.near"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                elonmusk_tesla.near
-              </a>
-            </span>
+              elonmusk_tesla.near
+            </a>
           </div>
         </div>
       </div>
@@ -100,17 +92,14 @@ exports[`<ActionsList /> renders compact for Receipts 1`] = `
           <div
             className="c-ActionRowTransaction-lbSlCc col"
           >
-            <span
+            <a
+              className="c-Anchor-hIXuvg"
+              href="/transactions/2WDYbcuRyyRXJvrXkfFej9Vrv3s3GNTxVQAqKFTiEtGh#7uADRkZL3b8HRbCRe3ML6yRyVZ46HHp1pEJKbxewq5Hg"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
-              <a
-                href="/transactions/2WDYbcuRyyRXJvrXkfFej9Vrv3s3GNTxVQAqKFTiEtGh#7uADRkZL3b8HRbCRe3ML6yRyVZ46HHp1pEJKbxewq5Hg"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                7uADRkZ...
-              </a>
-            </span>
+              7uADRkZ...
+            </a>
           </div>
         </div>
         <div
@@ -167,18 +156,14 @@ Array [
               className="c-ActionRowTitle-cYlxUq col"
             >
               component.transactions.ActionMessage.CreateAccount.new_account_created
-              <span
+              <a
+                className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                href="/accounts/receiver.test"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
-                <a
-                  className="c-AccountLinkWrapper-dbzzBd"
-                  href="/accounts/receiver.test"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  receiver.test
-                </a>
-              </span>
+                receiver.test
+              </a>
             </div>
           </div>
           <div
@@ -189,18 +174,14 @@ Array [
             >
               component.transactions.ActionRowBlock.by
                
-              <span
+              <a
+                className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                href="/accounts/signer.test"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
-                <a
-                  className="c-AccountLinkWrapper-dbzzBd"
-                  href="/accounts/signer.test"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  signer.test
-                </a>
-              </span>
+                signer.test
+              </a>
             </div>
           </div>
         </div>
@@ -213,17 +194,14 @@ Array [
             <div
               className="c-ActionRowTransaction-lbSlCc col"
             >
-              <span
+              <a
+                className="c-Anchor-hIXuvg"
+                href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
-                <a
-                  href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  BvJeW6g...
-                </a>
-              </span>
+                BvJeW6g...
+              </a>
             </div>
           </div>
           <div
@@ -276,18 +254,14 @@ Array [
               className="c-ActionRowTitle-cYlxUq col"
             >
               component.transactions.ActionMessage.AddKey.new_key_added
-              <span
+              <a
+                className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                href="/accounts/receiver.test"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
-                <a
-                  className="c-AccountLinkWrapper-dbzzBd"
-                  href="/accounts/receiver.test"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  receiver.test
-                </a>
-              </span>
+                receiver.test
+              </a>
               : ed25519:8LXEySy...
               <p>
                 component.transactions.ActionMessage.AddKey.fullAccessPermission
@@ -302,18 +276,14 @@ Array [
             >
               component.transactions.ActionRowBlock.by
                
-              <span
+              <a
+                className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                href="/accounts/signer.test"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
-                <a
-                  className="c-AccountLinkWrapper-dbzzBd"
-                  href="/accounts/signer.test"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  signer.test
-                </a>
-              </span>
+                signer.test
+              </a>
             </div>
           </div>
         </div>
@@ -326,17 +296,14 @@ Array [
             <div
               className="c-ActionRowTransaction-lbSlCc col"
             >
-              <span
+              <a
+                className="c-Anchor-hIXuvg"
+                href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
-                <a
-                  href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  BvJeW6g...
-                </a>
-              </span>
+                BvJeW6g...
+              </a>
             </div>
           </div>
           <div
@@ -393,18 +360,14 @@ exports[`<ActionsList /> renders functioncall by default 1`] = `
             className="c-ActionRowTitle-cYlxUq col"
           >
             component.transactions.ActionMessage.FunctionCall.called_method
-            <span
+            <a
+              className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+              href="/accounts/receiver2.test"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
-              <a
-                className="c-AccountLinkWrapper-dbzzBd"
-                href="/accounts/receiver2.test"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                receiver2.test
-              </a>
-            </span>
+              receiver2.test
+            </a>
             <dl>
               <dt>
                 component.transactions.ActionMessage.FunctionCall.arguments
@@ -442,18 +405,14 @@ exports[`<ActionsList /> renders functioncall by default 1`] = `
           >
             component.transactions.ActionRowBlock.by
              
-            <span
+            <a
+              className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+              href="/accounts/signer2.test"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
-              <a
-                className="c-AccountLinkWrapper-dbzzBd"
-                href="/accounts/signer2.test"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                signer2.test
-              </a>
-            </span>
+              signer2.test
+            </a>
           </div>
         </div>
       </div>
@@ -466,17 +425,14 @@ exports[`<ActionsList /> renders functioncall by default 1`] = `
           <div
             className="c-ActionRowTransaction-lbSlCc col"
           >
-            <span
+            <a
+              className="c-Anchor-hIXuvg"
+              href="/transactions/222eW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
-              <a
-                href="/transactions/222eW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                222eW6g...
-              </a>
-            </span>
+              222eW6g...
+            </a>
           </div>
         </div>
         <div
@@ -532,18 +488,14 @@ exports[`<ActionsList /> renders sparsely by default for Receipts 1`] = `
             className="c-ActionRowTitle-cYlxUq col"
           >
             component.transactions.ActionMessage.FunctionCall.called_method
-            <span
+            <a
+              className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+              href="/accounts/5ce78003b590264df3f259983f3c3e0917fc10ea.lockup.near"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
-              <a
-                className="c-AccountLinkWrapper-dbzzBd"
-                href="/accounts/5ce78003b590264df3f259983f3c3e0917fc10ea.lockup.near"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                5ce78…ockup.near
-              </a>
-            </span>
+              5ce78…ockup.near
+            </a>
           </div>
         </div>
         <div
@@ -554,18 +506,14 @@ exports[`<ActionsList /> renders sparsely by default for Receipts 1`] = `
           >
             component.transactions.ActionRowBlock.by
              
-            <span
+            <a
+              className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+              href="/accounts/5ce78003b590264df3f259983f3c3e0917fc10ea.lockup.near"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
-              <a
-                className="c-AccountLinkWrapper-dbzzBd"
-                href="/accounts/5ce78003b590264df3f259983f3c3e0917fc10ea.lockup.near"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                5ce78…ockup.near
-              </a>
-            </span>
+              5ce78…ockup.near
+            </a>
           </div>
         </div>
       </div>
@@ -578,17 +526,14 @@ exports[`<ActionsList /> renders sparsely by default for Receipts 1`] = `
           <div
             className="c-ActionRowTransaction-lbSlCc col"
           >
-            <span
+            <a
+              className="c-Anchor-hIXuvg"
+              href="/transactions/hash#BvG4qfnrxVfpqXrSgxxnfdrHYTKFjTcf2LtgEeX5Mzyz"
               onClick={[Function]}
+              onMouseEnter={[Function]}
             >
-              <a
-                href="/transactions/hash#BvG4qfnrxVfpqXrSgxxnfdrHYTKFjTcf2LtgEeX5Mzyz"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-              >
-                BvG4qfn...
-              </a>
-            </span>
+              BvG4qfn...
+            </a>
           </div>
         </div>
         <div
@@ -645,18 +590,14 @@ Array [
               className="c-ActionRowTitle-cYlxUq col"
             >
               component.transactions.ActionMessage.CreateAccount.new_account_created
-              <span
+              <a
+                className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                href="/accounts/receiver.test"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
-                <a
-                  className="c-AccountLinkWrapper-dbzzBd"
-                  href="/accounts/receiver.test"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  receiver.test
-                </a>
-              </span>
+                receiver.test
+              </a>
             </div>
           </div>
           <div
@@ -667,18 +608,14 @@ Array [
             >
               component.transactions.ActionRowBlock.by
                
-              <span
+              <a
+                className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                href="/accounts/signer.test"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
-                <a
-                  className="c-AccountLinkWrapper-dbzzBd"
-                  href="/accounts/signer.test"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  signer.test
-                </a>
-              </span>
+                signer.test
+              </a>
             </div>
           </div>
         </div>
@@ -691,17 +628,14 @@ Array [
             <div
               className="c-ActionRowTransaction-lbSlCc col"
             >
-              <span
+              <a
+                className="c-Anchor-hIXuvg"
+                href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
-                <a
-                  href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  BvJeW6g...
-                </a>
-              </span>
+                BvJeW6g...
+              </a>
             </div>
           </div>
           <div
@@ -754,18 +688,14 @@ Array [
               className="c-ActionRowTitle-cYlxUq col"
             >
               component.transactions.ActionMessage.AddKey.new_key_added
-              <span
+              <a
+                className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                href="/accounts/receiver.test"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
-                <a
-                  className="c-AccountLinkWrapper-dbzzBd"
-                  href="/accounts/receiver.test"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  receiver.test
-                </a>
-              </span>
+                receiver.test
+              </a>
               : ed25519:8LXEySy...
               <p>
                 component.transactions.ActionMessage.AddKey.fullAccessPermission
@@ -780,18 +710,14 @@ Array [
             >
               component.transactions.ActionRowBlock.by
                
-              <span
+              <a
+                className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                href="/accounts/signer.test"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
-                <a
-                  className="c-AccountLinkWrapper-dbzzBd"
-                  href="/accounts/signer.test"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  signer.test
-                </a>
-              </span>
+                signer.test
+              </a>
             </div>
           </div>
         </div>
@@ -804,17 +730,14 @@ Array [
             <div
               className="c-ActionRowTransaction-lbSlCc col"
             >
-              <span
+              <a
+                className="c-Anchor-hIXuvg"
+                href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
-                <a
-                  href="/transactions/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  BvJeW6g...
-                </a>
-              </span>
+                BvJeW6g...
+              </a>
             </div>
           </div>
           <div

--- a/frontend/src/components/transactions/__tests__/__snapshots__/ReceiptRow.test.tsx.snap
+++ b/frontend/src/components/transactions/__tests__/__snapshots__/ReceiptRow.test.tsx.snap
@@ -32,17 +32,14 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
       <div
         className="c-ReceiptRowReceiptHash-cQOeDh c-ReceiptRowReceiptHash-cQOeDh-gkXQBw-truncateLink-true col"
       >
-        <span
+        <a
+          className="c-Anchor-hIXuvg"
+          href="/transactions/T1111111111111111111111111111111111111111111#R1111111111111111111111111111111111111111111"
           onClick={[Function]}
+          onMouseEnter={[Function]}
         >
-          <a
-            href="/transactions/T1111111111111111111111111111111111111111111#R1111111111111111111111111111111111111111111"
-            onClick={[Function]}
-            onMouseEnter={[Function]}
-          >
-            R1111111111111111111111111111111111111111111
-          </a>
-        </span>
+          R1111111111111111111111111111111111111111111
+        </a>
       </div>
     </div>
     <div
@@ -57,17 +54,14 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
       <div
         className="c-ReceiptRowReceiptHash-cQOeDh c-ReceiptRowReceiptHash-cQOeDh-gkXQBw-truncateLink-true col"
       >
-        <span
+        <a
+          className="c-Anchor-hIXuvg"
+          href="/blocks/B111111111111111111111111111111111111111111"
           onClick={[Function]}
+          onMouseEnter={[Function]}
         >
-          <a
-            href="/blocks/B111111111111111111111111111111111111111111"
-            onClick={[Function]}
-            onMouseEnter={[Function]}
-          >
-            B111111111111111111111111111111111111111111
-          </a>
-        </span>
+          B111111111111111111111111111111111111111111
+        </a>
       </div>
     </div>
     <div
@@ -83,18 +77,14 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
         className="c-ReceiptRowReceiptHash-cQOeDh col"
         title="signer.test"
       >
-        <span
+        <a
+          className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+          href="/accounts/signer.test"
           onClick={[Function]}
+          onMouseEnter={[Function]}
         >
-          <a
-            className="c-AccountLinkWrapper-dbzzBd"
-            href="/accounts/signer.test"
-            onClick={[Function]}
-            onMouseEnter={[Function]}
-          >
-            signer.test
-          </a>
-        </span>
+          signer.test
+        </a>
       </div>
     </div>
     <div
@@ -110,18 +100,14 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
         className="c-ReceiptRowReceiptHash-cQOeDh col"
         title="receiver.test"
       >
-        <span
+        <a
+          className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+          href="/accounts/receiver.test"
           onClick={[Function]}
+          onMouseEnter={[Function]}
         >
-          <a
-            className="c-AccountLinkWrapper-dbzzBd"
-            href="/accounts/receiver.test"
-            onClick={[Function]}
-            onMouseEnter={[Function]}
-          >
-            receiver.test
-          </a>
-        </span>
+          receiver.test
+        </a>
       </div>
     </div>
     <div
@@ -197,18 +183,14 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
                     className="c-ActionRowTitle-cYlxUq col"
                   >
                     component.transactions.ActionMessage.FunctionCall.called_method
-                    <span
+                    <a
+                      className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                      href="/accounts/receiver.test"
                       onClick={[Function]}
+                      onMouseEnter={[Function]}
                     >
-                      <a
-                        className="c-AccountLinkWrapper-dbzzBd"
-                        href="/accounts/receiver.test"
-                        onClick={[Function]}
-                        onMouseEnter={[Function]}
-                      >
-                        receiver.test
-                      </a>
-                    </span>
+                      receiver.test
+                    </a>
                     <dl>
                       <dt>
                         component.transactions.ActionMessage.FunctionCall.arguments
@@ -316,17 +298,14 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
               <div
                 className="c-ReceiptRowReceiptHash-cQOeDh c-ReceiptRowReceiptHash-cQOeDh-gkXQBw-truncateLink-true col"
               >
-                <span
+                <a
+                  className="c-Anchor-hIXuvg"
+                  href="/transactions/T1111111111111111111111111111111111111111111#R2222222222222222222222222222222222222222222"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
-                  <a
-                    href="/transactions/T1111111111111111111111111111111111111111111#R2222222222222222222222222222222222222222222"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                  >
-                    R2222222222222222222222222222222222222222222
-                  </a>
-                </span>
+                  R2222222222222222222222222222222222222222222
+                </a>
               </div>
             </div>
             <div
@@ -341,17 +320,14 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
               <div
                 className="c-ReceiptRowReceiptHash-cQOeDh c-ReceiptRowReceiptHash-cQOeDh-gkXQBw-truncateLink-true col"
               >
-                <span
+                <a
+                  className="c-Anchor-hIXuvg"
+                  href="/blocks/B222222222222222222222222222222222222222222"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
-                  <a
-                    href="/blocks/B222222222222222222222222222222222222222222"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                  >
-                    B222222222222222222222222222222222222222222
-                  </a>
-                </span>
+                  B222222222222222222222222222222222222222222
+                </a>
               </div>
             </div>
             <div
@@ -367,18 +343,14 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
                 className="c-ReceiptRowReceiptHash-cQOeDh col"
                 title="system"
               >
-                <span
+                <a
+                  className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                  href="/accounts/system"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
-                  <a
-                    className="c-AccountLinkWrapper-dbzzBd"
-                    href="/accounts/system"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                  >
-                    system
-                  </a>
-                </span>
+                  system
+                </a>
               </div>
             </div>
             <div
@@ -394,18 +366,14 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
                 className="c-ReceiptRowReceiptHash-cQOeDh col"
                 title="receiver.test"
               >
-                <span
+                <a
+                  className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                  href="/accounts/receiver.test"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
-                  <a
-                    className="c-AccountLinkWrapper-dbzzBd"
-                    href="/accounts/receiver.test"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                  >
-                    receiver.test
-                  </a>
-                </span>
+                  receiver.test
+                </a>
               </div>
             </div>
             <div
@@ -492,18 +460,14 @@ exports[`<ReceiptRow /> renders Failure receipt 1`] = `
                               Ⓝ
                             </span>
                             component.transactions.ActionMessage.Transfer.to
-                            <span
+                            <a
+                              className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                              href="/accounts/receiver.test"
                               onClick={[Function]}
+                              onMouseEnter={[Function]}
                             >
-                              <a
-                                className="c-AccountLinkWrapper-dbzzBd"
-                                href="/accounts/receiver.test"
-                                onClick={[Function]}
-                                onMouseEnter={[Function]}
-                              >
-                                receiver.test
-                              </a>
-                            </span>
+                              receiver.test
+                            </a>
                           </div>
                         </div>
                       </div>
@@ -570,17 +534,14 @@ exports[`<ReceiptRow /> renders receipt with many outcome receipts 1`] = `
       <div
         className="c-ReceiptRowReceiptHash-cQOeDh c-ReceiptRowReceiptHash-cQOeDh-gkXQBw-truncateLink-true col"
       >
-        <span
+        <a
+          className="c-Anchor-hIXuvg"
+          href="/transactions/T1111111111111111111111111111111111111111111#R1111111111111111111111111111111111111111111"
           onClick={[Function]}
+          onMouseEnter={[Function]}
         >
-          <a
-            href="/transactions/T1111111111111111111111111111111111111111111#R1111111111111111111111111111111111111111111"
-            onClick={[Function]}
-            onMouseEnter={[Function]}
-          >
-            R1111111111111111111111111111111111111111111
-          </a>
-        </span>
+          R1111111111111111111111111111111111111111111
+        </a>
       </div>
     </div>
     <div
@@ -595,17 +556,14 @@ exports[`<ReceiptRow /> renders receipt with many outcome receipts 1`] = `
       <div
         className="c-ReceiptRowReceiptHash-cQOeDh c-ReceiptRowReceiptHash-cQOeDh-gkXQBw-truncateLink-true col"
       >
-        <span
+        <a
+          className="c-Anchor-hIXuvg"
+          href="/blocks/B222222222222222222222222222222222222222222"
           onClick={[Function]}
+          onMouseEnter={[Function]}
         >
-          <a
-            href="/blocks/B222222222222222222222222222222222222222222"
-            onClick={[Function]}
-            onMouseEnter={[Function]}
-          >
-            B222222222222222222222222222222222222222222
-          </a>
-        </span>
+          B222222222222222222222222222222222222222222
+        </a>
       </div>
     </div>
     <div
@@ -621,18 +579,14 @@ exports[`<ReceiptRow /> renders receipt with many outcome receipts 1`] = `
         className="c-ReceiptRowReceiptHash-cQOeDh col"
         title="signer.test"
       >
-        <span
+        <a
+          className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+          href="/accounts/signer.test"
           onClick={[Function]}
+          onMouseEnter={[Function]}
         >
-          <a
-            className="c-AccountLinkWrapper-dbzzBd"
-            href="/accounts/signer.test"
-            onClick={[Function]}
-            onMouseEnter={[Function]}
-          >
-            signer.test
-          </a>
-        </span>
+          signer.test
+        </a>
       </div>
     </div>
     <div
@@ -648,18 +602,14 @@ exports[`<ReceiptRow /> renders receipt with many outcome receipts 1`] = `
         className="c-ReceiptRowReceiptHash-cQOeDh col"
         title="receiver.test"
       >
-        <span
+        <a
+          className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+          href="/accounts/receiver.test"
           onClick={[Function]}
+          onMouseEnter={[Function]}
         >
-          <a
-            className="c-AccountLinkWrapper-dbzzBd"
-            href="/accounts/receiver.test"
-            onClick={[Function]}
-            onMouseEnter={[Function]}
-          >
-            receiver.test
-          </a>
-        </span>
+          receiver.test
+        </a>
       </div>
     </div>
     <div
@@ -735,18 +685,14 @@ exports[`<ReceiptRow /> renders receipt with many outcome receipts 1`] = `
                     className="c-ActionRowTitle-cYlxUq col"
                   >
                     component.transactions.ActionMessage.FunctionCall.called_method
-                    <span
+                    <a
+                      className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                      href="/accounts/receiver.test"
                       onClick={[Function]}
+                      onMouseEnter={[Function]}
                     >
-                      <a
-                        className="c-AccountLinkWrapper-dbzzBd"
-                        href="/accounts/receiver.test"
-                        onClick={[Function]}
-                        onMouseEnter={[Function]}
-                      >
-                        receiver.test
-                      </a>
-                    </span>
+                      receiver.test
+                    </a>
                     <dl>
                       <dt>
                         component.transactions.ActionMessage.FunctionCall.arguments
@@ -849,17 +795,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
               <div
                 className="c-ReceiptRowReceiptHash-cQOeDh c-ReceiptRowReceiptHash-cQOeDh-gkXQBw-truncateLink-true col"
               >
-                <span
+                <a
+                  className="c-Anchor-hIXuvg"
+                  href="/transactions/T1111111111111111111111111111111111111111111#R222222222222222222222222222222222222222222"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
-                  <a
-                    href="/transactions/T1111111111111111111111111111111111111111111#R222222222222222222222222222222222222222222"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                  >
-                    R222222222222222222222222222222222222222222
-                  </a>
-                </span>
+                  R222222222222222222222222222222222222222222
+                </a>
               </div>
             </div>
             <div
@@ -874,17 +817,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
               <div
                 className="c-ReceiptRowReceiptHash-cQOeDh c-ReceiptRowReceiptHash-cQOeDh-gkXQBw-truncateLink-true col"
               >
-                <span
+                <a
+                  className="c-Anchor-hIXuvg"
+                  href="/blocks/B333333333333333333333333333333333333333333"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
-                  <a
-                    href="/blocks/B333333333333333333333333333333333333333333"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                  >
-                    B333333333333333333333333333333333333333333
-                  </a>
-                </span>
+                  B333333333333333333333333333333333333333333
+                </a>
               </div>
             </div>
             <div
@@ -900,18 +840,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                 className="c-ReceiptRowReceiptHash-cQOeDh col"
                 title="signer1.test"
               >
-                <span
+                <a
+                  className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                  href="/accounts/signer1.test"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
-                  <a
-                    className="c-AccountLinkWrapper-dbzzBd"
-                    href="/accounts/signer1.test"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                  >
-                    signer1.test
-                  </a>
-                </span>
+                  signer1.test
+                </a>
               </div>
             </div>
             <div
@@ -927,18 +863,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                 className="c-ReceiptRowReceiptHash-cQOeDh col"
                 title="receiver.test"
               >
-                <span
+                <a
+                  className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                  href="/accounts/receiver.test"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
-                  <a
-                    className="c-AccountLinkWrapper-dbzzBd"
-                    href="/accounts/receiver.test"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                  >
-                    receiver.test
-                  </a>
-                </span>
+                  receiver.test
+                </a>
               </div>
             </div>
             <div
@@ -1014,18 +946,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                             className="c-ActionRowTitle-cYlxUq col"
                           >
                             component.transactions.ActionMessage.FunctionCall.called_method
-                            <span
+                            <a
+                              className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                              href="/accounts/receiver.test"
                               onClick={[Function]}
+                              onMouseEnter={[Function]}
                             >
-                              <a
-                                className="c-AccountLinkWrapper-dbzzBd"
-                                href="/accounts/receiver.test"
-                                onClick={[Function]}
-                                onMouseEnter={[Function]}
-                              >
-                                receiver.test
-                              </a>
-                            </span>
+                              receiver.test
+                            </a>
                             <dl>
                               <dt>
                                 component.transactions.ActionMessage.FunctionCall.arguments
@@ -1139,17 +1067,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                       <div
                         className="c-ReceiptRowReceiptHash-cQOeDh c-ReceiptRowReceiptHash-cQOeDh-gkXQBw-truncateLink-true col"
                       >
-                        <span
+                        <a
+                          className="c-Anchor-hIXuvg"
+                          href="/transactions/T1111111111111111111111111111111111111111111#R555555555555555555555555555555555555555555"
                           onClick={[Function]}
+                          onMouseEnter={[Function]}
                         >
-                          <a
-                            href="/transactions/T1111111111111111111111111111111111111111111#R555555555555555555555555555555555555555555"
-                            onClick={[Function]}
-                            onMouseEnter={[Function]}
-                          >
-                            R555555555555555555555555555555555555555555
-                          </a>
-                        </span>
+                          R555555555555555555555555555555555555555555
+                        </a>
                       </div>
                     </div>
                     <div
@@ -1164,17 +1089,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                       <div
                         className="c-ReceiptRowReceiptHash-cQOeDh c-ReceiptRowReceiptHash-cQOeDh-gkXQBw-truncateLink-true col"
                       >
-                        <span
+                        <a
+                          className="c-Anchor-hIXuvg"
+                          href="/blocks/B444444444444444444444444444444444444444444"
                           onClick={[Function]}
+                          onMouseEnter={[Function]}
                         >
-                          <a
-                            href="/blocks/B444444444444444444444444444444444444444444"
-                            onClick={[Function]}
-                            onMouseEnter={[Function]}
-                          >
-                            B444444444444444444444444444444444444444444
-                          </a>
-                        </span>
+                          B444444444444444444444444444444444444444444
+                        </a>
                       </div>
                     </div>
                     <div
@@ -1190,18 +1112,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                         className="c-ReceiptRowReceiptHash-cQOeDh col"
                         title="system"
                       >
-                        <span
+                        <a
+                          className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                          href="/accounts/system"
                           onClick={[Function]}
+                          onMouseEnter={[Function]}
                         >
-                          <a
-                            className="c-AccountLinkWrapper-dbzzBd"
-                            href="/accounts/system"
-                            onClick={[Function]}
-                            onMouseEnter={[Function]}
-                          >
-                            system
-                          </a>
-                        </span>
+                          system
+                        </a>
                       </div>
                     </div>
                     <div
@@ -1217,18 +1135,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                         className="c-ReceiptRowReceiptHash-cQOeDh col"
                         title="receiver.test"
                       >
-                        <span
+                        <a
+                          className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                          href="/accounts/receiver.test"
                           onClick={[Function]}
+                          onMouseEnter={[Function]}
                         >
-                          <a
-                            className="c-AccountLinkWrapper-dbzzBd"
-                            href="/accounts/receiver.test"
-                            onClick={[Function]}
-                            onMouseEnter={[Function]}
-                          >
-                            receiver.test
-                          </a>
-                        </span>
+                          receiver.test
+                        </a>
                       </div>
                     </div>
                     <div
@@ -1315,18 +1229,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                                       Ⓝ
                                     </span>
                                     component.transactions.ActionMessage.Transfer.to
-                                    <span
+                                    <a
+                                      className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                                      href="/accounts/receiver.test"
                                       onClick={[Function]}
+                                      onMouseEnter={[Function]}
                                     >
-                                      <a
-                                        className="c-AccountLinkWrapper-dbzzBd"
-                                        href="/accounts/receiver.test"
-                                        onClick={[Function]}
-                                        onMouseEnter={[Function]}
-                                      >
-                                        receiver.test
-                                      </a>
-                                    </span>
+                                      receiver.test
+                                    </a>
                                   </div>
                                 </div>
                               </div>
@@ -1398,17 +1308,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
               <div
                 className="c-ReceiptRowReceiptHash-cQOeDh c-ReceiptRowReceiptHash-cQOeDh-gkXQBw-truncateLink-true col"
               >
-                <span
+                <a
+                  className="c-Anchor-hIXuvg"
+                  href="/transactions/T1111111111111111111111111111111111111111111#R3333333333333333333333333333333333333333333"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
-                  <a
-                    href="/transactions/T1111111111111111111111111111111111111111111#R3333333333333333333333333333333333333333333"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                  >
-                    R3333333333333333333333333333333333333333333
-                  </a>
-                </span>
+                  R3333333333333333333333333333333333333333333
+                </a>
               </div>
             </div>
             <div
@@ -1423,17 +1330,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
               <div
                 className="c-ReceiptRowReceiptHash-cQOeDh c-ReceiptRowReceiptHash-cQOeDh-gkXQBw-truncateLink-true col"
               >
-                <span
+                <a
+                  className="c-Anchor-hIXuvg"
+                  href="/blocks/B4444444444444444444444444444444444444444444"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
-                  <a
-                    href="/blocks/B4444444444444444444444444444444444444444444"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                  >
-                    B4444444444444444444444444444444444444444444
-                  </a>
-                </span>
+                  B4444444444444444444444444444444444444444444
+                </a>
               </div>
             </div>
             <div
@@ -1449,18 +1353,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                 className="c-ReceiptRowReceiptHash-cQOeDh col"
                 title="signer1.test"
               >
-                <span
+                <a
+                  className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                  href="/accounts/signer1.test"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
-                  <a
-                    className="c-AccountLinkWrapper-dbzzBd"
-                    href="/accounts/signer1.test"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                  >
-                    signer1.test
-                  </a>
-                </span>
+                  signer1.test
+                </a>
               </div>
             </div>
             <div
@@ -1476,18 +1376,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                 className="c-ReceiptRowReceiptHash-cQOeDh col"
                 title="receiver1.test"
               >
-                <span
+                <a
+                  className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                  href="/accounts/receiver1.test"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
-                  <a
-                    className="c-AccountLinkWrapper-dbzzBd"
-                    href="/accounts/receiver1.test"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                  >
-                    receiver1.test
-                  </a>
-                </span>
+                  receiver1.test
+                </a>
               </div>
             </div>
             <div
@@ -1563,18 +1459,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                             className="c-ActionRowTitle-cYlxUq col"
                           >
                             component.transactions.ActionMessage.FunctionCall.called_method
-                            <span
+                            <a
+                              className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                              href="/accounts/receiver1.test"
                               onClick={[Function]}
+                              onMouseEnter={[Function]}
                             >
-                              <a
-                                className="c-AccountLinkWrapper-dbzzBd"
-                                href="/accounts/receiver1.test"
-                                onClick={[Function]}
-                                onMouseEnter={[Function]}
-                              >
-                                receiver1.test
-                              </a>
-                            </span>
+                              receiver1.test
+                            </a>
                             <dl>
                               <dt>
                                 component.transactions.ActionMessage.FunctionCall.arguments
@@ -1688,17 +1580,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                       <div
                         className="c-ReceiptRowReceiptHash-cQOeDh c-ReceiptRowReceiptHash-cQOeDh-gkXQBw-truncateLink-true col"
                       >
-                        <span
+                        <a
+                          className="c-Anchor-hIXuvg"
+                          href="/transactions/T1111111111111111111111111111111111111111111#R6666666666666666666666666666666666666666666"
                           onClick={[Function]}
+                          onMouseEnter={[Function]}
                         >
-                          <a
-                            href="/transactions/T1111111111111111111111111111111111111111111#R6666666666666666666666666666666666666666666"
-                            onClick={[Function]}
-                            onMouseEnter={[Function]}
-                          >
-                            R6666666666666666666666666666666666666666666
-                          </a>
-                        </span>
+                          R6666666666666666666666666666666666666666666
+                        </a>
                       </div>
                     </div>
                     <div
@@ -1713,17 +1602,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                       <div
                         className="c-ReceiptRowReceiptHash-cQOeDh c-ReceiptRowReceiptHash-cQOeDh-gkXQBw-truncateLink-true col"
                       >
-                        <span
+                        <a
+                          className="c-Anchor-hIXuvg"
+                          href="/blocks/B666666666666666666666666666666666666666666"
                           onClick={[Function]}
+                          onMouseEnter={[Function]}
                         >
-                          <a
-                            href="/blocks/B666666666666666666666666666666666666666666"
-                            onClick={[Function]}
-                            onMouseEnter={[Function]}
-                          >
-                            B666666666666666666666666666666666666666666
-                          </a>
-                        </span>
+                          B666666666666666666666666666666666666666666
+                        </a>
                       </div>
                     </div>
                     <div
@@ -1739,18 +1625,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                         className="c-ReceiptRowReceiptHash-cQOeDh col"
                         title="system"
                       >
-                        <span
+                        <a
+                          className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                          href="/accounts/system"
                           onClick={[Function]}
+                          onMouseEnter={[Function]}
                         >
-                          <a
-                            className="c-AccountLinkWrapper-dbzzBd"
-                            href="/accounts/system"
-                            onClick={[Function]}
-                            onMouseEnter={[Function]}
-                          >
-                            system
-                          </a>
-                        </span>
+                          system
+                        </a>
                       </div>
                     </div>
                     <div
@@ -1766,18 +1648,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                         className="c-ReceiptRowReceiptHash-cQOeDh col"
                         title="receiver.test"
                       >
-                        <span
+                        <a
+                          className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                          href="/accounts/receiver.test"
                           onClick={[Function]}
+                          onMouseEnter={[Function]}
                         >
-                          <a
-                            className="c-AccountLinkWrapper-dbzzBd"
-                            href="/accounts/receiver.test"
-                            onClick={[Function]}
-                            onMouseEnter={[Function]}
-                          >
-                            receiver.test
-                          </a>
-                        </span>
+                          receiver.test
+                        </a>
                       </div>
                     </div>
                     <div
@@ -1864,18 +1742,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                                       Ⓝ
                                     </span>
                                     component.transactions.ActionMessage.Transfer.to
-                                    <span
+                                    <a
+                                      className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                                      href="/accounts/receiver.test"
                                       onClick={[Function]}
+                                      onMouseEnter={[Function]}
                                     >
-                                      <a
-                                        className="c-AccountLinkWrapper-dbzzBd"
-                                        href="/accounts/receiver.test"
-                                        onClick={[Function]}
-                                        onMouseEnter={[Function]}
-                                      >
-                                        receiver.test
-                                      </a>
-                                    </span>
+                                      receiver.test
+                                    </a>
                                   </div>
                                 </div>
                               </div>
@@ -1947,17 +1821,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
               <div
                 className="c-ReceiptRowReceiptHash-cQOeDh c-ReceiptRowReceiptHash-cQOeDh-gkXQBw-truncateLink-true col"
               >
-                <span
+                <a
+                  className="c-Anchor-hIXuvg"
+                  href="/transactions/T1111111111111111111111111111111111111111111#R4444444444444444444444444444444444444444444"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
-                  <a
-                    href="/transactions/T1111111111111111111111111111111111111111111#R4444444444444444444444444444444444444444444"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                  >
-                    R4444444444444444444444444444444444444444444
-                  </a>
-                </span>
+                  R4444444444444444444444444444444444444444444
+                </a>
               </div>
             </div>
             <div
@@ -1972,17 +1843,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
               <div
                 className="c-ReceiptRowReceiptHash-cQOeDh c-ReceiptRowReceiptHash-cQOeDh-gkXQBw-truncateLink-true col"
               >
-                <span
+                <a
+                  className="c-Anchor-hIXuvg"
+                  href="/blocks/B555555555555555555555555555555555555555555"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
-                  <a
-                    href="/blocks/B555555555555555555555555555555555555555555"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                  >
-                    B555555555555555555555555555555555555555555
-                  </a>
-                </span>
+                  B555555555555555555555555555555555555555555
+                </a>
               </div>
             </div>
             <div
@@ -1998,18 +1866,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                 className="c-ReceiptRowReceiptHash-cQOeDh col"
                 title="system"
               >
-                <span
+                <a
+                  className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                  href="/accounts/system"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
-                  <a
-                    className="c-AccountLinkWrapper-dbzzBd"
-                    href="/accounts/system"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                  >
-                    system
-                  </a>
-                </span>
+                  system
+                </a>
               </div>
             </div>
             <div
@@ -2025,18 +1889,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                 className="c-ReceiptRowReceiptHash-cQOeDh col"
                 title="receiver.test"
               >
-                <span
+                <a
+                  className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                  href="/accounts/receiver.test"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
-                  <a
-                    className="c-AccountLinkWrapper-dbzzBd"
-                    href="/accounts/receiver.test"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                  >
-                    receiver.test
-                  </a>
-                </span>
+                  receiver.test
+                </a>
               </div>
             </div>
             <div
@@ -2123,18 +1983,14 @@ Memo: Swapping 9807229473212706028 🍌 to get 9807229473212706028 🥒
                               Ⓝ
                             </span>
                             component.transactions.ActionMessage.Transfer.to
-                            <span
+                            <a
+                              className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                              href="/accounts/receiver.test"
                               onClick={[Function]}
+                              onMouseEnter={[Function]}
                             >
-                              <a
-                                className="c-AccountLinkWrapper-dbzzBd"
-                                href="/accounts/receiver.test"
-                                onClick={[Function]}
-                                onMouseEnter={[Function]}
-                              >
-                                receiver.test
-                              </a>
-                            </span>
+                              receiver.test
+                            </a>
                           </div>
                         </div>
                       </div>
@@ -2201,17 +2057,14 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
       <div
         className="c-ReceiptRowReceiptHash-cQOeDh c-ReceiptRowReceiptHash-cQOeDh-gkXQBw-truncateLink-true col"
       >
-        <span
+        <a
+          className="c-Anchor-hIXuvg"
+          href="/transactions/T1111111111111111111111111111111111111111111#R1111111111111111111111111111111111111111111"
           onClick={[Function]}
+          onMouseEnter={[Function]}
         >
-          <a
-            href="/transactions/T1111111111111111111111111111111111111111111#R1111111111111111111111111111111111111111111"
-            onClick={[Function]}
-            onMouseEnter={[Function]}
-          >
-            R1111111111111111111111111111111111111111111
-          </a>
-        </span>
+          R1111111111111111111111111111111111111111111
+        </a>
       </div>
     </div>
     <div
@@ -2226,17 +2079,14 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
       <div
         className="c-ReceiptRowReceiptHash-cQOeDh c-ReceiptRowReceiptHash-cQOeDh-gkXQBw-truncateLink-true col"
       >
-        <span
+        <a
+          className="c-Anchor-hIXuvg"
+          href="/blocks/B222222222222222222222222222222222222222222"
           onClick={[Function]}
+          onMouseEnter={[Function]}
         >
-          <a
-            href="/blocks/B222222222222222222222222222222222222222222"
-            onClick={[Function]}
-            onMouseEnter={[Function]}
-          >
-            B222222222222222222222222222222222222222222
-          </a>
-        </span>
+          B222222222222222222222222222222222222222222
+        </a>
       </div>
     </div>
     <div
@@ -2252,18 +2102,14 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
         className="c-ReceiptRowReceiptHash-cQOeDh col"
         title="signer.test"
       >
-        <span
+        <a
+          className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+          href="/accounts/signer.test"
           onClick={[Function]}
+          onMouseEnter={[Function]}
         >
-          <a
-            className="c-AccountLinkWrapper-dbzzBd"
-            href="/accounts/signer.test"
-            onClick={[Function]}
-            onMouseEnter={[Function]}
-          >
-            signer.test
-          </a>
-        </span>
+          signer.test
+        </a>
       </div>
     </div>
     <div
@@ -2279,18 +2125,14 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
         className="c-ReceiptRowReceiptHash-cQOeDh col"
         title="receiver.test"
       >
-        <span
+        <a
+          className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+          href="/accounts/receiver.test"
           onClick={[Function]}
+          onMouseEnter={[Function]}
         >
-          <a
-            className="c-AccountLinkWrapper-dbzzBd"
-            href="/accounts/receiver.test"
-            onClick={[Function]}
-            onMouseEnter={[Function]}
-          >
-            receiver.test
-          </a>
-        </span>
+          receiver.test
+        </a>
       </div>
     </div>
     <div
@@ -2366,18 +2208,14 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
                     className="c-ActionRowTitle-cYlxUq col"
                   >
                     component.transactions.ActionMessage.FunctionCall.called_method
-                    <span
+                    <a
+                      className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                      href="/accounts/receiver.test"
                       onClick={[Function]}
+                      onMouseEnter={[Function]}
                     >
-                      <a
-                        className="c-AccountLinkWrapper-dbzzBd"
-                        href="/accounts/receiver.test"
-                        onClick={[Function]}
-                        onMouseEnter={[Function]}
-                      >
-                        receiver.test
-                      </a>
-                    </span>
+                      receiver.test
+                    </a>
                     <dl>
                       <dt>
                         component.transactions.ActionMessage.FunctionCall.arguments
@@ -2496,17 +2334,14 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
               <div
                 className="c-ReceiptRowReceiptHash-cQOeDh c-ReceiptRowReceiptHash-cQOeDh-gkXQBw-truncateLink-true col"
               >
-                <span
+                <a
+                  className="c-Anchor-hIXuvg"
+                  href="/transactions/T1111111111111111111111111111111111111111111#R2222222222222222222222222222222222222222222"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
-                  <a
-                    href="/transactions/T1111111111111111111111111111111111111111111#R2222222222222222222222222222222222222222222"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                  >
-                    R2222222222222222222222222222222222222222222
-                  </a>
-                </span>
+                  R2222222222222222222222222222222222222222222
+                </a>
               </div>
             </div>
             <div
@@ -2521,17 +2356,14 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
               <div
                 className="c-ReceiptRowReceiptHash-cQOeDh c-ReceiptRowReceiptHash-cQOeDh-gkXQBw-truncateLink-true col"
               >
-                <span
+                <a
+                  className="c-Anchor-hIXuvg"
+                  href="/blocks/B333333333333333333333333333333333333333333"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
-                  <a
-                    href="/blocks/B333333333333333333333333333333333333333333"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                  >
-                    B333333333333333333333333333333333333333333
-                  </a>
-                </span>
+                  B333333333333333333333333333333333333333333
+                </a>
               </div>
             </div>
             <div
@@ -2547,18 +2379,14 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
                 className="c-ReceiptRowReceiptHash-cQOeDh col"
                 title="system"
               >
-                <span
+                <a
+                  className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                  href="/accounts/system"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
-                  <a
-                    className="c-AccountLinkWrapper-dbzzBd"
-                    href="/accounts/system"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                  >
-                    system
-                  </a>
-                </span>
+                  system
+                </a>
               </div>
             </div>
             <div
@@ -2574,18 +2402,14 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
                 className="c-ReceiptRowReceiptHash-cQOeDh col"
                 title="receiver.test"
               >
-                <span
+                <a
+                  className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                  href="/accounts/receiver.test"
                   onClick={[Function]}
+                  onMouseEnter={[Function]}
                 >
-                  <a
-                    className="c-AccountLinkWrapper-dbzzBd"
-                    href="/accounts/receiver.test"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                  >
-                    receiver.test
-                  </a>
-                </span>
+                  receiver.test
+                </a>
               </div>
             </div>
             <div
@@ -2672,18 +2496,14 @@ exports[`<ReceiptRow /> renders successful receipt 1`] = `
                               Ⓝ
                             </span>
                             component.transactions.ActionMessage.Transfer.to
-                            <span
+                            <a
+                              className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                              href="/accounts/receiver.test"
                               onClick={[Function]}
+                              onMouseEnter={[Function]}
                             >
-                              <a
-                                className="c-AccountLinkWrapper-dbzzBd"
-                                href="/accounts/receiver.test"
-                                onClick={[Function]}
-                                onMouseEnter={[Function]}
-                              >
-                                receiver.test
-                              </a>
-                            </span>
+                              receiver.test
+                            </a>
                           </div>
                         </div>
                       </div>

--- a/frontend/src/components/transactions/__tests__/__snapshots__/TransactionDetails.test.tsx.snap
+++ b/frontend/src/components/transactions/__tests__/__snapshots__/TransactionDetails.test.tsx.snap
@@ -41,18 +41,14 @@ exports[`<TransactionDetails /> renders no deposit 1`] = `
             <div
               className="c-CardCellText-eLcwWo ml-auto align-self-center col-md-12 col-auto"
             >
-              <span
+              <a
+                className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                href="/accounts/signer.test"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
-                <a
-                  className="c-AccountLinkWrapper-dbzzBd"
-                  href="/accounts/signer.test"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  signer.test
-                </a>
-              </span>
+                signer.test
+              </a>
             </div>
           </div>
         </div>
@@ -92,18 +88,14 @@ exports[`<TransactionDetails /> renders no deposit 1`] = `
             <div
               className="c-CardCellText-eLcwWo ml-auto align-self-center col-md-12 col-auto"
             >
-              <span
+              <a
+                className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                href="/accounts/receiver.test"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
-                <a
-                  className="c-AccountLinkWrapper-dbzzBd"
-                  href="/accounts/receiver.test"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  receiver.test
-                </a>
-              </span>
+                receiver.test
+              </a>
             </div>
           </div>
         </div>
@@ -465,17 +457,14 @@ exports[`<TransactionDetails /> renders no deposit 1`] = `
             <div
               className="c-CardCellText-eLcwWo ml-auto align-self-center col-md-12 col-auto"
             >
-              <span
+              <a
+                className="c-Anchor-hIXuvg"
+                href="/blocks/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
-                <a
-                  href="/blocks/BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj
-                </a>
-              </span>
+                BvJeW6gnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj
+              </a>
             </div>
           </div>
         </div>
@@ -526,18 +515,14 @@ exports[`<TransactionDetails /> renders with one small deposit 1`] = `
             <div
               className="c-CardCellText-eLcwWo ml-auto align-self-center col-md-12 col-auto"
             >
-              <span
+              <a
+                className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                href="/accounts/signer2.test"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
-                <a
-                  className="c-AccountLinkWrapper-dbzzBd"
-                  href="/accounts/signer2.test"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  signer2.test
-                </a>
-              </span>
+                signer2.test
+              </a>
             </div>
           </div>
         </div>
@@ -577,18 +562,14 @@ exports[`<TransactionDetails /> renders with one small deposit 1`] = `
             <div
               className="c-CardCellText-eLcwWo ml-auto align-self-center col-md-12 col-auto"
             >
-              <span
+              <a
+                className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                href="/accounts/receiver2.test"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
-                <a
-                  className="c-AccountLinkWrapper-dbzzBd"
-                  href="/accounts/receiver2.test"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  receiver2.test
-                </a>
-              </span>
+                receiver2.test
+              </a>
             </div>
           </div>
         </div>
@@ -950,17 +931,14 @@ exports[`<TransactionDetails /> renders with one small deposit 1`] = `
             <div
               className="c-CardCellText-eLcwWo ml-auto align-self-center col-md-12 col-auto"
             >
-              <span
+              <a
+                className="c-Anchor-hIXuvg"
+                href="/blocks/222BBBgnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
-                <a
-                  href="/blocks/222BBBgnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  222BBBgnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj
-                </a>
-              </span>
+                222BBBgnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj
+              </a>
             </div>
           </div>
         </div>
@@ -1011,18 +989,14 @@ exports[`<TransactionDetails /> renders with two big deposit 1`] = `
             <div
               className="c-CardCellText-eLcwWo ml-auto align-self-center col-md-12 col-auto"
             >
-              <span
+              <a
+                className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                href="/accounts/signer2.test"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
-                <a
-                  className="c-AccountLinkWrapper-dbzzBd"
-                  href="/accounts/signer2.test"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  signer2.test
-                </a>
-              </span>
+                signer2.test
+              </a>
             </div>
           </div>
         </div>
@@ -1062,18 +1036,14 @@ exports[`<TransactionDetails /> renders with two big deposit 1`] = `
             <div
               className="c-CardCellText-eLcwWo ml-auto align-self-center col-md-12 col-auto"
             >
-              <span
+              <a
+                className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+                href="/accounts/receiver2.test"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
-                <a
-                  className="c-AccountLinkWrapper-dbzzBd"
-                  href="/accounts/receiver2.test"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  receiver2.test
-                </a>
-              </span>
+                receiver2.test
+              </a>
             </div>
           </div>
         </div>
@@ -1435,17 +1405,14 @@ exports[`<TransactionDetails /> renders with two big deposit 1`] = `
             <div
               className="c-CardCellText-eLcwWo ml-auto align-self-center col-md-12 col-auto"
             >
-              <span
+              <a
+                className="c-Anchor-hIXuvg"
+                href="/blocks/222BBBgnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
               >
-                <a
-                  href="/blocks/222BBBgnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  222BBBgnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj
-                </a>
-              </span>
+                222BBBgnFjkCBKCsRNEBrRLDQCFZNxLAi6uXzmLaVrrj
+              </a>
             </div>
           </div>
         </div>

--- a/frontend/src/components/utils/AccountLink.tsx
+++ b/frontend/src/components/utils/AccountLink.tsx
@@ -4,7 +4,7 @@ import Link from "@explorer/frontend/components/utils/Link";
 import { truncateAccountId } from "@explorer/frontend/libraries/formatting";
 import { styled } from "@explorer/frontend/libraries/styles";
 
-const AccountLinkWrapper = styled("a", {
+const AccountLinkWrapper = styled(Link, {
   whiteSpace: "nowrap",
 });
 
@@ -13,9 +13,9 @@ export interface Props {
 }
 
 const AccountLink: React.FC<Props> = React.memo(({ accountId }) => (
-  <Link href={`/accounts/${accountId}`} passHref>
-    <AccountLinkWrapper>{truncateAccountId(accountId)}</AccountLinkWrapper>
-  </Link>
+  <AccountLinkWrapper href={`/accounts/${accountId}`}>
+    {truncateAccountId(accountId)}
+  </AccountLinkWrapper>
 ));
 
 export default AccountLink;

--- a/frontend/src/components/utils/BlockLink.tsx
+++ b/frontend/src/components/utils/BlockLink.tsx
@@ -10,10 +10,8 @@ export interface Props {
 
 const BlockLink: React.FC<Props> = React.memo(
   ({ blockHash, children, truncate = true }) => (
-    <Link href="/blocks/[hash]" as={`/blocks/${blockHash}`}>
-      <a>
-        {children || (truncate ? `${blockHash.substring(0, 7)}...` : blockHash)}
-      </a>
+    <Link href={`/blocks/${blockHash}`}>
+      {children || (truncate ? `${blockHash.substring(0, 7)}...` : blockHash)}
     </Link>
   )
 );

--- a/frontend/src/components/utils/Header.tsx
+++ b/frontend/src/components/utils/Header.tsx
@@ -56,10 +56,8 @@ const SearchBoxColumn = styled(Col, {
   margin: "0 16px",
 });
 
-const HeaderHome = styled("a", {
+const HeaderHome = styled(Link, {
   fontWeight: 500,
-  color: "#000000",
-  textDecoration: "none",
 });
 
 const Header: React.FC = React.memo(() => {
@@ -77,17 +75,13 @@ const Header: React.FC = React.memo(() => {
           <HeaderMainBar noGutters>
             <Col md="6" className="d-none d-md-block d-lg-block">
               <Link href="/">
-                <a>
-                  <NearLogo />
-                </a>
+                <NearLogo />
               </Link>
             </Col>
 
             <Col xs="2" className="d-md-none text-left">
               <Link href="/">
-                <a>
-                  <NearMiniLogo />
-                </a>
+                <NearMiniLogo />
               </Link>
             </Col>
 
@@ -135,9 +129,9 @@ const Header: React.FC = React.memo(() => {
               <LanguageToggle />
             </Col>
             <Col md={shouldShowSwitch ? 3 : 4} className="align-self-center">
-              <Link href="/" passHref>
-                <HeaderHome>{t("component.utils.Header.home")}</HeaderHome>
-              </Link>
+              <HeaderHome href="/">
+                {t("component.utils.Header.home")}
+              </HeaderHome>
             </Col>
             <Col md={shouldShowSwitch ? 4 : 5} className="align-self-center">
               <HeaderNavDropdown />

--- a/frontend/src/components/utils/HeaderNavDropdown.tsx
+++ b/frontend/src/components/utils/HeaderNavDropdown.tsx
@@ -17,16 +17,14 @@ const Icon = styled("svg", {
   marginRight: 3,
 });
 
-const HeaderNavLink = styled("a", {
+const HeaderNavLink = styled(Link, {
   display: "block",
   color: "#a5a5a5",
   paddingTop: 10,
   paddingBottom: 15,
   paddingLeft: 18,
-  textDecoration: "none",
   width: "100%",
   height: "100%",
-  cursor: "pointer",
 
   "&:hover": {
     background: "#000000",
@@ -54,12 +52,10 @@ interface Props {
 
 const HeaderNavItem: React.FC<Props> = React.memo(
   ({ link, IconElement, text }) => (
-    <Link href={link} passHref>
-      <HeaderNavLink>
-        <Icon as={IconElement} />
-        <NavText>{text}</NavText>
-      </HeaderNavLink>
-    </Link>
+    <HeaderNavLink href={link}>
+      <Icon as={IconElement} />
+      <NavText>{text}</NavText>
+    </HeaderNavLink>
   )
 );
 

--- a/frontend/src/components/utils/Link.tsx
+++ b/frontend/src/components/utils/Link.tsx
@@ -3,25 +3,73 @@ import * as React from "react";
 import Link from "next/link";
 
 import { useAnalyticsTrack } from "@explorer/frontend/hooks/analytics/use-analytics-track";
+import { CSS, styled } from "@explorer/frontend/libraries/styles";
 
-const LinkWrapper: React.FC<
-  React.ComponentProps<typeof Link> & { className?: string }
-> = React.memo(({ className, ...props }) => {
-  const track = useAnalyticsTrack();
+const Anchor = styled("a", {
+  textDecoration: "none",
+  color: "inherit",
+  "&:hover": {
+    color: "inherit",
+  },
 
-  return (
-    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-    <span
-      className={className}
-      onClick={() =>
-        track("Explorer Click Link", {
-          href: props.href,
-        })
-      }
-    >
-      {props.href ? <Link {...props} /> : props.children}
-    </span>
-  );
+  variants: {
+    disabled: {
+      true: {
+        cursor: "default",
+      },
+    },
+  },
 });
+
+type LinkProps = React.ComponentProps<typeof Link>;
+
+type Props = Omit<LinkProps, "href"> & {
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>;
+  css?: CSS;
+  className?: string;
+  href?: LinkProps["href"];
+};
+
+const LinkWrapper = React.memo<Props>(
+  ({ onClick: onClickRaw, shallow, css, className, href, ...props }) => {
+    const track = useAnalyticsTrack();
+    const onClick = React.useCallback<NonNullable<Props["onClick"]>>(
+      (e) => {
+        if (!href) {
+          e.preventDefault();
+        }
+        track("Explorer Click Link", { href });
+        onClickRaw?.(e);
+      },
+      [onClickRaw, track, href]
+    );
+
+    const anchor = (
+      <Anchor
+        onClick={onClick}
+        css={css}
+        className={className}
+        disabled={!href}
+      >
+        {props.children}
+      </Anchor>
+    );
+
+    if (!href) {
+      return anchor;
+    }
+
+    return (
+      <Link
+        shallow={shallow === false ? shallow : true}
+        passHref
+        href={href}
+        {...props}
+      >
+        {anchor}
+      </Link>
+    );
+  }
+);
 
 export default LinkWrapper;

--- a/frontend/src/components/utils/LongCardCell.tsx
+++ b/frontend/src/components/utils/LongCardCell.tsx
@@ -1,17 +1,14 @@
 import * as React from "react";
 
-import cx from "classnames";
 import { Row, Col, Spinner } from "react-bootstrap";
 
 import {
   TRPCSubscriptionKey,
   TRPCSubscriptionOutput,
 } from "@explorer/common/types/trpc";
-import Link from "@explorer/frontend/components/utils/Link";
 import { UseSubscriptionResultByTopic } from "@explorer/frontend/hooks/use-subscription";
 import { typedMemo } from "@explorer/frontend/libraries/react";
 import { CSS, styled } from "@explorer/frontend/libraries/styles";
-import RightArrowSvg from "@explorer/frontend/public/static/images/right-arrow.svg";
 
 const CardCellText = styled(Col, {
   fontWeight: 900,
@@ -57,23 +54,10 @@ const LongCardCellTitle = styled(Col, {
   marginBottom: 5,
 });
 
-const RightArrow = styled(Col, {
-  margin: "auto 0",
-
-  "& svg path": {
-    stroke: "#9da2a5",
-  },
-
-  [`${LongCardCellWrapper}:hover & svg path`]: {
-    stroke: "#0072ce",
-  },
-});
-
 export interface Props<K extends TRPCSubscriptionKey> {
   title: React.ReactNode;
   subscription: UseSubscriptionResultByTopic<K>;
   children: (result: TRPCSubscriptionOutput<K>) => React.ReactNode;
-  href?: string;
   className?: string;
   textCss?: CSS;
 }
@@ -82,56 +66,33 @@ const LongCardCell = typedMemo(
   <K extends TRPCSubscriptionKey>({
     title,
     subscription,
-    href,
     className,
     textCss,
     children,
-  }: Props<K>) => {
-    const plainCell = (
-      <Row noGutters>
-        <LongCardCellTitle xs="12" className="align-self-center">
-          {title}
-        </LongCardCellTitle>
-        <CardCellText
-          xs="12"
-          md="12"
-          className="ml-auto align-self-center"
-          css={textCss}
-        >
-          {subscription.status === "loading" ||
-          subscription.status === "idle" ? (
-            <Spinner animation="border" variant="secondary" />
-          ) : subscription.status === "success" ? (
-            children(subscription.data)
-          ) : null}
-        </CardCellText>
-      </Row>
-    );
-    return (
-      <>
-        {href ? (
-          <Link href={href}>
-            <a>
-              <LongCardCellWrapper
-                className={cx("href-cell", className)}
-                withLink
-                noGutters
-              >
-                <Col>{plainCell}</Col>
-                <RightArrow xs="auto">
-                  <RightArrowSvg />
-                </RightArrow>
-              </LongCardCellWrapper>
-            </a>
-          </Link>
-        ) : (
-          <LongCardCellWrapper className={className} noGutters>
-            <Col>{plainCell}</Col>
-          </LongCardCellWrapper>
-        )}
-      </>
-    );
-  }
+  }: Props<K>) => (
+    <LongCardCellWrapper className={className} noGutters>
+      <Col>
+        <Row noGutters>
+          <LongCardCellTitle xs="12" className="align-self-center">
+            {title}
+          </LongCardCellTitle>
+          <CardCellText
+            xs="12"
+            md="12"
+            className="ml-auto align-self-center"
+            css={textCss}
+          >
+            {subscription.status === "loading" ||
+            subscription.status === "idle" ? (
+              <Spinner animation="border" variant="secondary" />
+            ) : subscription.status === "success" ? (
+              children(subscription.data)
+            ) : null}
+          </CardCellText>
+        </Row>
+      </Col>
+    </LongCardCellWrapper>
+  )
 );
 
 export default LongCardCell;

--- a/frontend/src/components/utils/MobileHeaderNavDropdown.tsx
+++ b/frontend/src/components/utils/MobileHeaderNavDropdown.tsx
@@ -20,7 +20,7 @@ const Icon = styled("svg", {
   marginRight: 3,
 });
 
-const HeaderNavLink = styled("a", {
+const HeaderNavLink = styled(Link, {
   color: "#a5a5a5",
   display: "block",
   paddingVertical: 14,
@@ -50,12 +50,10 @@ interface Props {
 
 const MobileNavItem: React.FC<Props> = React.memo(
   ({ link, IconElement, text }) => (
-    <Link href={link} passHref>
-      <HeaderNavLink>
-        <Icon as={IconElement} />
-        <NavText>{text}</NavText>
-      </HeaderNavLink>
-    </Link>
+    <HeaderNavLink href={link}>
+      <Icon as={IconElement} />
+      <NavText>{text}</NavText>
+    </HeaderNavLink>
   )
 );
 
@@ -111,7 +109,7 @@ const DropdownContent = styled("div", {
   textAlign: "left",
 });
 
-const LinkWrapper = styled("a", {
+const LinkWrapper = styled(Link, {
   color: "#F8F8F8",
   width: "100%",
 });
@@ -174,9 +172,9 @@ const MobileNavDropdown: React.FC = React.memo(() => {
       {isMenuShown ? (
         <DropdownContent ref={dropdownMenuRef}>
           <MobileNav>
-            <Link href="/" passHref>
-              <LinkWrapper>{t("component.utils.Header.home")}</LinkWrapper>
-            </Link>
+            <LinkWrapper href="/">
+              {t("component.utils.Header.home")}
+            </LinkWrapper>
           </MobileNav>
           <MobileNav>{t("component.utils.HeaderNavDropdown.title")}</MobileNav>
           <MobileNavItem

--- a/frontend/src/components/utils/ReceiptLink.tsx
+++ b/frontend/src/components/utils/ReceiptLink.tsx
@@ -14,7 +14,7 @@ const ReceiptLink: React.FC<Props> = React.memo(
     const children = truncate ? `${receiptId.substring(0, 7)}...` : receiptId;
     return (
       <Link href={`/transactions/${transactionHash}#${receiptId}`}>
-        <a>{children}</a>
+        {children}
       </Link>
     );
   }

--- a/frontend/src/components/utils/TransactionLink.tsx
+++ b/frontend/src/components/utils/TransactionLink.tsx
@@ -10,7 +10,7 @@ export interface Props {
 const TransactionLink: React.FC<Props> = React.memo(
   ({ transactionHash, children }) => (
     <Link href="/transactions/[hash]" as={`/transactions/${transactionHash}`}>
-      <a>{children || `${transactionHash.substring(0, 7)}...`}</a>
+      {children || `${transactionHash.substring(0, 7)}...`}
     </Link>
   )
 );

--- a/frontend/src/components/utils/__tests__/__snapshots__/AccountLink.test.tsx.snap
+++ b/frontend/src/components/utils/__tests__/__snapshots__/AccountLink.test.tsx.snap
@@ -1,31 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<AccountLink /> renders long account id 1`] = `
-<span
+<a
+  className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+  href="/accounts/b7df2090560a225dc4934aed43db03a6c674c2d4.lockup.near"
   onClick={[Function]}
+  onMouseEnter={[Function]}
 >
-  <a
-    className="c-AccountLinkWrapper-dbzzBd"
-    href="/accounts/b7df2090560a225dc4934aed43db03a6c674c2d4.lockup.near"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-  >
-    b7df2…ockup.near
-  </a>
-</span>
+  b7df2…ockup.near
+</a>
 `;
 
 exports[`<AccountLink /> renders short account id 1`] = `
-<span
+<a
+  className="c-Anchor-hIXuvg c-AccountLinkWrapper-dbzzBd"
+  href="/accounts/jerry.zest.near"
   onClick={[Function]}
+  onMouseEnter={[Function]}
 >
-  <a
-    className="c-AccountLinkWrapper-dbzzBd"
-    href="/accounts/jerry.zest.near"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-  >
-    jerry.zest.near
-  </a>
-</span>
+  jerry.zest.near
+</a>
 `;

--- a/frontend/src/components/utils/__tests__/__snapshots__/BlockLink.test.tsx.snap
+++ b/frontend/src/components/utils/__tests__/__snapshots__/BlockLink.test.tsx.snap
@@ -1,15 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<BlockLink /> renders 1`] = `
-<span
+<a
+  className="c-Anchor-hIXuvg"
+  href="/blocks/H4CpspC1bqkykKG6dtCoGmLepvcyV2f2phfoqNAn5L2b"
   onClick={[Function]}
+  onMouseEnter={[Function]}
 >
-  <a
-    href="/blocks/H4CpspC1bqkykKG6dtCoGmLepvcyV2f2phfoqNAn5L2b"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-  >
-    H4CpspC...
-  </a>
-</span>
+  H4CpspC...
+</a>
 `;

--- a/frontend/src/components/utils/__tests__/__snapshots__/ReceiptLink.test.tsx.snap
+++ b/frontend/src/components/utils/__tests__/__snapshots__/ReceiptLink.test.tsx.snap
@@ -1,29 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ReceiptLink /> renders successfully in existing transaction 1`] = `
-<span
+<a
+  className="c-Anchor-hIXuvg"
+  href="/transactions/66WYKL9FcK1Av1WffDYwftm6t4iwUkJrnfZPjvZgsEB7#FNNA1kX7mBPZ5LD7t8RFAVNybvybVr8h5o3n5Xw86hUW"
   onClick={[Function]}
+  onMouseEnter={[Function]}
 >
-  <a
-    href="/transactions/66WYKL9FcK1Av1WffDYwftm6t4iwUkJrnfZPjvZgsEB7#FNNA1kX7mBPZ5LD7t8RFAVNybvybVr8h5o3n5Xw86hUW"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-  >
-    FNNA1kX...
-  </a>
-</span>
+  FNNA1kX...
+</a>
 `;
 
 exports[`<ReceiptLink /> renders successfully in non existing transaction 1`] = `
-<span
+<a
+  className="c-Anchor-hIXuvg"
+  href="/transactions/hash#9zSjvFzm6BeNsco3fdNWqKNaYFkrj94AWWfGvgssQJuG"
   onClick={[Function]}
+  onMouseEnter={[Function]}
 >
-  <a
-    href="/transactions/hash#9zSjvFzm6BeNsco3fdNWqKNaYFkrj94AWWfGvgssQJuG"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-  >
-    9zSjvFz...
-  </a>
-</span>
+  9zSjvFz...
+</a>
 `;

--- a/frontend/src/components/utils/__tests__/__snapshots__/TransactionLink.test.tsx.snap
+++ b/frontend/src/components/utils/__tests__/__snapshots__/TransactionLink.test.tsx.snap
@@ -1,15 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<TransactionLink /> renders 1`] = `
-<span
+<a
+  className="c-Anchor-hIXuvg"
+  href="/transactions/H4CpspC1bqkykKG6dtCoGmLepvcyV2f2phfoqNAn5L2b"
   onClick={[Function]}
+  onMouseEnter={[Function]}
 >
-  <a
-    href="/transactions/H4CpspC1bqkykKG6dtCoGmLepvcyV2f2phfoqNAn5L2b"
-    onClick={[Function]}
-    onMouseEnter={[Function]}
-  >
-    H4CpspC...
-  </a>
-</span>
+  H4CpspC...
+</a>
 `;


### PR DESCRIPTION
Link has [new behavior](https://nextjs.org/blog/next-13#upgrading-nextlink-to-nextjs-13) in next 13, let's get prepared for it (also, move most of the common styling to `LinkWrapper`).