### PR TITLE
Chore: base docker version upgrade

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:16 AS build
+FROM node:16-alpine AS build
 
 WORKDIR /near-explorer
 ENV HOME=/tmp
@@ -14,7 +14,7 @@ RUN rm -rf ./node_modules
 RUN npm install patch-package
 RUN npm install -w backend -w common --prod
 
-FROM mhart/alpine-node:16
+FROM node:16-alpine
 
 WORKDIR /near-explorer
 ENV HOME=/tmp

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:16 AS build
+FROM node:16-alpine AS build
 
 WORKDIR /near-explorer
 ENV HOME=/tmp
@@ -16,7 +16,7 @@ RUN rm -rf ./node_modules
 RUN npm install patch-package
 RUN npm install -w frontend -w common --prod
 
-FROM mhart/alpine-node:16
+FROM node:16-alpine
 
 RUN apk add --no-cache git
 


### PR DESCRIPTION
Current docker image has node version that doesn't support `Array.at` method which may fail on some transactions on `/beta/transaction/[hash]` page.

```
❯ docker run mhart/alpine-node:16 node -v
v16.4.2
❯ docker run node:16-alpine node -v
v16.19.1
```