### PR TITLE
Refactor: balance in account row

### DIFF
--- a/backend/src/router/account/balance.ts
+++ b/backend/src/router/account/balance.ts
@@ -1,0 +1,21 @@
+import * as trpc from "@trpc/server";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+
+import { Context } from "@explorer/backend/context";
+import { getAccountRpcData } from "@explorer/backend/router/account/by-id";
+import { validators } from "@explorer/backend/router/validators";
+
+export const router = trpc.router<Context>().query("nonStakedBalance", {
+  input: z.strictObject({ id: validators.accountId }),
+  resolve: async ({ input: { id } }) => {
+    const rpcData = await getAccountRpcData(id);
+    if (!rpcData) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: `Account ${id} does not exist on RPC`,
+      });
+    }
+    return rpcData.amount.toString();
+  },
+});

--- a/backend/src/router/account/by-id.ts
+++ b/backend/src/router/account/by-id.ts
@@ -33,14 +33,17 @@ const getLockupAccountId = async (
   return lockupAccountId;
 };
 
+export const getAccountRpcData = (accountId: string) =>
+  nearApi
+    .sendJsonRpcQuery("view_account", {
+      finality: "final",
+      account_id: accountId,
+    })
+    .catch(ignoreIfDoesNotExist);
+
 const getAccountDetails = async (accountId: string) => {
   const [accountInfo, lockupAccountId] = await Promise.all([
-    nearApi
-      .sendJsonRpcQuery("view_account", {
-        finality: "final",
-        account_id: accountId,
-      })
-      .catch(ignoreIfDoesNotExist),
+    getAccountRpcData(accountId),
     getLockupAccountId(accountId),
   ]);
 

--- a/backend/src/router/account/index.ts
+++ b/backend/src/router/account/index.ts
@@ -3,6 +3,7 @@ import * as trpc from "@trpc/server";
 import { Context } from "@explorer/backend/context";
 
 import { router as activityRouter } from "./activity";
+import { router as balanceRouter } from "./balance";
 import { router as byIdRouter } from "./by-id";
 import { router as fungibleTokensRouter } from "./fungible-tokens";
 import { router as listRouter } from "./list";
@@ -16,4 +17,5 @@ export const router = trpc
   .merge(transactionsCountRouter)
   .merge(fungibleTokensRouter)
   .merge(activityRouter)
-  .merge(nonFungibleTokensRouter);
+  .merge(nonFungibleTokensRouter)
+  .merge(balanceRouter);

--- a/frontend/src/components/accounts/Accounts.tsx
+++ b/frontend/src/components/accounts/Accounts.tsx
@@ -18,7 +18,7 @@ const Accounts: React.FC = React.memo(() => {
         if (!lastElement) {
           return;
         }
-        return { index: lastElement.accountIndex };
+        return { index: lastElement.index };
       },
     }
   );
@@ -30,9 +30,7 @@ const Accounts: React.FC = React.memo(() => {
       {(items) => (
         <FlipMove duration={1000} staggerDurationBy={0}>
           {items.map((account) => (
-            <div key={account.accountId}>
-              <AccountRow accountId={account.accountId} />
-            </div>
+            <AccountRow key={account.id} account={account} />
           ))}
         </FlipMove>
       )}

--- a/frontend/src/components/accounts/__tests__/AccountRow.test.tsx
+++ b/frontend/src/components/accounts/__tests__/AccountRow.test.tsx
@@ -7,13 +7,31 @@ describe("<AccountRow />", () => {
   beforeEach(() => jest.resetAllMocks());
 
   it("renders with short name", () => {
-    expect(renderElement(<AccountRow accountId="account" />)).toMatchSnapshot();
+    expect(
+      renderElement(
+        <AccountRow
+          account={{
+            id: "account",
+            index: 0,
+            createdTimestamp: 1601461389590,
+            deletedTimestamp: undefined,
+          }}
+        />
+      )
+    ).toMatchSnapshot();
   });
 
   it("renders with long name", () => {
     expect(
       renderElement(
-        <AccountRow accountId="b7df2090560a225dc4934aed43db03a6c674c2d4.lockup.near" />
+        <AccountRow
+          account={{
+            id: "b7df2090560a225dc4934aed43db03a6c674c2d4.lockup.near",
+            index: 0,
+            createdTimestamp: 1601461389590,
+            deletedTimestamp: undefined,
+          }}
+        />
       )
     ).toMatchSnapshot();
   });

--- a/frontend/src/components/accounts/__tests__/__snapshots__/AccountRow.test.tsx.snap
+++ b/frontend/src/components/accounts/__tests__/__snapshots__/AccountRow.test.tsx.snap
@@ -25,7 +25,34 @@ exports[`<AccountRow /> renders with long name 1`] = `
     </div>
     <div
       className="c-TransactionRowTransactionId-lbSlCc ml-auto pt-1 text-right col-md-3 col-5"
-    />
+    >
+      <div
+        className="c-TransactionRowTimer-ehtocQ"
+      >
+        component.accounts.AccountRow.created_on
+         
+        2020-09-30T10:23:09Z formatted by PPP
+        <div
+          className="c-Wrapper-kgHvMp c-Wrapper-kgHvMp-ieesTsS-css"
+        >
+          <svg
+            height=".6em"
+            onClick={[Function]}
+            viewBox="0 0 18 18"
+            width=".6em"
+          >
+            <path
+              d="m11.315 5.9932h-9.7723c-0.85717 0-1.5427 0.63916-1.5427 1.4383v9.1302c0 0.7788 0.68557 1.4383 1.5427 1.4383h9.7931c0.8354 0 1.5427-0.6392 1.5427-1.4383l8e-4 -9.1302c-0.0217-0.79915-0.7073-1.4383-1.5645-1.4383h2e-4zm0.2569 10.549c0 0.1201-0.1071 0.22-0.236 0.22l-9.793-7e-4c-0.12891 0-0.23606-0.0999-0.23606-0.2201l8.3e-4 -9.11c0-0.12018 0.10715-0.22009 0.23607-0.22009h9.793c0.1289 0 0.2361 0.0999 0.2361 0.22009l-9e-4 9.1108z"
+              fill="currentColor"
+            />
+            <path
+              d="m16.457 1.1984e-4h-9.7723c-0.85718 0-1.5427 0.63916-1.5427 1.4383v3.3566h1.2858v-3.3566c0-0.12019 0.10714-0.22009 0.23606-0.22009h9.793c0.1289 0 0.2361 0.09989 0.2361 0.22009v9.1302c0 0.1202-0.1071 0.2201-0.2361 0.2201h-2.3146v1.1987h2.3146c0.8354 0 1.5428-0.6392 1.5428-1.4383v-9.1108c0-0.79916-0.6856-1.4383-1.5428-1.4383l2e-4 1.1984e-4z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
   </div>
 </a>
 `;
@@ -55,7 +82,34 @@ exports[`<AccountRow /> renders with short name 1`] = `
     </div>
     <div
       className="c-TransactionRowTransactionId-lbSlCc ml-auto pt-1 text-right col-md-3 col-5"
-    />
+    >
+      <div
+        className="c-TransactionRowTimer-ehtocQ"
+      >
+        component.accounts.AccountRow.created_on
+         
+        2020-09-30T10:23:09Z formatted by PPP
+        <div
+          className="c-Wrapper-kgHvMp c-Wrapper-kgHvMp-ieesTsS-css"
+        >
+          <svg
+            height=".6em"
+            onClick={[Function]}
+            viewBox="0 0 18 18"
+            width=".6em"
+          >
+            <path
+              d="m11.315 5.9932h-9.7723c-0.85717 0-1.5427 0.63916-1.5427 1.4383v9.1302c0 0.7788 0.68557 1.4383 1.5427 1.4383h9.7931c0.8354 0 1.5427-0.6392 1.5427-1.4383l8e-4 -9.1302c-0.0217-0.79915-0.7073-1.4383-1.5645-1.4383h2e-4zm0.2569 10.549c0 0.1201-0.1071 0.22-0.236 0.22l-9.793-7e-4c-0.12891 0-0.23606-0.0999-0.23606-0.2201l8.3e-4 -9.11c0-0.12018 0.10715-0.22009 0.23607-0.22009h9.793c0.1289 0 0.2361 0.0999 0.2361 0.22009l-9e-4 9.1108z"
+              fill="currentColor"
+            />
+            <path
+              d="m16.457 1.1984e-4h-9.7723c-0.85718 0-1.5427 0.63916-1.5427 1.4383v3.3566h1.2858v-3.3566c0-0.12019 0.10714-0.22009 0.23606-0.22009h9.793c0.1289 0 0.2361 0.09989 0.2361 0.22009v9.1302c0 0.1202-0.1071 0.2201-0.2361 0.2201h-2.3146v1.1987h2.3146c0.8354 0 1.5428-0.6392 1.5428-1.4383v-9.1108c0-0.79916-0.6856-1.4383-1.5428-1.4383l2e-4 1.1984e-4z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
   </div>
 </a>
 `;


### PR DESCRIPTION
Currently we load `accounts.byIdOld` for every account in account list though only one field is needed there.
This refactor lessen the amount of data going around on the backend.