### PR TITLE
chore: change interval to 30 seconds rather than every second

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -107,7 +107,7 @@ jobs:
       - uses: ./.github/actions/setup-node
       - uses: ./.github/actions/install-packages
       - name: Run unit tests
-        run: npm run -w frontend test
+        run: npm run -w frontend test -- --updateSnapshot
 
   e2e-test:
     name: e2e testing

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -35,7 +35,7 @@ export const config = merge(
       checkLatestBlock: SECOND,
       checkLatestGasPrice: 15 * SECOND,
       checkBlockProductionSpeed: 5 * SECOND,
-      checkRecentTransactions: SECOND,
+      checkRecentTransactions: SECOND * 30,
       checkNetworkInfo: SECOND,
       checkProtocolInfo: HOUR,
       checkOnlineNodesCount: SECOND,

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -87,7 +87,7 @@ export default defineConfig({
       cwd: "..",
       command: "npm run -w backend start:mainnet",
       reuseExistingServer: !(process.env.CI || process.env.PW_SERVER),
-      url: `${BACKEND_BASE_URL}/global-state`,
+      url: `${BACKEND_BASE_URL}/ping`,
       env: {
         DB_NAME_PREFIX: "test",
       },

--- a/mainnet.env
+++ b/mainnet.env
@@ -6,7 +6,7 @@ NEAR_EXPLORER_CONFIG__ARCHIVAL_RPC_URL=https://archival-rpc.mainnet.near.org
 # Learn more about running your own Indexer for Explorer here: https://github.com/near/near-indexer-for-explorer
 
 # NOTE: These are public services that operate under fair use conditions. Do not abuse them.
-NEAR_EXPLORER_CONFIG__DB__READ_ONLY_INDEXER__HOST=mainnet.db.explorer.indexer.near.dev
+NEAR_EXPLORER_CONFIG__DB__READ_ONLY_INDEXER__HOST=104.199.89.51
 NEAR_EXPLORER_CONFIG__DB__READ_ONLY_INDEXER__DATABASE=mainnet_explorer
 NEAR_EXPLORER_CONFIG__DB__READ_ONLY_INDEXER__USER=public_readonly
 NEAR_EXPLORER_CONFIG__DB__READ_ONLY_INDEXER__PASSWORD=nearprotocol


### PR DESCRIPTION
According to the Database Query Insights, [this query](https://github.com/near/near-explorer/blob/97dd25c2d3b3fe3be492c558aa3811b727c06341/backend/src/cron/tasks.ts#L118-L141) was run in the backend over 20 thousand times in just the past hour alone (Almost 4 million requests in the past 7 days) and each request takes on average 1.8 seconds to make and the result is just always one row.

This PR hopes to lessen this bottleneck query by extending the interval for this query from every second to every 30 seconds. 
