### PR TITLE
feat: Enable StatelessNet network

### DIFF
--- a/common/src/types/common.ts
+++ b/common/src/types/common.ts
@@ -3,6 +3,7 @@ export type NetworkName =
   | "testnet"
   | "shardnet"
   | "guildnet"
+  | "statelessnet"
   | "localnet";
 
 // Workaround of Omit breaking discriminated unions

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -28,6 +28,7 @@ const defaultBackendConfig: BackendConfig = {
     shardnet: "localhost",
     guildnet: "localhost",
     localnet: "localhost",
+    statelessnet: "localhost",
   },
   port: 10000,
   secure: false,


### PR DESCRIPTION
*I am aware that NEAR Explorer has been sunset and considered as deprecated, but we decided to use it one last time for the Stake Wars IV since we don't expect the data on that network to overload all the underlying technologies behind the NEAR Explorer project*

I believe this change should do the trick to make this instance https://legacy.explorer.statelessnet.near.org/ of NEAR Explorer work for a new network launched for the Stake Wars IV.

P.S. I have no idea what I am doing with NEAR Explorer (following the method of the blind kitten)